### PR TITLE
fix grpo cosine reward

### DIFF
--- a/docs/source/Instruction/GRPO.md
+++ b/docs/source/Instruction/GRPO.md
@@ -69,8 +69,8 @@ A conversation between User and Assistant. The user asks a question, and the Ass
 使用余弦函数平滑地调整奖励值，确保奖励变化在合理范围内。余弦函数的参数包括生成文本的长度、最大长度限制以及奖励的最小值和最大值。
 
 参数
-- cosine_min_len_value_wrong（默认值：0.0）：生成错误答案时，最小长度对应的奖励值。
-- cosine_max_len_value_wrong（默认值：-0.5）：生成错误答案时，最大长度对应的奖励值。
+- cosine_min_len_value_wrong（默认值：-0.5）：生成错误答案时，最小长度对应的奖励值。
+- cosine_max_len_value_wrong（默认值：0.0）：生成错误答案时，最大长度对应的奖励值。
 - cosine_min_len_value_correct（默认值：1.0）：生成正确答案时，最小长度对应的奖励值。
 - cosine_max_len_value_correct（默认值：0.5）：生成正确答案时，最大长度对应的奖励值。
 - cosine_max_len（默认值等于模型生成的最大程度）：生成文本的最大长度限制。

--- a/docs/source_en/Instruction/GRPO.md
+++ b/docs/source_en/Instruction/GRPO.md
@@ -72,8 +72,8 @@ The paper found that training with only the accuracy reward function could lead 
 A cosine function is used to smoothly adjust the reward value, ensuring that the changes are within a reasonable range. The parameters for the cosine function include the length of the generated text, the maximum length limit, and the minimum and maximum reward values.
 
 Parameters:
-- `cosine_min_len_value_wrong` (default: 0.0): Reward value corresponding to the minimum length when the answer is incorrect.
-- `cosine_max_len_value_wrong` (default: -0.5): Reward value corresponding to the maximum length when the answer is incorrect.
+- `cosine_min_len_value_wrong` (default: -0.5): Reward value corresponding to the minimum length when the answer is incorrect.
+- `cosine_max_len_value_wrong` (default: 0.0): Reward value corresponding to the maximum length when the answer is incorrect.
 - `cosine_min_len_value_correct` (default: 1.0): Reward value corresponding to the minimum length when the answer is correct.
 - `cosine_max_len_value_correct` (default: 0.5): Reward value corresponding to the maximum length when the answer is correct.
 - `cosine_max_len` (default value equal to the model's maximum generation capacity): Maximum length limit for generated text.

--- a/swift/plugin/orm.py
+++ b/swift/plugin/orm.py
@@ -300,8 +300,8 @@ class CosineReward(ORM):
     # https://arxiv.org/abs/2502.03373
     def __init__(self,
                  tokenizer=None,
-                 cosine_min_len_value_wrong: float = 0.0,
-                 cosine_max_len_value_wrong: float = -0.5,
+                 cosine_min_len_value_wrong: float = -0.5,
+                 cosine_max_len_value_wrong: float = 0.0,
                  cosine_min_len_value_correct: float = 1.0,
                  cosine_max_len_value_correct: float = 0.5,
                  cosine_max_len: int = 1000,
@@ -329,8 +329,8 @@ class CosineReward(ORM):
                 min_value = self.max_len_value_correct
                 max_value = self.min_len_value_correct
             else:
-                min_value = self.min_len_value_wrong
-                max_value = self.max_len_value_wrong
+                min_value = self.max_len_value_wrong
+                max_value = self.min_len_value_wrong
             gen_len = len(self.tokenizer.encode(content))
             reward = self.cosfn(gen_len, self.max_len, min_value, max_value)
             rewards.append(reward)

--- a/swift/trainers/arguments.py
+++ b/swift/trainers/arguments.py
@@ -133,8 +133,8 @@ class GRPOArgumentsMixin:
     vllm_enable_prefix_caching: bool = True
     # reward function args, see details in swift/plugin/orm.py
     # cosine reward, https://arxiv.org/abs/2502.03373
-    cosine_min_len_value_wrong: float = 0.0  # r^w_0 in paper, Reward for wrong answers with zero completion length.
-    cosine_max_len_value_wrong: float = -0.5  # r^w_L in paper, Reward for wrong answers with max completion length.
+    cosine_min_len_value_wrong: float = -0.5  # r^w_0 in paper, Reward for wrong answers with zero completion length.
+    cosine_max_len_value_wrong: float = 0.0  # r^w_L in paper, Reward for wrong answers with max completion length.
     cosine_min_len_value_correct: float = 1.0  # r^c_0 in paper, Reward for correct answers with zero completion length.
     cosine_max_len_value_correct: float = 0.5  # r^c_L in paper, Reward for correct answers with max completion length.
     cosine_max_len: Optional[int] = None  # Lmax in paper, default equal to max_completion_length


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

https://github.com/modelscope/ms-swift/issues/3636

fix the mismatch between the parameter name and description of the cosine reward, which may cause errors when the default value is not used.


Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
