### PR TITLE
fix task type judgement in rlhf

### DIFF
--- a/swift/llm/train/rlhf.py
+++ b/swift/llm/train/rlhf.py
@@ -57,7 +57,8 @@ class SwiftRLHF(SwiftSft):
                 if hasattr(model_config, 'num_labels'):
                     num_labels = model_config.num_labels
 
-                if num_labels is not None:
+                # PretrainedConfig default num_labels = 2
+                if num_labels == 1:
                     task_type = 'seq_cls'
 
             model, processor = args.get_model_processor(


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

fix a bug that the task_type of models in rlhf is set to `seq_cls` , since the default value of num_labels
Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
