### PR TITLE
[grpo]  support move_model_batches for external mode

### DIFF
--- a/docs/source/Instruction/GRPO.md
+++ b/docs/source/Instruction/GRPO.md
@@ -221,7 +221,7 @@ A conversation between User and Assistant. The user asks a question, and the Ass
   - vllm_limit_mm_per_prompt: vllm透传参数，默认为None.
   - vllm_enable_prefix_caching: vllm透传参数，默认为True.
   - sleep_level: 训练时释放 vLLM 显存，可选项为[0, 1], 默认为0，不释放.
-  - move_model_batches: 在模型向vLLM等快速推理框架移动参数时，将layers分为多少个batch. 默认为None, 代表整个模型不进行拆分，否则拆分为move_model_batches+1(非layer参数)+1(多模态部分参数)个。
+  - move_model_batches: 在模型向vLLM等快速推理框架移动参数时，将layers分为多少个batch. 默认为None, 代表整个模型不进行拆分，否则拆分为move_model_batches+1(非layer参数)+1(多模态部分参数)个。注意：该参数仅对LoRA(PEFT)训练有意义。
   - offload_optimizer: 是否在vLLM推理时offload optimizer参数，默认为False。
   - offload_model: 是否在vLLM推理时offload 模型本身，默认为False。
   - gc_collect_after_offload: 是否在offload结束时进行gc（python gc和GPU gc），默认为False。

--- a/docs/source/Instruction/命令行参数.md
+++ b/docs/source/Instruction/命令行参数.md
@@ -442,7 +442,7 @@ reward模型参数将在PPO、GRPO中使用。
   - vllm_limit_mm_per_prompt: vllm透传参数，默认为None。
   - vllm_enable_prefix_caching: vllm透传参数，默认为True。
   - sleep_level: 训练时释放 vLLM 显存，可选项为[0, 1], 默认为0，不释放
-  - move_model_batches: 在模型向vLLM等快速推理框架移动参数时，将layers分为多少个batch. 默认为None, 代表整个模型不进行拆分，否则拆分为move_model_batches+1(非layer参数)+1(多模态部分参数)个。
+  - move_model_batches: 在模型向vLLM等快速推理框架移动参数时，将layers分为多少个batch. 默认为None, 代表整个模型不进行拆分，否则拆分为move_model_batches+1(非layer参数)+1(多模态部分参数)个。注意：该参数仅对LoRA(PEFT)训练有意义。
   - offload_optimizer: 是否在vLLM推理时offload optimizer参数，默认为False。
   - offload_model: 是否在vLLM推理时offload 模型本身，默认为False。
   - gc_collect_after_offload: 是否在offload结束时进行gc（python gc和GPU gc），默认为False。

--- a/docs/source_en/Instruction/Command-line-parameters.md
+++ b/docs/source_en/Instruction/Command-line-parameters.md
@@ -454,7 +454,7 @@ The meanings of the following parameters can be referenced [here](https://huggin
   - vllm_limit_mm_per_prompt: vLLM passthrough parameter, default is None.
   - vllm_tensor_parallel_size: the tensor parallel size of vLLM engine, default is 1.
   - sleep_level: make vllm sleep when model is training. Options are 0 or 1, default is 0, no sleep
-  - move_model_batches: When moving model parameters to fast inference frameworks such as vLLM/LMDeploy, determines how many batches to divide the layers into. The default is `None`, which means the entire model is not split. Otherwise, the model is split into `move_model_batches + 1` (non-layer parameters) + `1` (multi-modal component parameters) batches.
+  - move_model_batches: When moving model parameters to fast inference frameworks such as vLLM/LMDeploy, determines how many batches to divide the layers into. The default is `None`, which means the entire model is not split. Otherwise, the model is split into `move_model_batches + 1` (non-layer parameters) + `1` (multi-modal component parameters) batches. This parameter is only meaningful for LoRA (PEFT).
   - offload_optimizer: Whether to offload optimizer parameters during inference with vLLM/LMDeploy. The default is `False`.
   - offload_model: Whether to offload the model itself during inference with vLLM/LMDeploy. The default is `False`.
   - gc_collect_after_offload: Whether to perform garbage collection (both Python GC and GPU GC) after offloading. The default is `False`.

--- a/docs/source_en/Instruction/GRPO.md
+++ b/docs/source_en/Instruction/GRPO.md
@@ -231,7 +231,7 @@ Arguments
   - vllm_limit_mm_per_prompt: vLLM passthrough parameter, default is None.
   - vllm_tensor_parallel_size: the tensor parallel size of vLLM engine, default is 1.
   - sleep_level: make vllm sleep when model is training. Options are 0 or 1, default is 0, no sleep
-  - move_model_batches: When moving model parameters to fast inference frameworks such as vLLM, determines how many batches to divide the layers into. The default is `None`, which means the entire model is not split. Otherwise, the model is split into `move_model_batches + 1` (non-layer parameters) + `1` (multi-modal component parameters) batches.
+  - move_model_batches: When moving model parameters to fast inference frameworks such as vLLM, determines how many batches to divide the layers into. The default is `None`, which means the entire model is not split. Otherwise, the model is split into `move_model_batches + 1` (non-layer parameters) + `1` (multi-modal component parameters) batches. This parameter is only meaningful for LoRA (PEFT).
   - offload_optimizer: Whether to offload optimizer parameters during inference with vLLM. The default is `False`.
   - offload_model: Whether to offload the model itself during inference with vLLM. The default is `False`.
   - gc_collect_after_offload: Whether to perform garbage collection (both Python GC and GPU GC) after offloading. The default is `False`.

--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -473,27 +473,31 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
         if is_peft_model(self.model):
             for i, parameter_group in enumerate(self.parameter_groups):  # < this is the change
                 parameter_group_no_lora = self.parameter_groups_no_lora[i]
-                if parameter_group_no_lora:
-                    parameter_group_no_lora = [n.replace('base_model.model.', '') for n in parameter_group_no_lora]
                 with gather_if_zero3(list(parameter_group)), patch_lora_merge(self.model, parameter_group):
                     self.model.merge_adapter()
+                    state_dict = self.model.state_dict()
+                    state_dict = {
+                        k.removeprefix('base_model.model.').replace('.base_layer', ''): v
+                        for k, v in state_dict.items()
+                    }
+                    state_dict = {k: v for k, v in state_dict.items() if self.model.prefix not in k}
+                    # When module to save, remove its prefix and discard the original module
+                    state_dict = {
+                        k.replace('modules_to_save.default.', ''): v
+                        for k, v in state_dict.items() if 'original_module' not in k
+                    }
+                    if parameter_group_no_lora:
+                        parameter_group_no_lora = [n.replace('base_model.model.', '') for n in parameter_group_no_lora]
+                        state_dict = {k: v for k, v in state_dict.items() if k in parameter_group_no_lora}
+                    assert len(state_dict) > 0 and all(
+                        [state.shape != torch.Size([0]) for state in state_dict.values()])
 
-                for name, param in parameter_group:
-                    name = name.removeprefix('base_model.model.').replace('.base_layer', '')
-
-                    # skip lora weights with prefix(example: "_lora")
-                    if self.model.prefix in name:
-                        continue
-                    if 'original_module' in name:
-                        continue
-                    name = name.replace('modules_to_save.default.', '')
-                    if parameter_group_no_lora and name not in parameter_group_no_lora:
-                        continue
-                    if self.vllm_mode == 'server' and self.accelerator.is_main_process:
-                        self.vllm_client.update_named_param(name, param.data)
-                    elif self.vllm_mode == 'colocate':
-                        llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
-                        llm_model.load_weights([(name, param.data)])
+                    for name, param in state_dict:
+                        if self.vllm_mode == 'server' and self.accelerator.is_main_process:
+                            self.vllm_client.update_named_param(name, param.data)
+                        elif self.vllm_mode == 'colocate':
+                            llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                            llm_model.load_weights([(name, param.data)])
 
                 with patch_lora_unmerge(self.model):
                     self.model.unmerge_adapter()

--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -7,7 +7,7 @@ import re
 import time
 from collections import defaultdict, deque
 from concurrent.futures import Future
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from copy import copy, deepcopy
 from dataclasses import asdict, dataclass, field
 from functools import partial
@@ -222,7 +222,8 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
         # transformers if num_generations exceeds per_device_train_batch_size. We could skip it if we use vLLM, but
         # it's safer to set it in all cases.
         set_seed(args.seed, device_specific=True)
-        self.parameter_groups, self.parameter_groups_no_lora = self.split_batches()
+        if is_peft_model(self.model):
+            self.parameter_groups, self.parameter_groups_no_lora = self.split_batches()
         self.use_fast_infer = self.use_vllm  # whether to use the PT backend
         if self.use_vllm:
             if not is_vllm_available():
@@ -457,60 +458,44 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
 
     @profiling_decorator
     def _move_model_to_vllm(self):
-        if self.vllm_mode == 'server':
-            return super()._move_model_to_vllm()
+        deepspeed_plugin = self.accelerator.state.deepspeed_plugin
+        zero_stage_3 = deepspeed_plugin is not None and deepspeed_plugin.zero_stage == 3
+        if zero_stage_3:
+            import deepspeed
+            gather_if_zero3 = deepspeed.zero.GatheredParameters
+        else:
+            gather_if_zero3 = nullcontext
+        if is_peft_model(self.model):
+            if self.args.async_generate:
+                # before sync weight, we should wait async generate finish
+                self._wait_queue()
+            for parameter_group in self.parameter_groups:  # < this is the change
+                with gather_if_zero3(list(parameter_group)), patch_lora_merge(self.model, parameter_group):
+                    self.model.merge_adapter()
+                for name, param in parameter_group:
+                    name = name.removeprefix('base_model.model.').replace('.base_layer', '')
+                    if self.model.prefix in name:
+                        continue
+                    if 'original_module' in name:
+                        continue
+                    name = name.replace('modules_to_save.default.', '')
+                    if self.vllm_mode == 'server' and self.accelerator.is_main_process:
+                        self.vllm_client.update_named_param(name, param.data)
+                    elif self.vllm_mode == 'colocate':
+                        llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                        llm_model.load_weights([(name, param.data)])
+        else:
+            for name, param in self.model.named_parameters():
+                with gather_if_zero3([param]):
+                    if self.vllm_mode == 'server' and self.accelerator.is_main_process:
+                        self.vllm_client.update_named_param(name, param.data)
+                    elif self.vllm_mode == 'colocate':
+                        llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                        llm_model.load_weights([(name, param.data)])
 
-        from accelerate.utils.other import is_compiled_module
-
-        for i, parameter_group in enumerate(self.parameter_groups):
-            parameter_group_no_lora = self.parameter_groups_no_lora[i]
-            with unwrap_model_for_generation(
-                    self.model,
-                    self.accelerator,
-                    gather_deepspeed3_params=self.args.ds3_gather_for_generation,
-                    gather_parameters=parameter_group) as unwrapped_model:
-
-                if is_compiled_module(unwrapped_model):
-                    unwrapped_model = unwrapped_model._orig_mod
-                if is_peft_model(unwrapped_model):
-                    with patch_lora_merge(unwrapped_model, parameter_group):
-                        unwrapped_model.merge_adapter()
-                    state_dict = unwrapped_model.state_dict()
-                    # Remove base_model and base_layer prefixes
-                    state_dict = {
-                        k.removeprefix('base_model.model.').replace('.base_layer', ''): v
-                        for k, v in state_dict.items()
-                    }
-                    # Remove values with adapter prefix (example: "_lora")
-                    state_dict = {k: v for k, v in state_dict.items() if unwrapped_model.prefix not in k}
-                    # When module to save, remove its prefix and discard the original module
-                    state_dict = {
-                        k.replace('modules_to_save.default.', ''): v
-                        for k, v in state_dict.items() if 'original_module' not in k
-                    }
-                else:
-                    state_dict = unwrapped_model.state_dict()
-                if parameter_group_no_lora:
-                    parameter_group_no_lora = [n.replace('base_model.model.', '') for n in parameter_group_no_lora]
-                    state_dict = {k: v for k, v in state_dict.items() if k in parameter_group_no_lora}
-                assert len(state_dict) > 0 and all([state.shape != torch.Size([0]) for state in state_dict.values()])
-                if self.use_fast_infer:
-                    if self.args.async_generate:
-                        # before sync weight, we should wait async generate finish
-                        self._wait_queue()
-                    if self.use_vllm:
-                        llm_model = self.engine.inner_model
-                    else:
-                        llm_model = self.engine.engine.engine
-                    llm_model.load_weights(state_dict.items())
-                    del state_dict
-                    gc_collect()
-                # Unmerge the adapter to restore the model to its original state.
-                # This must be done after loading weights to ensure they correspond to the merged state.
-                if is_peft_model(unwrapped_model):
-                    with patch_lora_unmerge(unwrapped_model):
-                        unwrapped_model.unmerge_adapter()
-        if self.use_vllm and self.vllm_mode == 'colocate':
+        if self.vllm_mode == 'server' and self.accelerator.is_main_process:
+            self.vllm_client.reset_prefix_cache()
+        elif self.vllm_mode == 'colocate':
             # since vLLM model weights has been updated, we should reset the prefix cache
             self.engine.engine.reset_prefix_cache()
 

--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -500,8 +500,8 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
                             llm_model = self.engine.inner_model
                             llm_model.load_weights([(name, param)])
 
-                with patch_lora_unmerge(self.model):
-                    self.model.unmerge_adapter()
+                    with patch_lora_unmerge(self.model):
+                        self.model.unmerge_adapter()
         else:
             for name, param in self.model.named_parameters():
                 with gather_if_zero3([param]):

--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -497,7 +497,7 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
                         if self.vllm_mode == 'server' and self.accelerator.is_main_process:
                             self.vllm_client.update_named_param(name, param)
                         elif self.vllm_mode == 'colocate':
-                            llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                            llm_model = self.engine.inner_model
                             llm_model.load_weights([(name, param)])
 
                 with patch_lora_unmerge(self.model):
@@ -508,7 +508,7 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
                     if self.vllm_mode == 'server' and self.accelerator.is_main_process:
                         self.vllm_client.update_named_param(name, param.data)
                     elif self.vllm_mode == 'colocate':
-                        llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+                        llm_model = self.engine.inner_model
                         llm_model.load_weights([(name, param.data)])
 
         if self.vllm_mode == 'server' and self.accelerator.is_main_process:

--- a/swift/trainers/rlhf_trainer/utils.py
+++ b/swift/trainers/rlhf_trainer/utils.py
@@ -98,11 +98,6 @@ def patch_lora_merge(model, parameter_group=None):
 
 @contextmanager
 def patch_lora_unmerge(model):
-    """Patch the unmerge method to ensure proper device handling."""
-
-    def _cache_pop_patched(self, key: str) -> Any:
-        value = self._caches.pop(key).to(self.base_layer.weight.device)
-        return value
 
     def unmerge_patched(self):
         if not self.merged:
@@ -119,8 +114,6 @@ def patch_lora_unmerge(model):
         if isinstance(module, LoraLayer) and not hasattr(module, 'unmerge_origin'):
             module.unmerge_origin = module.unmerge
             module.unmerge = MethodType(unmerge_patched, module)
-            module._cache_pop_origin = module._cache_pop
-            module._cache_pop = MethodType(_cache_pop_patched, module)
 
     try:
         yield model
@@ -129,8 +122,6 @@ def patch_lora_unmerge(model):
             if isinstance(module, LoraLayer) and hasattr(module, 'unmerge_origin'):
                 module.unmerge = module.unmerge_origin
                 del module.unmerge_origin
-                module._cache_pop = module._cache_pop_origin
-                del module._cache_pop_origin
 
 
 @contextmanager


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR adds support for the move_model_batches parameter in external mode, allowing for batch-wise gathering of Zero3 model synchronization weights during LoRA training to reduce peak GPU memory usage.

## Experiment results

Paste your experiment result here(if needed).
