### PR TITLE
fix(base.py): 添加音频令牌长度限制以避免编码失败

### DIFF
--- a/swift/llm/template/base.py
+++ b/swift/llm/template/base.py
@@ -285,20 +285,20 @@ class Template(ProcessorMixin):
     def _extend_tokens(input_ids: List[int], labels: Optional[List[int]], replace_idx_list: List[int],
                        get_new_tokens: Callable[[int], List[int]], max_audio_tokens = 2048) -> Tuple[List[int], Optional[List[int]]]:
         added_tokens_len = 0
-        for i, idx in enumerate(replace_idx_list):
-            new_tokens = get_new_tokens(i)
+        sorted_indices = sorted(replace_idx_list)
+        for idx in sorted_indices:
+            new_tokens = get_new_tokens(sorted_indices.index(idx))
             token_len = len(new_tokens)
-            if token_len < max_audio_tokens:
-                input_ids = input_ids[:idx + added_tokens_len] + new_tokens + input_ids[added_tokens_len + idx + 1:]
-                if labels:
-                    labels = labels[:idx + added_tokens_len] + [-100] * token_len + labels[added_tokens_len + idx + 1:]
-                added_tokens_len += token_len - 1
-            else:
-                logger.warning_once(f'Failed to encode audio: `{idx}`, audio length is too long.', hash_id='audio')
-                input_ids = input_ids[:idx + added_tokens_len] + new_tokens[:max_audio_tokens] + input_ids[added_tokens_len + idx + 1:]
-                if labels:
-                    labels = labels[:idx + added_tokens_len] + [-100] * max_audio_tokens + labels[added_tokens_len + idx + 1:]
-                added_tokens_len += max_audio_tokens - 1
+            # 加入长度限制逻辑
+            if token_len > max_audio_tokens:
+                logger.warning_once(f'Truncating audio tokens from {token_len} to {max_audio_tokens}', hash_id='audio_trunc')
+                new_tokens = new_tokens[:max_audio_tokens]
+                token_len = max_audio_tokens
+            adjusted_idx = idx + added_tokens_len
+            input_ids = input_ids[:adjusted_idx] + new_tokens + input_ids[adjusted_idx + 1:]
+            if labels:
+                labels = labels[:adjusted_idx] + [-100] * token_len + labels[adjusted_idx + 1:]
+            added_tokens_len += token_len - 1
         return input_ids, labels
 
     def compute_loss_context(self, model, inputs):


### PR DESCRIPTION
当音频令牌长度超过最大限制时，截取令牌并记录警告日志，防止编码失败。这一修改确保了在处理过长音频令牌时系统的稳定性和可靠性。

# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
