### PR TITLE
[doc] remove vllm version warning in grpo

### DIFF
--- a/docs/source/GetStarted/SWIFT安装.md
+++ b/docs/source/GetStarted/SWIFT安装.md
@@ -38,7 +38,7 @@ pip install ms-swift==2.*
 ## 镜像
 
 ```
-# vllm0.8.3 (该版本vllm可能导致部分GRPO训练卡住，GRPO建议优先使用vllm0.7.3)
+# vllm0.8.3
 modelscope-registry.cn-hangzhou.cr.aliyuncs.com/modelscope-repo/modelscope:ubuntu22.04-cuda12.4.0-py311-torch2.6.0-vllm0.8.3-modelscope1.25.0-swift3.3.0.post1
 modelscope-registry.us-west-1.cr.aliyuncs.com/modelscope-repo/modelscope:ubuntu22.04-cuda12.4.0-py311-torch2.6.0-vllm0.8.3-modelscope1.25.0-swift3.3.0.post1
 

--- a/docs/source_en/GetStarted/SWIFT-installation.md
+++ b/docs/source_en/GetStarted/SWIFT-installation.md
@@ -39,7 +39,7 @@ pip install ms-swift==2.*
 ## Mirror
 
 ```
-# vllm0.8.3 (This version of vllm may cause some GRPO training to get stuck; it is recommended to use vllm0.7.3 for GRPO training as a priority).
+# vllm0.8.3
 modelscope-registry.cn-hangzhou.cr.aliyuncs.com/modelscope-repo/modelscope:ubuntu22.04-cuda12.4.0-py311-torch2.6.0-vllm0.8.3-modelscope1.25.0-swift3.3.0.post1
 modelscope-registry.us-west-1.cr.aliyuncs.com/modelscope-repo/modelscope:ubuntu22.04-cuda12.4.0-py311-torch2.6.0-vllm0.8.3-modelscope1.25.0-swift3.3.0.post1
 


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
https://github.com/modelscope/ms-swift/issues/4202

Since GRPO already supports vLLM 0.8 in https://github.com/modelscope/ms-swift/pull/4097, the warning about the vLLM version in the documentation can be removed.

## Experiment results

Paste your experiment result here(if needed).
