### PR TITLE
[TorchAcc] fix: fix find_labels and can_return_loss

### DIFF
--- a/swift/llm/sft.py
+++ b/swift/llm/sft.py
@@ -248,8 +248,6 @@ def prepare_model_template_train(args, msg: Optional[Dict[str, Any]] = None):
         label_names = find_labels(model)
         return_loss = can_return_loss(model)
         model = patch_acc_model(model, args)
-        model.label_names = label_names
-        model.return_loss = return_loss
 
     if args.is_multimodal and args.gradient_checkpointing and args.vit_use_gc:
         dynamic_vit_gradient_checkpointing(model, args.model_type)
@@ -279,6 +277,8 @@ def prepare_model_template_train(args, msg: Optional[Dict[str, Any]] = None):
             args.fp16,
             gradient_checkpointing=True,
             fsdp_flatten_parameters=(args.sft_type == 'full'))
+        model.label_names = label_names
+        model.return_loss = return_loss
 
     template_kwargs = {}
     template_kwargs['use_loss_scale'] = args.use_loss_scale


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
set `find_labels` and `can_return_loss` after `ta_accelerate`, because `ta_accelerate` will wrapper original model to DistributedParallel module in TorchAcc.
