### PR TITLE
add "enable_prefix_caching" args for vllm engine.

### DIFF
--- a/docs/source/Instruction/命令行参数.md
+++ b/docs/source/Instruction/命令行参数.md
@@ -276,6 +276,7 @@ Vera使用`target_modules`, `target_regex`, `modules_to_save`三个参数.
 - enforce_eager: vllm使用pytorch eager模式还是建立cuda graph. 默认为`False`. 设置为True可以节约显存, 但会影响效率.
 - 🔥limit_mm_per_prompt: 控制vllm使用多图, 默认为`None`. 例如传入`--limit_mm_per_prompt '{"image": 10, "video": 5}'`
 - vllm_max_lora_rank: 默认为`16`. vllm对于lora支持的参数
+- enable_prefix_caching: 是否开启 vllm 的 Prefix Caching 能力. 默认为`False`. 设置为 True 可以节约重复请求前缀（例如 System Prompt，长文档或多轮对话）处理时间。
 
 
 ### 合并参数

--- a/docs/source_en/Instruction/Command-line-parameters.md
+++ b/docs/source_en/Instruction/Command-line-parameters.md
@@ -281,6 +281,7 @@ Parameter meanings can be found in the [vllm documentation](https://docs.vllm.ai
 - enforce_eager: Whether vllm uses pytorch eager mode or establishes a cuda graph. Default is `False`. Setting to True can save memory but may affect efficiency.
 - 🔥limit_mm_per_prompt: Controls vllm using multiple images, default is `None`. For example, use `--limit_mm_per_prompt '{"image": 10, "video": 5}'`.
 - vllm_max_lora_rank: Default value is `16`. Parameters supported by vllm for LoRA.
+- enable_prefix_caching: Whether enable `Automatic Prefix Caching` feature for vllm. Default is `False`. Setting to True can save processing time for repeatable request prefix(such as system prompt, long docs, or multi-turn dialog, etc).
 
 ### Merge Arguments
 

--- a/swift/llm/argument/infer_args.py
+++ b/swift/llm/argument/infer_args.py
@@ -83,18 +83,18 @@ class VllmArguments:
         if hasattr(self, 'adapter_mapping'):
             adapters = adapters + list(self.adapter_mapping.values())
         return {
-            "gpu_memory_utilization": self.gpu_memory_utilization,
-            "tensor_parallel_size": self.tensor_parallel_size,
-            "pipeline_parallel_size": self.pipeline_parallel_size,
-            "max_num_seqs": self.max_num_seqs,
-            "max_model_len": self.max_model_len,
-            "disable_custom_all_reduce": self.disable_custom_all_reduce,
-            "enforce_eager": self.enforce_eager,
-            "limit_mm_per_prompt": self.limit_mm_per_prompt,
-            "max_lora_rank": self.vllm_max_lora_rank,
-            "enable_lora": len(adapters) > 0,
-            "max_loras": max(len(adapters), 1),
-            "enable_prefix_caching": self.enable_prefix_caching,
+            'gpu_memory_utilization': self.gpu_memory_utilization,
+            'tensor_parallel_size': self.tensor_parallel_size,
+            'pipeline_parallel_size': self.pipeline_parallel_size,
+            'max_num_seqs': self.max_num_seqs,
+            'max_model_len': self.max_model_len,
+            'disable_custom_all_reduce': self.disable_custom_all_reduce,
+            'enforce_eager': self.enforce_eager,
+            'limit_mm_per_prompt': self.limit_mm_per_prompt,
+            'max_lora_rank': self.vllm_max_lora_rank,
+            'enable_lora': len(adapters) > 0,
+            'max_loras': max(len(adapters), 1),
+            'enable_prefix_caching': self.enable_prefix_caching,
         }
 
 

--- a/swift/llm/argument/infer_args.py
+++ b/swift/llm/argument/infer_args.py
@@ -61,6 +61,7 @@ class VllmArguments:
         enforce_eager (bool): Flag to enforce eager execution. Default is False.
         limit_mm_per_prompt (Optional[str]): Limit multimedia per prompt. Default is None.
         vllm_max_lora_rank (int): Maximum LoRA rank. Default is 16.
+        enable_prefix_caching (bool): Flag to enable automatic prefix caching. Default is False.
     """
     # vllm
     gpu_memory_utilization: float = 0.9
@@ -72,6 +73,7 @@ class VllmArguments:
     enforce_eager: bool = False
     limit_mm_per_prompt: Optional[Union[dict, str]] = None  # '{"image": 10, "video": 5}'
     vllm_max_lora_rank: int = 16
+    enable_prefix_caching: bool = False
 
     def __post_init__(self):
         self.limit_mm_per_prompt = ModelArguments.parse_to_dict(self.limit_mm_per_prompt)
@@ -81,17 +83,18 @@ class VllmArguments:
         if hasattr(self, 'adapter_mapping'):
             adapters = adapters + list(self.adapter_mapping.values())
         return {
-            'gpu_memory_utilization': self.gpu_memory_utilization,
-            'tensor_parallel_size': self.tensor_parallel_size,
-            'pipeline_parallel_size': self.pipeline_parallel_size,
-            'max_num_seqs': self.max_num_seqs,
-            'max_model_len': self.max_model_len,
-            'disable_custom_all_reduce': self.disable_custom_all_reduce,
-            'enforce_eager': self.enforce_eager,
-            'limit_mm_per_prompt': self.limit_mm_per_prompt,
-            'max_lora_rank': self.vllm_max_lora_rank,
-            'enable_lora': len(adapters) > 0,
-            'max_loras': max(len(adapters), 1),
+            "gpu_memory_utilization": self.gpu_memory_utilization,
+            "tensor_parallel_size": self.tensor_parallel_size,
+            "pipeline_parallel_size": self.pipeline_parallel_size,
+            "max_num_seqs": self.max_num_seqs,
+            "max_model_len": self.max_model_len,
+            "disable_custom_all_reduce": self.disable_custom_all_reduce,
+            "enforce_eager": self.enforce_eager,
+            "limit_mm_per_prompt": self.limit_mm_per_prompt,
+            "max_lora_rank": self.vllm_max_lora_rank,
+            "enable_lora": len(adapters) > 0,
+            "max_loras": max(len(adapters), 1),
+            "enable_prefix_caching": self.enable_prefix_caching,
         }
 
 


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information
The [Automatic Prefix Caching](https://docs.vllm.ai/en/latest/features/automatic_prefix_caching.html) is very useful for modeling service.
This PR add argument (`--enable_prefix_caching`) for both infer and deploy mode. Prefix caching disable by default.


## Experiment results

