### PR TITLE
Fix qwen tool template to official format

### DIFF
--- a/swift/plugin/tools.py
+++ b/swift/plugin/tools.py
@@ -107,10 +107,20 @@ def format_qwen(tool_names, tool_descs):
 
 {tool_list}
 
-## 你可以在回复中插入以下命令以调用这些工具：
+## 你可以在回复中插入以下命令以并行调用N个工具：
 
-{format_list}
-    '''
+✿FUNCTION✿: 工具1的名称，必须是[{tool_names}]之一
+✿ARGS✿: 工具1的输入
+✿FUNCTION✿: 工具2的名称
+✿ARGS✿: 工具2的输入
+...
+✿FUNCTION✿: 工具N的名称
+✿ARGS✿: 工具N的输入
+✿RESULT✿: 工具1的结果
+✿RESULT✿: 工具2的结果
+...
+✿RESULT✿: 工具N的结果
+✿RETURN✿: 根据工具结果进行回复，需将图片用![](url)渲染出来'''
     # 定义星期映射
     weekdays = {0: '星期一', 1: '星期二', 2: '星期三', 3: '星期四', 4: '星期五', 5: '星期六', 6: '星期日'}
     now = dt.datetime.now()
@@ -125,11 +135,7 @@ def format_qwen(tool_names, tool_descs):
         tool_list += f'### {name} \n{name}: {tool["description"]} 输入参数: {json.dumps(tool["parameters"])}\n'
 
     PROMPT = PROMPT.replace('{tool_list}', tool_list)
-
-    format_list = ''
-    for i, _ in enumerate(tool_names):
-        format_list += f'✿FUNCTION✿:工具{i+1}的名称\n✿ARGS✿:工具{i + 1}的输入\n✿RESULT✿:工具{i + 1}的结果\n'
-    PROMPT = PROMPT.replace('{format_list}', format_list)
+    PROMPT = PROMPT.replace('{tool_names}', ','.join(tool_names))
     return PROMPT
 
 

--- a/swift/plugin/tools.py
+++ b/swift/plugin/tools.py
@@ -29,7 +29,7 @@ Final Answer: the final answer to the original input question
 
 Begin!
 """
-    tool_descs = [json.dumps(t) if not isinstance(t, str) else t for t in tool_descs]
+    tool_descs = [json.dumps(t, ensure_ascii=False) if not isinstance(t, str) else t for t in tool_descs]
     return REACT_PROMPT.format(tool_list='\n\n'.join(tool_descs), tool_names=','.join(tool_names))
 
 
@@ -49,7 +49,7 @@ Final Answer: 对输入问题的最终答案
 
 开始！
 """
-    tool_descs = [json.dumps(t) if not isinstance(t, str) else t for t in tool_descs]
+    tool_descs = [json.dumps(t, ensure_ascii=False) if not isinstance(t, str) else t for t in tool_descs]
     return REACT_ZH_PROMPT.format(tool_list='\n\n'.join(tool_descs), tool_names=','.join(tool_names))
 
 
@@ -59,7 +59,7 @@ def format_glm4(tool_names, tool_descs):
 # 可用工具
 
 {tool_list}"""
-    tool_descs = [json.dumps(t) if not isinstance(t, str) else t for t in tool_descs]
+    tool_descs = [json.dumps(t, ensure_ascii=False) if not isinstance(t, str) else t for t in tool_descs]
     tool_list = ''
     for name, tool in zip(tool_names, tool_descs):
         tool_list += f'## {name}\n\n{tool}\n\n'
@@ -92,7 +92,7 @@ or you find that function calls always fail(the function is not valid now), \
 use function Finish->give_up_and_restart.
 2.Do not use origin tool names, use only subfunctions' names.
 Specifically, you have access to the following APIs: {tool_list}"""
-    tool_descs = [json.dumps(t) if not isinstance(t, str) else t for t in tool_descs]
+    tool_descs = [json.dumps(t, ensure_ascii=False) if not isinstance(t, str) else t for t in tool_descs]
     return TOOLBENCH_PROMPT.format(tool_list='\n\n'.join(tool_descs))
 
 
@@ -133,7 +133,7 @@ def format_qwen(tool_names, tool_descs):
     tool_list = ''
     for name, tool in zip(tool_names, tool_descs):
         desc = tool.get('description', '')
-        parameters = json.dumps(params, ensure_ascii=False) if (params := tool.get("parameters")) else ''
+        parameters = json.dumps(params, ensure_ascii=False) if (params := tool.get('parameters')) else ''
         tool_list += f'### {name}\n\n{name}: {desc} 输入参数: {parameters} 此工具的输入应为JSON对象。'
 
     PROMPT = PROMPT.replace('{tool_list}', tool_list)
@@ -148,7 +148,7 @@ def format_custom(tool_names, tool_descs):
 
     {tool_list}'''
     tool_list = ''
-    tool_descs = [json.dumps(t) if not isinstance(t, str) else t for t in tool_descs]
+    tool_descs = [json.dumps(t, ensure_ascii=False) if not isinstance(t, str) else t for t in tool_descs]
     for name, tool in zip(tool_names, tool_descs):
         tool_list += f'## {name}\n\n{tool}\n\n'
     return PROMPT.format(tool_list=tool_list)

--- a/swift/plugin/tools.py
+++ b/swift/plugin/tools.py
@@ -120,7 +120,7 @@ def format_qwen(tool_names, tool_descs):
 ✿RESULT✿: 工具2的结果
 ...
 ✿RESULT✿: 工具N的结果
-✿RETURN✿: 根据工具结果进行回复，需将图片用![](url)渲染出来'''
+✿RETURN✿: 根据工具结果进行回复'''
     # 定义星期映射
     weekdays = {0: '星期一', 1: '星期二', 2: '星期三', 3: '星期四', 4: '星期五', 5: '星期六', 6: '星期日'}
     now = dt.datetime.now()
@@ -132,11 +132,13 @@ def format_qwen(tool_names, tool_descs):
     PROMPT = PROMPT.replace('{date}', formatted_date)
     tool_list = ''
     for name, tool in zip(tool_names, tool_descs):
-        tool_list += f'### {name} \n{name}: {tool["description"]} 输入参数: {json.dumps(tool["parameters"])}\n'
+        desc = tool.get('description', '')
+        parameters = json.dumps(params, ensure_ascii=False) if (params := tool.get("parameters")) else ''
+        tool_list += f'### {name}\n\n{name}: {desc} 输入参数: {parameters} 此工具的输入应为JSON对象。'
 
     PROMPT = PROMPT.replace('{tool_list}', tool_list)
     PROMPT = PROMPT.replace('{tool_names}', ','.join(tool_names))
-    return PROMPT
+    return PROMPT.rstrip()
 
 
 def format_custom(tool_names, tool_descs):


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

当前的 qwen-template（tool）在多个 tools 时，会被解析为如下的格式(例如 13 个工具)
```markdown
...

## 你可以在回复中插入以下命令以调用这些工具：

✿FUNCTION✿:工具1的名称
✿ARGS✿:工具1的输入
✿RESULT✿:工具1的结果
✿FUNCTION✿:工具2的名称
✿ARGS✿:工具2的输入
✿RESULT✿:工具2的结果
✿FUNCTION✿:工具3的名称
✿ARGS✿:工具3的输入
✿RESULT✿:工具3的结果
✿FUNCTION✿:工具4的名称
✿ARGS✿:工具4的输入
✿RESULT✿:工具4的结果
✿FUNCTION✿:工具5的名称
✿ARGS✿:工具5的输入
✿RESULT✿:工具5的结果
✿FUNCTION✿:工具6的名称
✿ARGS✿:工具6的输入
✿RESULT✿:工具6的结果
✿FUNCTION✿:工具7的名称
✿ARGS✿:工具7的输入
✿RESULT✿:工具7的结果
✿FUNCTION✿:工具8的名称
✿ARGS✿:工具8的输入
✿RESULT✿:工具8的结果
✿FUNCTION✿:工具9的名称
✿ARGS✿:工具9的输入
✿RESULT✿:工具9的结果
✿FUNCTION✿:工具10的名称
✿ARGS✿:工具10的输入
✿RESULT✿:工具10的结果
✿FUNCTION✿:工具11的名称
✿ARGS✿:工具11的输入
✿RESULT✿:工具11的结果
✿FUNCTION✿:工具12的名称
✿ARGS✿:工具12的输入
✿RESULT✿:工具12的结果
✿FUNCTION✿:工具13的名称
✿ARGS✿:工具13的输入
✿RESULT✿:工具13的结果
✿FUNCTION✿:工具14的名称
✿ARGS✿:工具14的输入
✿RESULT✿:工具14的结果
```

而正确的版本，参考如下链接：
* [Qwen2 函数调用模板](https://qwen.readthedocs.io/zh-cn/latest/framework/function_call.html#qwen2-function-calling-template)
* [QWEN-AGENT中的FN_CALL_TEMPLATE_FMT_PARA_ZH](https://github.com/QwenLM/Qwen-Agent/blob/a00999882ef4bc48f1b79c5e053eaa897924585e/qwen_agent/llm/fncall_prompts/qwen_fncall_prompt.py#L262)
```markdown
## 你可以在回复中插入以下命令以并行调用N个工具：
 
✿FUNCTION✿: 工具1的名称，必须是[{tool_names}]之一
✿ARGS✿: 工具1的输入
✿FUNCTION✿: 工具2的名称
✿ARGS✿: 工具2的输入
...
✿FUNCTION✿: 工具N的名称
✿ARGS✿: 工具N的输入
✿RESULT✿: 工具1的结果
✿RESULT✿: 工具2的结果
...
✿RESULT✿: 工具N的结果
✿RETURN✿: 根据工具结果进行回复，需将图片用![](url)渲染出来'''
```
可以看到相比较正确的格式，当前错误有几个：
1. `✿RESULT✿` 是放在模板最后的
2. 样例的数量是固定的，和 `request`中的 tools 数量无关（否则会导致 `prefix-caching`不能完全发挥作用）
3. 在第一个工具说明时，会附上所有的工具名称
4. `json.dump`处理中文时，会转换为 ascii 格式，导致模型处理中文时出现莫名其妙的问题。需要加入`ensure_ascii=False`来保证中文等字符的处理。



这个 PR 修正以上错误，和官方版本对齐。

## Experiment results

Paste your experiment result here(if needed).
