### PR TITLE
[loss_scale] support last_round_with_ignore_empty_think for rag

### DIFF
--- a/swift/plugin/loss_scale/loss_scale.py
+++ b/swift/plugin/loss_scale/loss_scale.py
@@ -141,7 +141,6 @@ class LastRoundWithIgnoreEmptyThink(LossScale):
                        is_last_round: bool,
                        *,
                        query: Optional[str] = None):
-        
         if context_type == ContextType.RESPONSE:
             if not is_last_round:
                 return [context], [float(is_last_round)]

--- a/swift/plugin/loss_scale/loss_scale.py
+++ b/swift/plugin/loss_scale/loss_scale.py
@@ -132,12 +132,32 @@ class IgnoreEmptyThink(REACTLossScale):
     loss_scale_config = 'ignore_empty_think.json'
 
 
+class LastRoundWithIgnoreEmptyThink(LossScale):
+    loss_scale_config = 'ignore_empty_think.json'
+
+    def get_loss_scale(self,
+                       context: str,
+                       context_type: ContextType,
+                       is_last_round: bool,
+                       *,
+                       query: Optional[str] = None):
+        
+        if context_type == ContextType.RESPONSE:
+            if not is_last_round:
+                return [context], [float(is_last_round)]
+            else:
+                return calculate_loss_scale(query, context, self.loss_scale_map)
+
+        return super().get_loss_scale(context, context_type, is_last_round)
+
+
 # Add your loss scale here, use --loss_scale xxx to train
 loss_scale_map = {
     'last_round': LastRoundLossScale,
     'default': LossScale,
     'all': TrainAllLossScale,
     'ignore_empty_think': IgnoreEmptyThink,
+    'last_round_with_ignore_empty_think': LastRoundWithIgnoreEmptyThink,
     # agent
     'react': REACTLossScale,
     'hermes': HermesLossScale,


### PR DESCRIPTION
extend loss_scale to support last_round_with_ignore_empty_think for rag trainning

# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
