### PR TITLE
fix internvl template

### DIFF
--- a/swift/llm/template/template/internvl.py
+++ b/swift/llm/template/template/internvl.py
@@ -120,6 +120,14 @@ class Internvl2Template(InternvlTemplate):
                 max_num = video_max_num
             pixel_values = [transform_image(image, input_size, max_num) for image in images]
             num_patches = [pv.shape[0] for pv in pixel_values]
+            if isinstance(self.config.torch_dtype, str):
+                dtype_mapping = {
+                    "float32": torch.float32,
+                    "float16": torch.float16,
+                    "bfloat16": torch.bfloat16,
+                }
+                self.config.torch_dtype = dtype_mapping.get(self.config.torch_dtype, torch.float16)
+
             pixel_values = torch.cat(pixel_values).to(self.config.torch_dtype)
         else:
             pixel_values = None


### PR DESCRIPTION
# PR type
- [√ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

对比 0313 拉取的main分支，0325 拉取的main分支，在微调 InternVL2d5 saving checkpoints 时会报错：
`RuntimeError: Invalid device string: 'bfloat16'`
是否是更新了参数解析相关的代码，导致internvl相关的内容会发生覆盖？

## Experiment results

0313的分支结果均正常，0325的分支仅微调internvl报错；
测试了 qwenvl 和 internvl 两个模型
