### PR TITLE
fix grpo lora split module

### DIFF
--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -318,7 +318,7 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
                         llm = llm[0]
                     if name.startswith('base_model'):
                         name = name.replace('base_model.', '')
-                    if name.startswith(llm):
+                    if name in llm:
                         layer_count = len(module)
                 else:
                     layer_count = len(module)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

peft model may start with a prefix like model.language_model, so using startswith might not work as expected


## Experiment results

Paste your experiment result here(if needed).
