### PR TITLE
[grpo] fix apply_chat_template

### DIFF
--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -1094,7 +1094,8 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
             InferRequest.remove_response(messages)
             template_inputs, _ = StdTemplateInputs.from_dict({'messages': messages})
             res_context_list, _, _ = self.template._swift_encode(template_inputs)
-            prompts_text.append(''.join(res_context_list))
+            prompts_text.append(''.join(elem for elem in res_context_list if isinstance(elem, str)))
+
         return prompts_text
 
     @profiling_decorator


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
Fix a bug where res_context_list returned by _swift_encode contains an int (such as bos_token), which causes a string join error.


## Experiment results

Paste your experiment result here(if needed).
