### PR TITLE
[TorchAcc] update data bucketing strategy

### DIFF
--- a/examples/pytorch/llm/scripts/torchacc/llama3_70b_instruct/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama3_70b_instruct/acc_lora_fsdp_sft.sh
@@ -4,6 +4,7 @@
 export USE_TORCHACC=1
 export PJRT_ALLOCATOR_FRACTION=0.96
 export XLA_EXPERIMENTAL=nonzero:masked_select
+export TORCHACC_DATA_BUCKETS=512,1024,1536,2048
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Meta-Llama-3-70B-Instruct
 mkdir -p $XLA_PERSISTENT_CACHE_PATH

--- a/examples/pytorch/llm/scripts/torchacc/qwen2_72b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen2_72b_chat/acc_lora_fsdp_sft.sh
@@ -5,6 +5,7 @@ export USE_TORCHACC=1
 # export TORCHACC_TRIM_GRAPH=1
 export PJRT_ALLOCATOR_FRACTION=0.96
 export XLA_EXPERIMENTAL=nonzero:masked_select
+export TORCHACC_DATA_BUCKETS=512,1024,1536,2048
 
 export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen2-72b-instruct-0724
 export XLA_FLAGS="--xla_gpu_enable_cudnn_fmha=false --xla_gpu_enable_priority_fusion=false --xla_gpu_normalize_layouts=false --xla_gpu_memory_limit_slop_factor=400"

--- a/swift/torchacc_utils.py
+++ b/swift/torchacc_utils.py
@@ -30,7 +30,7 @@ def get_bucket_sizes(max_length: int) -> List[int]:
     if os.getenv('TORCHACC_DATA_BUCKETS') is not None:
         bucket_sizes = [int(x) for x in os.getenv('TORCHACC_DATA_BUCKETS').split(',')]
         bucket_sizes.append(max_length)
-    else: # default normal distribution bucketing.
+    else:  # default normal distribution bucketing.
         mean = max_length // 2
         var = max_length // 8
         bucket_sizes = [mean + i * var for i in range(-3, 4)]

--- a/swift/torchacc_utils.py
+++ b/swift/torchacc_utils.py
@@ -22,7 +22,20 @@ logger = get_logger()
 
 # DataLoader
 def get_bucket_sizes(max_length: int) -> List[int]:
-    return [max_length // 4 * (i + 1) for i in range(4)]
+    """Get the bucket sizes for TorchAcc.
+    You can set the environment variable TORCHACC_DATA_BUCKETS to specify
+    the bucket sizes. If not set, we use a normal distribution bucketing with
+    8 buckets.
+    """
+    if os.getenv('TORCHACC_DATA_BUCKETS') is not None:
+        bucket_sizes = [int(x) for x in os.getenv('TORCHACC_DATA_BUCKETS').split(',')]
+        bucket_sizes.append(max_length)
+    else: # default normal distribution bucketing.
+        mean = max_length // 2
+        var = max_length // 8
+        bucket_sizes = [mean + i * var for i in range(-3, 4)]
+        bucket_sizes.append(max_length)
+    return bucket_sizes
 
 
 def _get_closet_bucket(bucket_sizes, data_length):


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Change default bucketing  strategy from uniform with 4 buckets to normal distribution with 8 buckets, and allow user to set buckets size through environment variable `TORCHACC_DATA_BUCKETS`

