### PR TITLE
Update bos_token

### DIFF
--- a/swift/llm/template/base.py
+++ b/swift/llm/template/base.py
@@ -1039,8 +1039,16 @@ class Template(ProcessorMixin):
             idx = all_tokens.index(single_token[0])
             bos_token = all_tokens[:idx]
             sep_token = all_tokens[idx + 1:]
+            """
+            1. qwen model tokenizer.encode function parameter add_special_tokens=True/False，both of then not output special token, forexample <|im_start|>, this special token will be added when process system/user/assistant message ,so should judge if bos_token is none/empty or not  
+            2. if bos_token is not none, means that current model should add specal token, old code has two errors:
+            	2.1 besides using bos_token = all_tokens[:idx],will get list as a element for res_context_list, but when execute code `prompts_text.append(''.join(res_context_list))`, will raise expcept
+            	2.2 element of res_context_list should be text（not token id）, bos_token = all_tokens[:idx] will get token_id list, this will error when execute tokenizer.encode()(encode token_id) 
+            	so we use self.tokenizer.bos_token is the most reasonable and correct
+            """
             if bos_token:
-                res_context_list.append(bos_token)
+                # res_context_list.append(bos_token)
+                res_context_list.append(self.tokenizer.bos_token)
                 res_context_types.append(ContextType.OTHER)
 
         if self.template_meta.is_post_system or not system:


### PR DESCRIPTION
# PR type
- [] Bug Fix, [issue](https://github.com/modelscope/ms-swift/issues/4785)

<img width="1305" alt="Clipboard_Screenshot_1751457316" src="https://github.com/user-attachments/assets/2fd3b1d7-ec1c-4343-aa8f-0012e82b2e65" />

# PR information
1. qwen模型的encode 不管add_special_tokens=True/False，都不会输出special token,如 <|im_start|>, qwen模型这些特殊的token会在拼接的时候补上，无需额外处理
                所以需要判断bos_token是否为空
            2. 若bos_token不为空，则表示需要加specal token，bos_token = all_tokens[:idx]得到的是列表，在执行`prompts_text.append(''.join(res_context_list))`时 
                会因为res_context_list[0]的类型是list而报错，并且这里的bos_token是token_id而不是token，在encode时也会出错，所以采用self.tokenizer.bos_token更为合适

