### PR TITLE
feat: support megatron wandb

### DIFF
--- a/swift/megatron/argument/megatron_args.py
+++ b/swift/megatron/argument/megatron_args.py
@@ -142,6 +142,9 @@ class MegatronArguments(ExtraMegatronArguments):
     log_validation_ppl_to_tensorboard: bool = True
     log_memory_to_tensorboard: bool = True
     logging_leval: Optional[str] = None
+    wandb_project: Optional[str] = None
+    wandb_exp_name: Optional[str] = None
+    wandb_save_dir: Optional[str] = None
 
     # evaluate
     eval_iters: int = 100


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Add support megatron wandb in ms-swift
Add arguments like megatron llm
https://github.com/NVIDIA/Megatron-LM/blob/89d758b28f57d71fe74a6e1b85d2f93a4302121a/megatron/training/arguments.py#L1514

Write the detail information belongs to this PR.

## Experiment results

``` bash
NPROC_PER_NODE=1 \
CUDA_VISIBLE_DEVICES=0 \
megatron sft \
    --load data/models/Qwen/Qwen3-0.6B-mcore \
    --dataset data/swift/Qwen3-SFT-Mixin/qwen3_32b_distill_1k.jsonl \
    --tensor_model_parallel_size 1 \
    --micro_batch_size 1 \
    --global_batch_size 16 \
    --recompute_granularity selective \
    --train_iters 31 \
    --eval_iters 5 \
    --finetune true \
    --cross_entropy_loss_fusion true \
    --lr 1e-5 \
    --lr_warmup_iters 10 \
    --min_lr 1e-6 \
    --save runs/test/qwen3-0.6b-megatron \
    --save_interval 100 \
    --max_length 2048 \
    --system 'You are a helpful assistant.' \
    --num_workers 4 \
    --no_save_optim true \
    --no_save_rng true \
    --dataset_num_proc 4 \
    --bf16 true \
    --log_interval 1 \
    --use_flash_attn true \
    --wandb_project llm101 \
    --wandb_exp_name qwen3-0.6b-megatron
```
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/74f8cdfd-ca30-49ee-b792-cab4528f5e0d" />

Resolves #4071 
