### PR TITLE
fix offline export

### DIFF
--- a/swift/llm/export.py
+++ b/swift/llm/export.py
@@ -287,7 +287,8 @@ def llm_export(args: ExportArguments) -> None:
                         'Skipping the conversion process.')
         else:
             from swift.llm.megatron import MegatronArguments, convert_hf_to_megatron, patch_megatron
-            model, tokenizer = get_model_tokenizer(args.model_type, torch.float32, {'device_map': 'auto'})
+            model, tokenizer = get_model_tokenizer(
+                args.model_type, torch.float32, {'device_map': 'auto'}, model_id_or_path=args.model_id_or_path)
             res = MegatronArguments.load_megatron_config(tokenizer.model_dir)
             res['model_type'] = args.model_type
             res['target_tensor_model_parallel_size'] = args.tp
@@ -311,7 +312,8 @@ def llm_export(args: ExportArguments) -> None:
                         'Skipping the conversion process.')
         else:
             from swift.llm.megatron import MegatronArguments, convert_megatron_to_hf, patch_megatron
-            hf_model, tokenizer = get_model_tokenizer(args.model_type, torch.float32, {'device_map': 'auto'})
+            hf_model, tokenizer = get_model_tokenizer(
+                args.model_type, torch.float32, {'device_map': 'auto'}, model_id_or_path=args.model_id_or_path)
             res = MegatronArguments.load_megatron_config(tokenizer.model_dir)
             res['model_type'] = args.model_type
             res['target_tensor_model_parallel_size'] = args.tp


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information

When exporting the Megatron model, the `get_model_tokenizer` function did not include the `model_id_or_path` parameter. 
This has now been improved by passing the `model_id_or_path parameter`, allowing the correct usage of local models in offline environments.

## Experiment results

Paste your experiment result here(if needed).
