### PR TITLE
Fix vLLM engine returning empty in stream generation

### DIFF
--- a/swift/llm/infer/infer_engine/vllm_engine.py
+++ b/swift/llm/infer/infer_engine/vllm_engine.py
@@ -308,7 +308,7 @@ class VllmEngine(InferEngine):
             kwargs['seed'] = get_seed()
         res = SamplingParams(**kwargs)
 
-        if hasattr(res, 'output_kind'):
+        if hasattr(res, 'output_kind') and res.n > 1:
             # fix n > 1 in V1 Engine
             from vllm.sampling_params import RequestOutputKind
             res.output_kind = RequestOutputKind.FINAL_ONLY


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

PR https://github.com/modelscope/ms-swift/pull/4295 resolves the n>1 issue for the vLLM V1 Engine. However, it inadvertently causes a regression, breaking stream generation and resulting in only empty outputs

## Experiment results

Add `stream=True` in the curl command to check it.
