### PR TITLE
[megatron] Add extra args and provider support for easily customize megatron

### DIFF
--- a/swift/megatron/model/register.py
+++ b/swift/megatron/model/register.py
@@ -1,4 +1,5 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
+from argparse import ArgumentParser
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
@@ -19,6 +20,8 @@ class MegatronModelMeta:
     convert_hf_config: Callable[[PretrainedConfig], Dict[str, Any]]
     convert_mcore2hf: Callable[[nn.Module, nn.Module], None]
     convert_hf2mcore: Callable[[nn.Module, nn.Module], None]
+
+    extra_args_provider: Optional[Callable[[ArgumentParser], ArgumentParser]] = None
 
 
 def register_megatron_model(megatron_model_meta: MegatronModelMeta, *, exist_ok: bool = False):

--- a/swift/megatron/train/sft.py
+++ b/swift/megatron/train/sft.py
@@ -47,11 +47,13 @@ class MegatronSft(SwiftSft):
         logger.info(f'The logging file will be saved in: {logging_path}')
         try:
             with patch_training_log(), patch_megatron_data_collator(data_collator):
+                extra_args_provider = args.megatron_model_meta.extra_args_provider
                 pretrain(
                     datasets_provider,
                     args.megatron_model_meta.model_provider,
                     ModelType.encoder_or_decoder,
                     forward_step,
+                    extra_args_provider=extra_args_provider,
                     args_defaults=args.extra_args)
         finally:
             # Visualization

--- a/swift/megatron/utils/convert.py
+++ b/swift/megatron/utils/convert.py
@@ -74,7 +74,8 @@ def convert_hf2mcore(args: ExportArguments) -> None:
     megatron_args = MegatronArguments(**kwargs, **convert_kwargs, save=args.output_dir, torch_dtype=args.torch_dtype)
     patch_megatron_tokenizer(processor)
     extra_args = megatron_args.parse_to_megatron()
-    initialize_megatron(args_defaults=extra_args)
+    extra_args_provider = megatron_model_meta.extra_args_provider
+    initialize_megatron(extra_args_provider=extra_args_provider, args_defaults=extra_args)
 
     mg_model = megatron_model_meta.model_provider()
     logger.info('Megatron model created successfully.')
@@ -101,7 +102,8 @@ def convert_mcore2hf(args: ExportArguments) -> None:
     megatron_args = MegatronArguments(**kwargs, **convert_kwargs, load=args.mcore_model, torch_dtype=args.torch_dtype)
     patch_megatron_tokenizer(processor)
     extra_args = megatron_args.parse_to_megatron()
-    initialize_megatron(args_defaults=extra_args)
+    extra_args_provider = megatron_model_meta.extra_args_provider
+    initialize_megatron(extra_args_provider=extra_args_provider, args_defaults=extra_args)
 
     mg_model = megatron_model_meta.model_provider()
     load_checkpoint([mg_model], None, None, strict=True)

--- a/tests/megatron/test_model.py
+++ b/tests/megatron/test_model.py
@@ -11,10 +11,11 @@ def get_mg_model_tokenizer(model_id):
     megatron_model_meta = get_megatron_model_meta(processor.model_meta.model_type)
     model_info = processor.model_info
     kwargs = megatron_model_meta.convert_hf_config(model_info.config)
-    megatron_args = MegatronArguments(**kwargs, seq_length=1, use_cpu_initialization=True, no_initialization=True)
+    megatron_args = MegatronArguments(**kwargs, seq_length=1, use_cpu_initialization=True, no_initialization=True, torch_dtype=torch.float32)
+    extra_args_provider = megatron_model_meta.extra_args_provider
     patch_megatron_tokenizer(processor)
     extra_args = megatron_args.parse_to_megatron()
-    initialize_megatron(args_defaults=extra_args)
+    initialize_megatron(args_defaults=extra_args, extra_args_provider=extra_args_provider)
     mg_model = megatron_model_meta.model_provider()
     megatron_model_meta.convert_hf2mcore(hf_model, mg_model)
     return hf_model, mg_model, processor


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## CN
我们正在使用swift训练一个具有自定义架构的LLM，现在通过MegatronModelMeta，我们可以使用我们自定义的model_provider，但是还有一部分数据无法通过参数传入provider。为了加入这些参数我们需要同时修改megatron和swift中的argument，因此我们添加了自定义参数的功能。

核心改动如下：
1.  extra_megatron_kwargs：通过在命令行参数中添加这个参数，通过JSON字符串进行传入，该参数会透传到megatron，这样可以直接配置目前swift未覆盖的megatron 参数，例如vpp_size等参数。
2. extra_args_provider：添加在MegatronModelMeta中，可以扩展megatron的arg，参数默认为None，这个参数扩展了megatron的args，这样才能在provider获取到我们添加的额外参数

## ENG
We are training a model with some custom arch modify. With MegatronModelMeta we can use our customized model_provider, but there is still a part of the data that can't be passed into the provider via arguments. in order to add these arguments we need to modify the arguments in megatron and swift at the same time, so we added the ability to customize the arguments.

The core changes are as follows:
1. extra_megatron_kwargs: by adding this parameter to the command line arguments, and passing it through a JSON string, the parameter will be passed through to the megatron, so that we can directly configure the megatron arguments that are not currently covered by swift, such as vpp_size and so on.
2. extra_args_provider: added in MegatronModelMeta, can extend the args of megatron, the default parameter is None, this parameter extends the args of megatron, so that we can get the extra parameters we added in the provider.

Translated with DeepL.com (free version)

示例：

1. 在convert_hf_config中使用extra_megatron_kwargs

![c2976d4a-81a0-49b2-a122-0e5ba0a8f98b](https://github.com/user-attachments/assets/d622f16c-b591-436e-b769-51f05a1c860f)

2. 为megatron添加 args

![image](https://github.com/user-attachments/assets/707507ca-9395-4541-8c6a-0ba6a84cc2cc)

3. 透传现有的megatron参数

```
megatron sft \
    *****其他参数
    --extra-megatron-kwargs "{\"num_layers_per_virtual_pipeline_stage\":2}"
```


## Experiment results

Paste your experiment result here(if needed).
