### PR TITLE
[TorchAcc] fix: add mark_step when GA is greater than 1

### DIFF
--- a/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_dp_sft.sh
@@ -3,8 +3,6 @@
 # Note: TorchAcc is currently only available internally.
 # torchacc dp
 export USE_TORCHACC=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Baichuan2-13B-Chat

--- a/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_fsdp_sft.sh
@@ -3,8 +3,6 @@
 # Note: TorchAcc is currently only available internally.
 # torchacc fsdp
 export USE_TORCHACC=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Baichuan2-13B-Chat

--- a/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_dp_sft.sh
@@ -3,8 +3,6 @@
 # Note: TorchAcc is currently only available internally.
 # torchacc dp
 export USE_TORCHACC=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/chatglm3-6b

--- a/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_fsdp_sft.sh
@@ -3,8 +3,6 @@
 # Note: TorchAcc is currently only available internally.
 # torchacc fsdp
 export USE_TORCHACC=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/chatglm3-6b

--- a/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_dp_sft.sh
@@ -4,8 +4,6 @@
 
 export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Llama-2-13b-chat-ms

--- a/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_fsdp_sft.sh
@@ -3,8 +3,6 @@
 # Note: TorchAcc is currently only available internally.
 export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Llama-2-13b-chat-ms

--- a/examples/pytorch/llm/scripts/torchacc/llama3_70b_instruct/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama3_70b_instruct/acc_lora_fsdp_sft.sh
@@ -2,8 +2,7 @@
 # 80GB GPU memory
 # Note: TorchAcc is currently only available internally.
 export USE_TORCHACC=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.96
+export PJRT_ALLOCATOR_FRACTION=0.96
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Meta-Llama-3-70B-Instruct

--- a/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_dp_sft.sh
@@ -4,8 +4,6 @@
 
 export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Meta-Llama-3-8B-Instruct

--- a/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_fsdp_sft.sh
@@ -2,8 +2,6 @@
 # 80GB GPU memory
 # Note: TorchAcc is currently only available internally.
 export USE_TORCHACC=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Meta-Llama-3-8B-Instruct

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_dp_sft.sh
@@ -3,8 +3,6 @@
 # Note: TorchAcc is currently only available internally.
 export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
-export XLA_IR_SHAPE_CACHE_SIZE=1000000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen1half-14b-chat

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_fsdp_sft.sh
@@ -5,8 +5,6 @@ DEBUG_PREFIX=qwen15_14b
 DEBUG_PATH=torchacc_debug/qwen15/
 export USE_TORCHACC=1
 # export TORCHACC_TRIM_GRAPH=1
-export XLA_IR_SHAPE_CACHE_SIZE=1000000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen1half-14b-chat

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_32b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_32b_chat/acc_lora_fsdp_sft.sh
@@ -3,8 +3,6 @@
 # Note: TorchAcc is currently only available internally.
 export USE_TORCHACC=1
 # export TORCHACC_TRIM_GRAPH=1
-export XLA_IR_SHAPE_CACHE_SIZE=1000000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen1half-32b-chat

--- a/examples/pytorch/llm/scripts/torchacc/qwen2_72b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen2_72b_chat/acc_lora_fsdp_sft.sh
@@ -3,8 +3,7 @@
 # Note: TorchAcc is currently only available internally.
 export USE_TORCHACC=1
 # export TORCHACC_TRIM_GRAPH=1
-export XLA_IR_SHAPE_CACHE_SIZE=1000000000
-export XLA_ALLOCATOR_FRACTION=0.96
+export PJRT_ALLOCATOR_FRACTION=0.96
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen2-72b-instruct-0724

--- a/examples/pytorch/llm/scripts/torchacc/qwen2_7b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen2_7b_chat/acc_lora_dp_sft.sh
@@ -4,8 +4,6 @@
 
 export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen2-7b-instruct

--- a/examples/pytorch/llm/scripts/torchacc/qwen2_7b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen2_7b_chat/acc_lora_fsdp_sft.sh
@@ -2,8 +2,6 @@
 # 80GB GPU memory
 # Note: TorchAcc is currently only available internally.
 export USE_TORCHACC=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen2-7b-instruct

--- a/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_full_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_full_fsdp_sft.sh
@@ -3,8 +3,7 @@
 # Note: TorchAcc is currently only available internally.
 
 export USE_TORCHACC=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.97
+export PJRT_ALLOCATOR_FRACTION=0.97
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen-72b-chat
 mkdir -p $XLA_PERSISTENT_CACHE_PATH

--- a/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_lora_fsdp_sft.sh
@@ -3,8 +3,6 @@
 # Note: TorchAcc is currently only available internally.
 
 export USE_TORCHACC=1
-export XLA_IR_SHAPE_CACHE_SIZE=100000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen-72b-chat

--- a/examples/pytorch/llm/scripts/torchacc/yi_34b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/yi_34b_chat/acc_lora_fsdp_sft.sh
@@ -3,8 +3,6 @@
 # Note: TorchAcc is currently only available internally.
 export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
-export XLA_IR_SHAPE_CACHE_SIZE=1000000000
-export XLA_ALLOCATOR_FRACTION=0.95
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/yi-34b-chat

--- a/swift/trainers/trainers.py
+++ b/swift/trainers/trainers.py
@@ -236,6 +236,11 @@ class Seq2SeqTrainer(PushToMsHubMixin, SwiftMixin, HfSeq2SeqTrainer):
                 if 'acc' not in self._custom_metrics:
                     self._custom_metrics['acc'] = self._acc
                 self._custom_metrics['acc'] = self._custom_metrics['acc'] + acc / self.args.gradient_accumulation_steps
+
+        if use_torchacc() and self.args.gradient_accumulation_steps > 1:
+            import torchacc as ta
+            ta.mark_step()
+
         return (loss, outputs) if return_outputs else loss
 
     def get_train_dataloader(self):


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Add `ta.mark_step()` when gradient_accumulation_steps > 1 to reduce memory usage.

Before this PR, Torchacc compiled for each gradient_accumulation_steps. After this PR, it will compile for each individual step. Thus, this change will reduce the graph size, leading to decreased memory usage.


## Experiment results

