### PR TITLE
feat: Add video support for GLM-4.1V models

### DIFF
--- a/swift/llm/template/template/glm.py
+++ b/swift/llm/template/template/glm.py
@@ -121,7 +121,7 @@ class GLM4_1VTemplate(Template):
     def replace_tag(self, media_type: Literal['image', 'video', 'audio'], index: int,
                     inputs: StdTemplateInputs) -> List[Context]:
         # TODO: model video infer bug
-        assert media_type in ['image']
+        assert media_type in ['image', 'video']
         if media_type == 'image':
             return [[-100]]
         elif media_type == 'video':


### PR DESCRIPTION
- Modified GLM template to accept 'video' and 'videos' media types
- GLM-4.1V models support video input but template was restricting to images only
- Fixes AssertionError when using video datasets with GLM-4.1V models

# PR type
- [X] Bug Fix
- [X] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
