### PR TITLE
[TorchAcc] fix serveral bugs for torchacc FSDP.

### DIFF
--- a/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_dp_sft.sh
@@ -5,8 +5,8 @@
 export USE_TORCHACC=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Baichuan2-13B-Chat
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/Baichuan2-13B-Chat
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=2 \
 CUDA_VISIBLE_DEVICES=0,1 \

--- a/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/baichuan2_13b_chat/acc_lora_fsdp_sft.sh
@@ -5,8 +5,8 @@
 export USE_TORCHACC=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Baichuan2-13B-Chat
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/Baichuan2-13B-Chat
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=2 \
 CUDA_VISIBLE_DEVICES=0,1 \

--- a/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_dp_sft.sh
@@ -5,8 +5,8 @@
 export USE_TORCHACC=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/chatglm3-6b
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/chatglm3-6b
+mkdir -p $TORCHACC_CACHE_PATH
 
 
 NPROC_PER_NODE=2 \

--- a/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/chatglm3_6b/acc_lora_fsdp_sft.sh
@@ -5,8 +5,8 @@
 export USE_TORCHACC=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/chatglm3-6b
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/chatglm3-6b
+mkdir -p $TORCHACC_CACHE_PATH
 
 
 NPROC_PER_NODE=2 \

--- a/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_dp_sft.sh
@@ -6,8 +6,8 @@ export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Llama-2-13b-chat-ms
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/Llama-2-13b-chat-ms
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=2 \
 CUDA_VISIBLE_DEVICES=0,1 \

--- a/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama2_13b_chat/acc_lora_fsdp_sft.sh
@@ -5,8 +5,8 @@ export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Llama-2-13b-chat-ms
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/Llama-2-13b-chat-ms
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=2 \
 CUDA_VISIBLE_DEVICES=0,1 \

--- a/examples/pytorch/llm/scripts/torchacc/llama3_70b_instruct/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama3_70b_instruct/acc_lora_fsdp_sft.sh
@@ -6,8 +6,8 @@ export PJRT_ALLOCATOR_FRACTION=0.96
 export XLA_EXPERIMENTAL=nonzero:masked_select
 export TORCHACC_DATA_BUCKETS=512,1024,1536,2048
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Meta-Llama-3-70B-Instruct
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/Meta-Llama-3-70B-Instruct
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=4 \
 CUDA_VISIBLE_DEVICES=0,1,2,3 \

--- a/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_dp_sft.sh
@@ -6,8 +6,8 @@ export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Meta-Llama-3-8B-Instruct
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/Meta-Llama-3-8B-Instruct
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=2 \
 CUDA_VISIBLE_DEVICES=0,1 \

--- a/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/llama3_8b_instruct/acc_lora_fsdp_sft.sh
@@ -4,8 +4,8 @@
 export USE_TORCHACC=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/Meta-Llama-3-8B-Instruct
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/Meta-Llama-3-8B-Instruct
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=2 \
 CUDA_VISIBLE_DEVICES=0,1 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_dp_sft.sh
@@ -5,8 +5,8 @@ export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen1half-14b-chat
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/qwen1half-14b-chat
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=2 \
 CUDA_VISIBLE_DEVICES=2,3 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_14b_chat/acc_lora_fsdp_sft.sh
@@ -7,8 +7,8 @@ export USE_TORCHACC=1
 # export TORCHACC_TRIM_GRAPH=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen1half-14b-chat
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/qwen1half-14b-chat
+mkdir -p $TORCHACC_CACHE_PATH
 
 MASTER_PORT=23783 \
 NPROC_PER_NODE=2 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen1half_32b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen1half_32b_chat/acc_lora_fsdp_sft.sh
@@ -5,8 +5,8 @@ export USE_TORCHACC=1
 # export TORCHACC_TRIM_GRAPH=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen1half-32b-chat
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/qwen1half-32b-chat
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=4 \
 CUDA_VISIBLE_DEVICES=0,1,2,3 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen2_72b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen2_72b_chat/acc_lora_fsdp_sft.sh
@@ -7,9 +7,9 @@ export PJRT_ALLOCATOR_FRACTION=0.96
 export XLA_EXPERIMENTAL=nonzero:masked_select
 export TORCHACC_DATA_BUCKETS=512,1024,1536,2048
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen2-72b-instruct-0724
+export TORCHACC_CACHE_PATH=./output/compiled_cache/qwen2-72b-instruct-0724
 export XLA_FLAGS="--xla_gpu_enable_cudnn_fmha=false --xla_gpu_enable_priority_fusion=false --xla_gpu_normalize_layouts=false --xla_gpu_memory_limit_slop_factor=400"
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=4 \
 CUDA_VISIBLE_DEVICES=0,1,2,3 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen2_7b_chat/acc_lora_dp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen2_7b_chat/acc_lora_dp_sft.sh
@@ -6,8 +6,8 @@ export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen2-7b-instruct
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/qwen2-7b-instruct
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=2 \
 CUDA_VISIBLE_DEVICES=2,3 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen2_7b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen2_7b_chat/acc_lora_fsdp_sft.sh
@@ -4,8 +4,8 @@
 export USE_TORCHACC=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen2-7b-instruct
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/qwen2-7b-instruct
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=2 \
 CUDA_VISIBLE_DEVICES=0,1 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_full_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_full_fsdp_sft.sh
@@ -5,8 +5,8 @@
 export USE_TORCHACC=1
 export PJRT_ALLOCATOR_FRACTION=0.97
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen-72b-chat
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/qwen-72b-chat
+mkdir -p $TORCHACC_CACHE_PATH
 # Note: You need to set the correct MASTER_ADDR, MASTER_PORT and NODE_RANK for each node.
 
 MASTER_ADDR=127.0.0.1 \

--- a/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/qwen_72b_chat/acc_lora_fsdp_sft.sh
@@ -5,8 +5,8 @@
 export USE_TORCHACC=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/qwen-72b-chat
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/qwen-72b-chat
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=4 \
 CUDA_VISIBLE_DEVICES=0,1,2,3 \

--- a/examples/pytorch/llm/scripts/torchacc/yi_34b_chat/acc_lora_fsdp_sft.sh
+++ b/examples/pytorch/llm/scripts/torchacc/yi_34b_chat/acc_lora_fsdp_sft.sh
@@ -5,8 +5,8 @@ export USE_TORCHACC=1
 export TORCHACC_TRIM_GRAPH=1
 export XLA_EXPERIMENTAL=nonzero:masked_select
 
-export XLA_PERSISTENT_CACHE_PATH=./output/compiled_cache/yi-34b-chat
-mkdir -p $XLA_PERSISTENT_CACHE_PATH
+export TORCHACC_CACHE_PATH=./output/compiled_cache/yi-34b-chat
+mkdir -p $TORCHACC_CACHE_PATH
 
 NPROC_PER_NODE=4 \
 CUDA_VISIBLE_DEVICES=0,1,2,3 \

--- a/swift/llm/accelerator.py
+++ b/swift/llm/accelerator.py
@@ -1,4 +1,5 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
+import os
 
 
 def ta_accelerate(model,
@@ -26,6 +27,9 @@ def ta_accelerate(model,
         config.dist.fsdp.wrap_layer_cls = {layer_cls_name}
         config.dist.fsdp.flatten_parameters = fsdp_flatten_parameters
         config.dist.dp.size = 1
+
+        if fsdp_num > 0:
+            os.environ['ACCELERATE_USE_FSDP'] = 'true'
 
         return config
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

1. remove mark_step() after compute_loss to speed up performance and reduce memory usage;
2. fix accelerate's clip_grad_norm_ for FSDP;
3. fix XLA_PERSISTENT_CACHE_PATH conflict in multi-processing case;
4. use flatten_parameters in full sft FSDP to better overlap communication and computation.

