### PR TITLE
Fix model max length

### DIFF
--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -1084,7 +1084,7 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
             origin_set_default_max_tokens = self.engine.set_default_max_tokens
 
             def new_set_default_max_tokens(_self, request_config: RequestConfig, inputs: Dict[str, Any]) -> None:
-                max_model_len = _self.max_model_len or 8192
+                max_model_len = self.args.vllm_max_model_len or 8192
                 for inp in inputs:
                     num_tokens = max(num_tokens, _self._get_num_tokens(inp))
                 _self.max_model_len = min(max_model_len, num_tokens + request_config.max_tokens)


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information

Every time I train right now, regardless of what I set the `max_length`, `max_completion_length`, or `vllm_max_model_len` to, the max_model_len gets set to 8192. We have a hidden default in here that doesn't listen to the arguments that are set. I believe we want the engine to be set to `vllm_max_model_len`, but happy to change it if I'm wrong.

@hjh0119 @tastelikefeet 