### PR TITLE
[Gemma] Fixing the ndarray cast warning

### DIFF
--- a/swift/llm/template/template/gemma.py
+++ b/swift/llm/template/template/gemma.py
@@ -115,7 +115,7 @@ class Gemma3VisionTemplate(Gemma3Template):
             # TODO: customize
             processor_kwargs = Gemma3ProcessorKwargs._defaults['images_kwargs']
             image_inputs = self.processor.image_processor(inputs.images, **processor_kwargs)
-            image_inputs['pixel_values'] = torch.as_tensor(image_inputs['pixel_values'])
+            image_inputs['pixel_values'] = torch.as_tensor(np.array(image_inputs['pixel_values']))
             image_inputs.pop('num_crops')
 
             array_ids = np.array(input_ids)


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information
There was a warning. Just addressing that.
```
/home/dev/src/prospero/python/external/ms-swift/swift/llm/template/template/gemma.py:118: UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at /pytorch/torch/csrc/utils/tensor_new.cpp:254.)
```
