### PR TITLE
[Bug Fix] fit Vit image shape

### DIFF
--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, TypeVar, Union
 import json
 import numpy as np
 import torch
-import torchvision.transformers
+import torchvision.transforms
 import torch.nn.functional as F
 import transformers
 from packaging import version
@@ -1417,7 +1417,7 @@ class InternLMXComposer2Template(Template):
 
     def _encode(self, example: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         def resize_image(image, target_height, target_width):
-            # resize image to target_height and target_width
+            # resize image to target_height and target_width while using internlm-xcomposer2-4KHD
             resize_transform = torchvision.transforms.Resize((target_height, target_width))
             return resize_transform(image)
             


### PR DESCRIPTION
# PR type
- [ ] Bug Fix

# PR information

Fix the bug when finetuning internlm-xcomposer2-4khd-7b uses custom dataset with images.
The custom dataset temples are what you provide [here](https://swift.readthedocs.io/en/latest/Multi-Modal/internlm-xcomposer2-best-practice.html).

## Experiment results

after fixing, i get the results just like the finetune script provided by internlm-xcomposer :)
