### PR TITLE
fix megatron_patch_path

### DIFF
--- a/swift/llm/megatron/utils.py
+++ b/swift/llm/megatron/utils.py
@@ -29,6 +29,8 @@ def init_megatron_env() -> None:
         megatron_patch_path = git_clone_github(
             'https://github.com/alibaba/Pai-Megatron-Patch', commit_hash='6fd5d050b240fd959f0ba69f1e9cd9a053e5a81d')
         os.environ['PAI_MEGATRON_PATCH_PATH'] = megatron_patch_path
+    else:
+        megatron_patch_path = os.environ['PAI_MEGATRON_PATCH_PATH']
     sys.path.append(os.environ['PAI_MEGATRON_PATCH_PATH'])
 
     # rename qwen1.5->qwen1_5 files


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information

When the environment variable `PAI_MEGATRON_PATCH_PATH` is set, the following error occurs: 
```
UnboundLocalError: local variable 'megatron_patch_path' referenced before assignment.
```

This error occurs because the variable `megatron_patch_path` is not declared in this context.

The change made was to assign the value of the environment variable `PAI_MEGATRON_PATCH_PATH` to `megatron_patch_path`.

## Experiment results

Paste your experiment result here(if needed).
