### PR TITLE
Update dataset_info.json

### DIFF
--- a/swift/llm/dataset/data/dataset_info.json
+++ b/swift/llm/dataset/data/dataset_info.json
@@ -708,5 +708,14 @@
             "problem_statement": "query"
         },
         "tags": ["grpo", "code"]
+    },
+    {
+        "hf_dataset_id": "battleMaster/RLHF-V-ms-swift",
+        "columns": {
+            "question": "query",
+            "chosen": "response",
+            "rejected": "rejected_response"
+        },
+        "tags": ["rlhf", "dpo", "multi-modal", "en"]
     }
 ]


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [✅ ] More Models or Datasets Support

# PR information

I have reformatted the openbmb/RLHF-V-Dataset to easily load it using ms-swift scripts. The reformatted dataset has been uploaded at hugging face: battleMaster/RLHF-V-ms-swift. Correspondingly registered the dataset in dataset_info.json

## Experiment results

Verified the dataset works normally with ms-swift scripts. 
