### PR TITLE
Error message fix - truncation strategy for RLHF

### DIFF
--- a/swift/llm/argument/rlhf_args.py
+++ b/swift/llm/argument/rlhf_args.py
@@ -139,7 +139,8 @@ class RLHFArguments(GRPOArguments, PPOArguments, RewardModelArguments, TrainArgu
                 self.gradient_accumulation_steps = 1
             self.remove_unused_columns = False
             logger.info(f'Setting args.remove_unused_columns: {self.remove_unused_columns}')
-            self.truncation_strategy = 'left'  # Used for trimming the excessively long parts of a prompt.
+            if self.truncation_strategy != 'left':
+                raise ValueError('GRPO only support left truncation strategy')
             if self.beta is None:
                 self.beta = 0.04  # https://arxiv.org/abs/2402.03300
             if self.async_generate:


### PR DESCRIPTION
# PR type
- [X] Bug Fix

# PR information

If you truncate from the left (overwriting whatever the user actually supplied from the CLI), it is awfully confusing. I ended up debugging this for a while when my multimodal model had its image tokens cropped, and I got a VLLM error saying I had an incorrect number of image tokens. I figure instead of overwriting the user preference, raising here is probably better.

Not really sure why we don't just respect the user argument preference instead, and happy to allow that too.
