### PR TITLE
docs: report_to add swanlab

### DIFF
--- a/docs/source/Instruction/命令行参数.md
+++ b/docs/source/Instruction/命令行参数.md
@@ -111,7 +111,7 @@
 - lr_scheduler_type: lr_scheduler类型，默认为'cosine'
 - lr_scheduler_kwargs: lr_scheduler其他参数。默认为None
 - 🔥gradient_checkpointing_kwargs: 传入`torch.utils.checkpoint`中的参数。例如设置为`--gradient_checkpointing_kwargs '{"use_reentrant": false}'`。默认为None
-- report_to: 默认值为`tensorboard`。你也可以指定`--report_to tensorboard wandb`、`--report_to all`
+- report_to: 默认值为`tensorboard`。你也可以指定`--report_to tensorboard wandb swanlab`、`--report_to all`
 - logging_first_step: 是否记录第一个step的日志，默认为True
 - logging_steps: 日志打印间隔，默认为5
 - predict_with_generate: 验证时使用生成式的方式，默认为False。

--- a/docs/source_en/Instruction/Command-line-parameters.md
+++ b/docs/source_en/Instruction/Command-line-parameters.md
@@ -115,7 +115,7 @@ This parameter list inherits from transformers `Seq2SeqTrainingArguments`, with 
 - lr_scheduler_type: Type of lr_scheduler, defaults to 'cosine'.
 - lr_scheduler_kwargs: Other parameters for the lr_scheduler, defaults to None.
 - 🔥gradient_checkpointing_kwargs: Parameters for `torch.utils.checkpoint`. For example, set as `--gradient_checkpointing_kwargs '{"use_reentrant": false}'`. Defaults to None.
-- report_to: Default value is `tensorboard`. You can also specify `--report_to tensorboard wandb` or `--report_to all`.
+- report_to: Default value is `tensorboard`. You can also specify `--report_to tensorboard wandb swanlab` or `--report_to all`.
 - logging_first_step: Whether to log the first step, defaults to True.
 - logging_steps: Interval for logging, defaults to 5.
 - predict_with_generate: Whether to use generative method during validation, default is False.


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information

This pull request includes updates to the documentation for command-line parameters in both Chinese and English versions. The most important changes are the addition of a new parameter and the modification of an existing parameter's description.

Documentation updates:

* Added `gradient_checkpointing_kwargs` parameter to both the Chinese and English documentation for command-line parameters. This parameter allows users to pass arguments to `torch.utils.checkpoint`. [[1]](diffhunk://#diff-5d836eb8f4fbfbf8991e70bc64d6e742756897dd5545d69e7b5e938a3629463aL114-R114) [[2]](diffhunk://#diff-397ba02df1b1eb8c632a1608f9987b3f2c630dfc92c47177ac3f1acec40f2868L118-R118)
* Updated the `report_to` parameter description to include `swanlab` as an option in both the Chinese and English documentation. [[1]](diffhunk://#diff-5d836eb8f4fbfbf8991e70bc64d6e742756897dd5545d69e7b5e938a3629463aL114-R114) [[2]](diffhunk://#diff-397ba02df1b1eb8c632a1608f9987b3f2c630dfc92c47177ac3f1acec40f2868L118-R118)

## Experiment results

Paste your experiment result here(if needed).
