### PR TITLE
fix: error when uploading model to huggingface

### DIFF
--- a/swift/hub/hub.py
+++ b/swift/hub/hub.py
@@ -394,7 +394,7 @@ class HFHub(HubOperation):
         if revision is None or revision == 'master':
             revision = 'main'
         return api.upload_folder(
-            repo_id,
+            repo_id=repo_id,
             folder_path=folder_path,
             path_in_repo=path_in_repo,
             commit_message=commit_message,


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

There is some error when using `swift export` to upload the model to huggingface.

## Experiment results

``` (/projects/m000091/llm) zheminh@n08:/projects/m000091$ swift export     --model /projects/m000091/output/v11-20250226-132530/checkpoint-321-merged     --use_hf true     --push_to_hub true     --hub_model_id zheminh/Qwen2.5-32B-Instruct-1
run sh: `/projects/m000091/llm/bin/python3.12 /projects/m000091/llm/lib/python3.12/site-packages/swift/cli/export.py --model /projects/m000091/output/v11-20250226-132530/checkpoint-321-merged --use_hf true --push_to_hub true --hub_model_id zheminh/Qwen2.5-32B-Instruct-1`
[INFO:swift] Successfully registered `/projects/m000091/llm/lib/python3.12/site-packages/swift/llm/dataset/data/dataset_info.json`
[INFO:swift] Successfully loaded /projects/m000091/output/v11-20250226-132530/checkpoint-321-merged/args.json.
[INFO:swift] rank: -1, local_rank: -1, world_size: 1, local_world_size: 1
[INFO:swift] Loading the model using model_dir: /projects/m000091/output/v11-20250226-132530/checkpoint-321-merged
[INFO:swift] Global seed set to 42
[INFO:swift] args: ExportArguments(model='/projects/m000091/output/v11-20250226-132530/checkpoint-321-merged', model_type='qwen2_5', model_revision=None, task_type='causal_lm', torch_dtype=torch.bfloat16, attn_impl=None, num_labels=None, rope_scaling=None, device_map=None, local_repo_path=None, template='qwen2_5', system='***.', max_length=2048, truncation_strategy='delete', max_pixels=None, tools_prompt='react_en', norm_bbox=None, padding_side='right', loss_scale='default', sequence_parallel_size=1, use_chat_template=True, template_backend='swift', dataset=[], val_dataset=[], split_dataset_ratio=0.01, data_seed=42, dataset_num_proc=1, streaming=False, enable_cache=False, download_mode='reuse_dataset_if_exists', columns={}, strict=False, remove_unused_columns=True, model_name=[None, None], model_author=[None, None], custom_dataset_info=[], quant_method=None, quant_bits=4, hqq_axis=None, bnb_4bit_compute_dtype=torch.bfloat16, bnb_4bit_quant_type='nf4', bnb_4bit_use_double_quant=True, bnb_4bit_quant_storage='bfloat16', max_new_tokens=None, temperature=None, top_k=None, top_p=None, repetition_penalty=None, num_beams=1, stream=False, stop_words=[], logprobs=False, top_logprobs=None, ckpt_dir='/projects/m000091/output/v11-20250226-132530/checkpoint-321-merged', load_dataset_config=None, lora_modules=[], tuner_backend='peft', train_type='lora', adapters=[], seed=42, model_kwargs={}, load_args=True, load_data_args=False, use_hf=True, hub_token=None, custom_register_path=[], ignore_args_error=False, use_swift_lora=False, merge_lora=False, safe_serialization=True, max_shard_size='5GB', output_dir=None, quant_n_samples=256, quant_batch_size=1, group_size=128, to_ollama=False, gguf_file=None, push_to_hub=True, hub_model_id='zheminh/Qwen2.5-32B-Instruct-1', hub_private_repo=False, commit_message='update files', to_peft_format=False, exist_ok=False)
[INFO:swift] Start time of running main: 2025-02-26 14:59:30.954289
Traceback (most recent call last):
  File "/projects/m000091/llm/lib/python3.12/site-packages/swift/cli/export.py", line 5, in <module>
    export_main()
  File "/projects/m000091/llm/lib/python3.12/site-packages/swift/llm/export/export.py", line 44, in export_main
    return SwiftExport(args).main()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/projects/m000091/llm/lib/python3.12/site-packages/swift/llm/base.py", line 46, in main
    result = self.run()
             ^^^^^^^^^^
  File "/projects/m000091/llm/lib/python3.12/site-packages/swift/llm/export/export.py", line 35, in run
    args.hub.push_to_hub(
  File "/projects/m000091/llm/lib/python3.12/site-packages/swift/hub/hub.py", line 396, in push_to_hub
    return api.upload_folder(
           ^^^^^^^^^^^^^^^^^^
  File "/projects/m000091/llm/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/projects/m000091/llm/lib/python3.12/site-packages/huggingface_hub/hf_api.py", line 1523, in _inner
    return fn(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: HfApi.upload_folder() takes 1 positional argument but 2 positional arguments (and 7 keyword-only arguments) were given```
