### PR TITLE
fix vllm ignore suffix

### DIFF
--- a/swift/llm/utils/template.py
+++ b/swift/llm/utils/template.py
@@ -1134,6 +1134,8 @@ class Template:
         tokenizer = self.tokenizer
         if hasattr(generate_ids, 'tolist'):
             generate_ids = generate_ids.tolist()
+        elif isinstance(generate_ids, tuple):
+            generate_ids = list(generate_ids)
         # avoid printing template.suffix[-1])
         if isinstance(self.suffix[-1], list) and (not is_finished or is_finished
                                                   and generate_ids[-len(self.suffix[-1]):] == self.suffix[-1]):


### PR DESCRIPTION
In the new version, the return value of vllm has changed from a list to a tuple. This caused a problem with equality checks, which prevents the removal of the suffix.