### PR TITLE
[grpo]Fix bug when repeatedly call inputs_to_rolloutrequest

### DIFF
--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -1605,24 +1605,14 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
                     raise ValueError('data_dict exists but is not a dictionary')
 
             # Collect all non-request_keys items as extra fields
-            extra_data = {
-                k: request[k]
-                for k in request
-                if k not in request_keys and k != 'data_dict'
-            }
+            extra_data = {k: request[k] for k in request if k not in request_keys and k != 'data_dict'}
 
             # Merge the data_dict, keeping keys from base_data_dict as priority
             final_data_dict = {**extra_data, **base_data_dict}
 
             # Create RolloutInferRequest instance
-            req_args = {
-                k: request[k]
-                for k in request_keys
-                if k in request
-            }
-            infer_requests.append(
-                RolloutInferRequest(**req_args, data_dict=final_data_dict)
-            )
+            req_args = {k: request[k] for k in request_keys if k in request}
+            infer_requests.append(RolloutInferRequest(**req_args, data_dict=final_data_dict))
 
         return infer_requests
 


### PR DESCRIPTION
Here's the translated version of your PR description and test cases:

### Fixed Repeated Calls to `inputs_to_rolloutrequest` Leading to Nested `data_dict`

# PR Type
- [✅] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR Information

During GRPO training with multi-turn sessions, the step method of MultiTurnScheduler returns a RolloutInferRequest containing a data_dict. However, this RolloutInferRequest is passed through the inputs_to_rolloutrequest function before the next request, which treats data_dict as a regular key and merges it into the new data_dict. This results in:
```
RolloutInferRequest.data_dict={"data_dict":{"key1":"value1","key2":"value2"}}
```
instead of the expected:
```
RolloutInferRequest.data_dict={"key1":"value1","key2":"value2"}
```
This issue worsens with each turn, making it difficult to access data_dict in the step method of MultiTurnScheduler subclasses.

Changes implemented:
1. If the input contains data_dict as a dictionary, preserve its content as the new data_dict
2. Add other regular keys (not in ['messages', 'images', 'audios', 'videos', 'tools', 'objects']) to the new data_dict. In case of key conflicts, data_dict content takes precedence
3. If input contains data_dict but it's not a dictionary, raise an error: "data_dict exists but is not a dictionary"

This ensures:
- Compatibility with original GRPO dataset reading processes
- Prevention of nested data_dict in multi-turn conversations
- Stable data_dict access in MultiTurnScheduler subclasses

## Experiment Results

Paste your experiment result here (if needed).

new function pass the test cases below:

```python
def test_inputs_to_rolloutrequest_nested():
    """Test nested data_dict scenarios"""
    # First call
    inputs = [
        {
            'messages': [{
                'role': 'system',
                'content': 'you are a helpful assistant.',
            }],
            'extra_key': 'extra_value',
            'another_key': 'another_value'
        }
    ]
    res1 = inputs_to_rolloutrequest(inputs)
    assert res1[0].data_dict == {'extra_key': 'extra_value', 'another_key': 'another_value'}
    
    # Use serialized result as input for second call
    res1_printable = [res1[0].to_printable()]
    res2 = inputs_to_rolloutrequest(res1_printable)
    # Verify nested data_dict issue is resolved
    assert res2[0].data_dict == {'extra_key': 'extra_value', 'another_key': 'another_value'}
    
    # Test key priority in data_dict
    inputs_with_conflict = [
        {
            'messages': [{
                'role': 'user',
                'content': 'hello',
            }],
            'data_dict': {'key1': 'value_from_data_dict', 'unique_key': 'unique_value'},
            'key1': 'value_outside',
            'key2': 'another_value'
        }
    ]
    res3 = inputs_to_rolloutrequest(inputs_with_conflict)
    # data_dict values should take priority
    assert res3[0].data_dict['key1'] == 'value_from_data_dict'
    assert res3[0].data_dict['unique_key'] == 'unique_value'
    assert res3[0].data_dict['key2'] == 'another_value']


def test_inputs_to_rolloutrequest_non_dict_datadict():
    """Test handling when 'data_dict' exists but isn't a dictionary"""
    # Test when data_dict is a string
    inputs_with_string_datadict = [
        {
            'messages': [{
                'role': 'user',
                'content': 'hello',
            }],
            'data_dict': 'this_is_not_a_dict',
            'normal_key': 'normal_value'
        }
    ]
    with pytest.raises(ValueError):
        inputs_to_rolloutrequest(inputs_with_string_datadict)
```