### PR TITLE
fix: add SO_REUSEADDR to find_free_port to handle TIME_WAIT state

### DIFF
--- a/swift/utils/utils.py
+++ b/swift/utils/utils.py
@@ -241,6 +241,7 @@ def find_free_port(start_port: Optional[int] = None, retry: int = 100) -> int:
         start_port = 0
     for port in range(start_port, start_port + retry):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
                 sock.bind(('', port))
                 port = sock.getsockname()[1]


### PR DESCRIPTION
# PR type
- [X] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
The `find_free_port()` function exhibits inconsistent behavior when trying to bind to recently used ports. Specifically:

- After killing a `swift deploy --port 8001` process on port 8001, `find_free_port(8001)` sometimes returns 8002 (I actually believe it would be better to throw an exception if a port was explicitly specified)
- Re-running the same function immediately after may then return 8001

When a process using a TCP port is terminated, the port enters TCP's TIME_WAIT state for 30-120 seconds (OS-dependent). During this period, `socket.bind()` fails even though the port is effectively available. Adding `SO_REUSEADDR` socket option to allow binding to ports in TIME_WAIT state. In fact, this is what has been done within `uvicorn` as well before launching the server: https://github.com/encode/uvicorn/blob/5e33d430f13622c8363fe74d97963ab37f3df3c2/uvicorn/config.py#L513
