### PR TITLE
fix template.loss_scale when use multi_turn_func

### DIFF
--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -444,7 +444,8 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
         template.max_length = None
         loss_scale = template.loss_scale
         if self.multi_turn_func:
-            template.loss_scale = 'default'
+            from swift.plugin import loss_scale_map
+            template.loss_scale = loss_scale_map['default']()
         try:
             yield
         finally:


### PR DESCRIPTION
fix bug, init an instance of loss_scale instead of String

# PR type
- [-] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
