### PR TITLE
fix n > 1 with vLLM V1 Engine

### DIFF
--- a/swift/llm/infer/infer_engine/vllm_engine.py
+++ b/swift/llm/infer/infer_engine/vllm_engine.py
@@ -307,6 +307,12 @@ class VllmEngine(InferEngine):
         if kwargs.get('seed') is None:
             kwargs['seed'] = get_seed()
         res = SamplingParams(**kwargs)
+
+        if hasattr(res, 'output_kind'):
+            # fix n > 1 in V1 Engine
+            from vllm.sampling_params import RequestOutputKind
+            res.output_kind = RequestOutputKind.FINAL_ONLY
+
         res.top_logprobs = request_config.top_logprobs
         return res
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix the issue where only one choice is returned when using V1 Engine and n > 1

https://github.com/vllm-project/vllm/pull/7381

The same logic can be found in vllm.LLM:
https://github.com/vllm-project/vllm/blob/v0.8.5/vllm/entrypoints/llm.py#L1347-L1350

The response aggregation logic in the VLLM V1 Engine is detailed here:
https://github.com/vllm-project/vllm/blob/v0.8.5/vllm/v1/engine/parallel_sampling.py#L101-L110

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
