### PR TITLE
Fix vllm sampling params

### DIFF
--- a/swift/llm/infer/infer_engine/vllm_engine.py
+++ b/swift/llm/infer/infer_engine/vllm_engine.py
@@ -161,32 +161,29 @@ class VllmEngine(InferEngine):
 
     def _load_generation_config(self) -> None:
         generation_config_path = os.path.join(self.model_dir, 'generation_config.json')
-            if os.path.isfile(generation_config_path):
-                generation_config = GenerationConfig.from_pretrained(self.model_dir)
-                kwargs = generation_config.to_dict()
-                max_new_tokens = kwargs.get('max_new_tokens')
-                if max_new_tokens is not None:
-                    kwargs['max_tokens'] = max_new_tokens
-                parameters = inspect.signature(SamplingParams).parameters
-                for k, v in kwargs.copy().items():
-                    if k not in parameters or v is None:
-                        kwargs.pop(k)
-                        continue
-                    # Check if parameter class has from_optional method
-                    param_type = parameters[k].annotation
+        if os.path.isfile(generation_config_path):
+            generation_config = GenerationConfig.from_pretrained(self.model_dir)
+            kwargs = generation_config.to_dict()
+            max_new_tokens = kwargs.get('max_new_tokens')
+            if max_new_tokens is not None:
+                kwargs['max_tokens'] = max_new_tokens
+            parameters = inspect.signature(SamplingParams).parameters
+            for k, v in kwargs.copy().items():
+                if k not in parameters or v is None:
+                    kwargs.pop(k)
+                    continue
+                # Check if parameter class has from_optional method
+                param_type = parameters[k].annotation
+                
+                if str(param_type).startswith('typing.Optional'):
+                    # Extract the actual type from Optional
+                    param_type = param_type.__args__[0]
+                if hasattr(param_type, 'from_optional') and v is not None:
+                    kwargs[k] = param_type.from_optional(v)
                     
-                    if str(param_type).startswith('typing.Optional'):
-                        # Extract the actual type from Optional
-                        param_type = param_type.__args__[0]
-                    print(param_type)
-                    if hasattr(param_type, 'from_optional') and v is not None:
-                        kwargs[k] = param_type.from_optional(v)
-                        
-                self.generation_config = SamplingParams(**kwargs)
-                print("self.generation_config")
-                print(self.generation_config)
-            else:
-                self.generation_config = SamplingParams()
+            self.generation_config = SamplingParams(**kwargs)
+        else:
+            self.generation_config = SamplingParams()
 
     def _add_stop_words(self, generation_config: SamplingParams, request_config: RequestConfig,
                         template_meta: TemplateMeta) -> None:

--- a/swift/llm/infer/infer_engine/vllm_engine.py
+++ b/swift/llm/infer/infer_engine/vllm_engine.py
@@ -167,7 +167,7 @@ class VllmEngine(InferEngine):
             max_new_tokens = kwargs.get('max_new_tokens')
             if max_new_tokens is not None:
                 kwargs['max_tokens'] = max_new_tokens
-            parameters = inspect.signature(SamplingParams.__init__).parameters
+            parameters = inspect.signature(SamplingParams).parameters
             for k, v in kwargs.copy().items():
                 if k not in parameters or v is None:
                     kwargs.pop(k)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Updates loading of generation config from file. 
Previously the `_load_generation_config` function did not load all configuration from a generation_config.json file. 

With this pull request `_load_generation_config` loads all configuration from a generation_config.json file. The `_prepare_generation_config` now uses the sampling parameters loaded from file and overwrites the ones provided in the request config. 

This allows to configure guided decoding in a generation_config.json file. Here is an example generation_config.json file:
```json
{
  "bos_token_id": 151643,
  "do_sample": true,
  "eos_token_id": 151645,
  "max_new_tokens": 2048,
  "pad_token_id": 151643,
  "temperature": 0.01,
  "top_k": 1,
  "top_p": 0.001,
  "transformers_version": "4.46.0.dev0",
  "guided_decoding": {
    "backend":"lm-format-enforcer",
    "json":{
      "type": "object",
      "properties": {
        "foo": { "type": "string"},
      },
      "required": ["foo"]
    }
  }
}
```
