### PR TITLE
优化_replace_image_tags防止数据中不包含具体图像的<img></img> tag中断训练

### DIFF
--- a/swift/llm/template/base.py
+++ b/swift/llm/template/base.py
@@ -228,8 +228,8 @@ class Template(ProcessorMixin):
 
     @staticmethod
     def _format_image_entry(src: str):
-        if src.startswith('http') or os.path.exists(os.path.expanduser(src)) \
-            or (not src.startswith('data:') and len(src) <= 200):
+        if src.startswith('http') or os.path.exists(os.path.expanduser(src)) or (not src.startswith('data:')
+                                                                                 and len(src) <= 200):
             return {'bytes': None, 'path': src}
         try:
             data = load_file(src)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

在一次GRPO训练中程序意外中断于 [此处](https://github.com/modelscope/ms-swift/blob/0b676f2c8fbbdea6d8ba39e799866aed1be046ea/swift/llm/template/base.py#L232)，原因是模型生成了`<img>乱七八糟的内容</img>`这样的文本，_replace_image_tags函数未加检查地错误地提取了其中内容，然后和数据中原始的images冲突。

本次PR更新了_replace_image_tags，主要实现两个逻辑。
1. 对`<img></img>`包裹的内容进行判断，若为合法的图像（如url、本地路径、base64等），才提取并compat `<img></img>` 为`<image>`，否则不处理。
2. 在原来有`<image>` tag且inputs.images有相应图像的情况下，保证`<img></img>`插入inputs.images的正确位置。

## Experiment results

经过测试可以忽略`<img></img>`内非图片内容，且对后续`<image>`和image文件的处理没有影响，能够正常训练。

原始数据中若inputs.images和`<image>`数量匹配，则没有问题。若inputs.images数量比原始`<image>`多，则由后续_add_default_tags函数处理。若inputs.images数量比原始`<image>`少，且在有效`<img></img>`前面有没有图像对应的`<image>` tag，则会造成图像错位，但实际上可能会因为最终`<image>`和inputs.images数量不匹配，在后续模型中报错（如llava）。
