### PR TITLE
Fix incorrect retry count check in LazyLLMDataset.__getitem__

### DIFF
--- a/swift/llm/dataset/utils.py
+++ b/swift/llm/dataset/utils.py
@@ -81,6 +81,7 @@ class LazyLLMDataset(Dataset):
 
     def __getitem__(self, idx: int) -> Dict[str, Any]:
         for i in range(self.n_try_fetch):
+            n_try = i
             if i == 0:
                 i = idx
             else:
@@ -90,7 +91,7 @@ class LazyLLMDataset(Dataset):
             try:
                 return self.encode_func(data)
             except Exception:
-                if i == self.n_try_fetch - 1:
+                if n_try == self.n_try_fetch - 1:
                     if self.strict:
                         logger.warning('To avoid errors, you can pass `strict=False`.')
                     raise


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

### Problem
In `LazyLLMDataset.__getitem__`, the loop variable `i` is modified inside the retry logic, which can lead to incorrect behavior when checking if the maximum retry attempts (`n_try_fetch`) have been reached.

For example:

If `i` = 0, it gets reassigned to `idx`, but later the condition `i == self.n_try_fetch - 1` may incorrectly evaluate because i is no longer the original loop counter.

This could cause the method to either:

 - Fail too early (if `idx` happens to match `n_try_fetch - 1`).

 - Fail too late (if `i` is reassigned to a smaller value).

### Solution

Introduce a separate variable n_try to track the actual retry count, ensuring the correct number of attempts is enforced.

This makes the retry logic more robust and predictable.


