### PR TITLE
solve the default 'template_backend' bug in llm.tempalte.base.Templte._encode

### DIFF
--- a/swift/llm/template/base.py
+++ b/swift/llm/template/base.py
@@ -1114,7 +1114,7 @@ class Template(ProcessorMixin):
 
     def _encode(self, inputs: StdTemplateInputs) -> Dict[str, Any]:
         template_backend = self.template_backend
-        if (self.template_meta.template_type == 'dummy' and self.use_chat_template and not self.is_training
+        if (self.template_meta.template_type != 'dummy' and self.use_chat_template and not self.is_training
                 and self.mode != 'seq_cls'):
             template_backend = 'jinja'
             logger.info_once(f'Setting template_backend: {template_backend}')


### PR DESCRIPTION
solve the template_backend bug: the correct default should be jinja rather than swift

# PR type
- [✅] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
The default template_backend in llm.tempalte.base.Templte._encode should be jinja rather than swift, however, becuase the self.template_meta.template_type in a specific Template class are derived from MLLMTemplateType or LLMTemplateType, which is a specific type(e.g, ovis2) rather than 'dummy', the template_backend is always 'swift'.

## Experiment results

Paste your experiment result here(if needed).
the prompt in vllm when inferring ovis: 
<img width="782" alt="企业微信截图_17506653559250" src="https://github.com/user-attachments/assets/40da54f3-ce17-4fa0-a35b-d53722e2d3bc" />

the prompt in swift:
<img width="782" alt="企业微信截图_17506654012609" src="https://github.com/user-attachments/assets/22daecc9-ef87-475f-aebb-59e14075772e" />
