### PR TITLE
fix model_type mismatch

### DIFF
--- a/swift/llm/infer/infer_engine/lmdeploy_engine.py
+++ b/swift/llm/infer/infer_engine/lmdeploy_engine.py
@@ -32,6 +32,9 @@ except ImportError:
 
 logger = get_logger()
 
+LMDEPLOY_MODEL_TYPE_MAPPING = {
+    'qwen2_5_vl': 'qwen2d5-vl',
+}
 
 class LmdeployEngine(InferEngine):
 
@@ -132,7 +135,10 @@ class LmdeployEngine(InferEngine):
         _old_best_match_model = async_engine.best_match_model
 
         def _best_match_model(*args, **kwargs) -> Optional[str]:
-            return self.model_info.model_type
+            model_type = self.model_info.model_type
+            if model_type in LMDEPLOY_MODEL_TYPE_MAPPING:
+                return LMDEPLOY_MODEL_TYPE_MAPPING[model_type]
+            return model_type
 
         async_engine.best_match_model = _best_match_model
         try:


### PR DESCRIPTION
# PR type
- [√] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixed the issue of mismatched model_type when using LMDeploy to infer QwenVL2.5.

## Experiment results

![Snipaste_2025-05-08_10-24-58](https://github.com/user-attachments/assets/379fd46e-3f41-44b6-8c60-3d9c5619854e)

The warning sometimes led to the presence of "Special Tokens" in the inference results. After eliminating this warning, no such issue was observed after multiple rounds of inference experiments.
