### PR TITLE
fix message merging strategy  when multi-turn tool calling.

### DIFF
--- a/swift/llm/template/template_inputs.py
+++ b/swift/llm/template/template_inputs.py
@@ -241,5 +241,10 @@ class StdTemplateInputs:
                 assert isinstance(pre_content, str)
                 pre_message['content'] = pre_content + content  # assistant
                 messages.pop(i)  # remove tool
+            elif (pre_role == 'assistant' and role == 'assistant' and isinstance(pre_content, str)
+                  and isinstance(content, str)):
+                # Consecutive messages from the assistant role need to be merged to prevent errors.
+                pre_message['content'] = pre_content + content
+                messages.pop(i)
             else:
                 i += 1

--- a/tests/llm/test_template.py
+++ b/tests/llm/test_template.py
@@ -36,6 +36,12 @@ def _infer_model(pt_engine, system=None, messages=None):
 
 class TestTemplate(unittest.TestCase):
 
+    def test_template(self):
+        pt_engine = PtEngine('Qwen/Qwen2.5-3B-Instruct-GPTQ-Int4')
+        response = _infer_model(pt_engine)
+        pt_engine.default_template.template_backend = 'jinja'
+        response2 = _infer_model(pt_engine)
+        assert response == response2
 
     def test_tool_message_join(self):
         from copy import deepcopy
@@ -72,7 +78,7 @@ class TestTemplate(unittest.TestCase):
         for tool_prompt in ('react_en', 'qwen'):
             tool_prompt = 'react_en'
             test_messages = deepcopy(messages)
-            obs_word = get_tools_keyword(tool_prompt).get("observation")
+            obs_word = get_tools_keyword(tool_prompt).get('observation')
             test_messages[1]['content'] = f'{obs_word}'
             test_messages[2]['content'] = 'first_round_result\n'
             test_messages[3]['content'] = f'{obs_word}'


### PR DESCRIPTION

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

修复 #2984 问题。多轮 tool-calling 时，message 会将 `role=tool` 内容merge 进上一条 `role=assistant` 的内容中；但是连续的 tool calling 会导致消息列表会由`user→assistant→tool→assistant→tool`变为 `user→assistant→assistant`，导致后续校验报错。

本 PR 修复了该问题，在`messages_join_observation`时也会将连续的`role=assistant`的内容进行合并，以避免上述问题。

## Experiment results

Paste your experiment result here(if needed).
