### PR TITLE
Fix cmdline parsing error on Windows system

### DIFF
--- a/swift/ui/llm_train/runtime.py
+++ b/swift/ui/llm_train/runtime.py
@@ -429,7 +429,7 @@ class Runtime(BaseUI):
     def refresh_tasks(running_task=None):
         output_dir = running_task if not running_task or 'pid:' not in running_task else None
         process_name = 'swift'
-        negative_name = 'swift.exe'
+        negative_names = ['swift.exe', 'swift-script.py']
         cmd_name = ['pt', 'sft', 'rlhf']
         process = []
         selected = None
@@ -438,10 +438,12 @@ class Runtime(BaseUI):
                 cmdlines = proc.cmdline()
             except (psutil.ZombieProcess, psutil.AccessDenied, psutil.NoSuchProcess):
                 cmdlines = []
-            if any([process_name in cmdline
-                    for cmdline in cmdlines]) and not any([negative_name in cmdline
-                                                           for cmdline in cmdlines]) and any(  # noqa
-                                                               [cmdline in cmd_name for cmdline in cmdlines]):  # noqa
+            if any([
+                    process_name in cmdline for cmdline in cmdlines  # noqa
+            ]) and not any([  # noqa
+                    negative_name in cmdline for negative_name in negative_names  # noqa
+                    for cmdline in cmdlines  # noqa
+            ]) and any([cmdline in cmd_name for cmdline in cmdlines]):  # noqa
                 process.append(Runtime.construct_running_task(proc))
                 if output_dir is not None and any(  # noqa
                     [output_dir == cmdline for cmdline in cmdlines]):  # noqa


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

Fix #4403,  cmdline parsing error on Windows system. 

## Experiment results

Paste your experiment result here(if needed).
