### PR TITLE
fix grpo trainer zero3 always gather parameters

### DIFF
--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -705,7 +705,11 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
             is_multimodal = self.model.model_meta.is_multimodal
             if is_multimodal:
                 models = self.template.remove_post_encode_hook()
-            with unwrap_model_for_generation(self.model_wrapped, self.accelerator):
+            with unwrap_model_for_generation(
+                    self.model_wrapped, 
+                    self.accelerator,
+                    gather_deepspeed3_params=self.args.ds3_gather_for_generation
+            ):
                 # same reference
                 outputs = self.engine.infer(inputs, self.request_config, use_tqdm=False)
                 self.model.train()

--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -706,10 +706,7 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
             if is_multimodal:
                 models = self.template.remove_post_encode_hook()
             with unwrap_model_for_generation(
-                    self.model_wrapped, 
-                    self.accelerator,
-                    gather_deepspeed3_params=self.args.ds3_gather_for_generation
-            ):
+                    self.model_wrapped, self.accelerator, gather_deepspeed3_params=self.args.ds3_gather_for_generation):
                 # same reference
                 outputs = self.engine.infer(inputs, self.request_config, use_tqdm=False)
                 self.model.train()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
当GRPO配置zero3时，始终会将所有参数收集到单卡推理，导致虽然设置了zero3，但实际上也跑不起来超过单卡显存的模型。即使设置了--ds3_gather_for_generation False也没用。这个PR修复了这个问题。

## Experiment results
修复前，zero3，16卡Ascend910B，单卡65G显存，跑不起来InternVL2.5-26B，直接OOM。
修复后，同样配置环境，InternVL2.5-26B，zero3可以正常训练，且显存占用降低到单卡30GB左右，符合预期。

Paste your experiment result here(if needed).
