### PR TITLE
fix: handle INFONCE_HARD_NEGATIVES as integer if provided

### DIFF
--- a/swift/plugin/loss.py
+++ b/swift/plugin/loss.py
@@ -174,6 +174,8 @@ def calculate_infonce_metrics(embeddings, labels):
     from scipy.stats import pearsonr, spearmanr
     hard_negatives = os.environ.get('INFONCE_HARD_NEGATIVES', None)
     use_batch = strtobool(os.environ.get('INFONCE_USE_BATCH', 'True'))
+    if hard_negatives is not None:
+        hard_negatives = int(hard_negatives)
     split_tensors = _parse_multi_negative_sentences(torch.tensor(embeddings), torch.tensor(labels), hard_negatives)
     split_tensors = [t.numpy() for t in split_tensors]
     can_batched = hard_negatives is not None


### PR DESCRIPTION
# PR type  
- [x] Bug Fix  
- [ ] New Feature  
- [ ] Document Updates  
- [ ] More Models or Datasets Support  

---

##  PR information

在训练 GME Embedding 时，有可能需要在环境变量中提供 `INFONCE_HARD_NEGATIVES`。原本的代码遗漏了将其转换为 `int` 类型。

In the training of GME Embedding, it may be necessary to provide `INFONCE_HARD_NEGATIVES` via environment variables. The original code missed converting this value to an integer.

---

## Experiment results

如果没有这段修改，在 validation 完成后计算 metrics 时将会报错：

If this modification is not included, an error will occur when computing metrics after validation:

```
[rank0]:     output = eval_loop(
[rank0]:   File "/home/tuozhi.wy/.conda/envs/gme/lib/python3.10/site-packages/transformers/trainer.py", line 4463, in evaluation_loop
[rank0]:     metrics = self.compute_metrics(
[rank0]:   File "/home/tuozhi.wy/.conda/envs/gme/lib/python3.10/site-packages/swift/trainers/trainers.py", line 75, in calculate_metric
[rank0]:     return calculate_infonce_metrics(eval_prediction.predictions, eval_prediction.label_ids)
[rank0]:   File "/home/tuozhi.wy/.conda/envs/gme/lib/python3.10/site-packages/swift/plugin/loss.py", line 173, in calculate_infonce_metrics
[rank0]:     split_tensors = _parse_multi_negative_sentences(torch.tensor(embeddings), torch.tensor(labels), hard_negatives)
[rank0]:   File "/home/tuozhi.wy/.conda/envs/gme/lib/python3.10/site-packages/swift/plugin/loss.py", line 255, in _parse_multi_negative_sentences
[rank0]:     if negatives > hard_negatives:
[rank0]: TypeError: '>' not supported between instances of 'int' and 'str'
```