### PR TITLE
更新LlavaHfTemplate以适配transformers版本大于4.47时对LLaVA和LLaVA-Next模型处理图像token逻辑的修改

### DIFF
--- a/swift/llm/template/template/llava.py
+++ b/swift/llm/template/template/llava.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional
 
 import torch
+from packaging import version
+import transformers
 
 from ..base import Template
 from ..constant import MLLMTemplateType
@@ -16,6 +18,12 @@ from .utils import ChatmlTemplateMeta
 
 
 class LlavaHfTemplate(Template):
+
+    @property
+    def image_token_index(self):
+        if not hasattr(self, '_image_token_index'):
+            self._image_token_index = self.tokenizer.convert_tokens_to_ids(self.processor.image_token)
+        return self._image_token_index
 
     def replace_tag(self, media_type: Literal['image', 'video', 'audio'], index: int,
                     inputs: StdTemplateInputs) -> List[Context]:
@@ -31,6 +39,30 @@ class LlavaHfTemplate(Template):
             encoded['pixel_values'] = image_inputs['pixel_values']
             if 'image_sizes' in image_inputs:
                 encoded['image_sizes'] = image_inputs['image_sizes']
+            if version.parse(transformers.__version__) >= version.parse('4.47'):
+                input_ids = encoded['input_ids']
+                labels = encoded['labels']
+                idx_list = findall(input_ids, self.image_token_index)  # <image>
+                height, width = image_inputs['pixel_values'][0].shape[-2:]
+                added_tokens_len = 0
+                for i, idx in enumerate(idx_list):
+                    if 'image_sizes' in image_inputs:
+                        orig_height, orig_width = image_inputs['image_sizes'][i].tolist()
+                        num_image_tokens = self.processor._get_number_of_features(orig_height, orig_width, height, width)
+                    else:
+                        num_image_tokens = (height // self.processor.patch_size) * (
+                            width // self.processor.patch_size
+                        ) + self.processor.num_additional_image_tokens
+                    if self.processor.vision_feature_select_strategy == "default":
+                        num_image_tokens -= 1
+                    input_ids = input_ids[:added_tokens_len + idx] + [self.image_token_index] * num_image_tokens \
+                        + input_ids[added_tokens_len + idx + 1:]
+                    if labels is not None:
+                        labels = labels[:added_tokens_len + idx] + [-100] * num_image_tokens \
+                            + labels[added_tokens_len + idx + 1:]
+                    added_tokens_len += num_image_tokens - 1
+                encoded['input_ids'] = input_ids
+                encoded['labels'] = labels
         return encoded
 
 
@@ -41,6 +73,7 @@ register_template(
         prompt=['USER: {{QUERY}}\nASSISTANT:'],
         chat_sep=['</s>'],
         suffix=['</s>'],
+        system_prefix=['<s>{{SYSTEM}}\n'],
         template_cls=LlavaHfTemplate,
     ))
 

--- a/swift/llm/template/template/llava.py
+++ b/swift/llm/template/template/llava.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional
 
 import torch
-from packaging import version
 import transformers
+from packaging import version
 
 from ..base import Template
 from ..constant import MLLMTemplateType
@@ -48,12 +48,12 @@ class LlavaHfTemplate(Template):
                 for i, idx in enumerate(idx_list):
                     if 'image_sizes' in image_inputs:
                         orig_height, orig_width = image_inputs['image_sizes'][i].tolist()
-                        num_image_tokens = self.processor._get_number_of_features(orig_height, orig_width, height, width)
+                        num_image_tokens = self.processor._get_number_of_features(orig_height, orig_width, height,
+                                                                                  width)
                     else:
                         num_image_tokens = (height // self.processor.patch_size) * (
-                            width // self.processor.patch_size
-                        ) + self.processor.num_additional_image_tokens
-                    if self.processor.vision_feature_select_strategy == "default":
+                            width // self.processor.patch_size) + self.processor.num_additional_image_tokens
+                    if self.processor.vision_feature_select_strategy == 'default':
                         num_image_tokens -= 1
                     input_ids = input_ids[:added_tokens_len + idx] + [self.image_token_index] * num_image_tokens \
                         + input_ids[added_tokens_len + idx + 1:]


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

在我sft训练LLaVA和LLaVA-Next的过程中，发现当transformers版本大于等于4.47时，训练会报错，小于4.46时可以正常训练。报错信息和此issue #3196 相同。经过查看transformers的llava模型代码，发现在4.46版本时，模型内部对单个<image> token扩展成实际数量的image token有两套处理逻辑，第一套是传统的在模型forward内部处理，第二条是交由processor在__call__中直接对输入文本扩展，forward内部只负责scatter image feature到对应位置。在transformers 4.47以后，第一套逻辑被删掉了。但是由于本框架在处理数据时，对文本和图像是分开处理的，没有调用processor.__call__函数，因此此时image token无法被正确扩展，导致token数量不匹配报错。因此本PR参考llava-onevision和qwen的处理逻辑，修改了LlavaHfTemplate的代码进行适配。

此外，还为llava1_5_hf的TemplateMeta增加了system_prefix，防止传入带system message的信息时报错。

## Experiment results

已经测试sft训练LLaVA和LLaVA-Next时没有问题。

Fixes #3196