### PR TITLE
Fix FlorenceTemplate for florence2

### DIFF
--- a/swift/llm/template/template/microsoft.py
+++ b/swift/llm/template/template/microsoft.py
@@ -68,8 +68,9 @@ class FlorenceTemplate(Template):
         image_size = None
         if images:
             image_size = (images[0].width, images[0].height)
+        task = "<"+template_inputs.query.split('<')[1].split('>')[0]+">"
         return json.dumps(
-            self.processor.post_process_generation(response, task=template_inputs.query, image_size=image_size))
+            self.processor.post_process_generation(response, task=task, image_size=image_size))
 
 
 register_template(


### PR DESCRIPTION
Remove description when using task_prompts_with_input mode to get correct task.

```Python
self.task_prompts_with_input = {
            '<CAPTION_TO_PHRASE_GROUNDING>': "Locate the phrases in the caption: {input}",
            '<REFERRING_EXPRESSION_SEGMENTATION>': 'Locate {input} in the image with mask',
            '<REGION_TO_SEGMENTATION>': 'What is the polygon mask of region {input}',
            '<OPEN_VOCABULARY_DETECTION>': 'Locate {input} in the image.',
            '<REGION_TO_CATEGORY>': 'What is the region {input}?',
            '<REGION_TO_DESCRIPTION>': 'What does the region {input} describe?',
            '<REGION_TO_OCR>': 'What text is in the region {input}?',
        }
```
When using the mode in task_prompts_with_input, such as <OPEN_VOCABULARY_DETECTION>, the input should be like `'<OPEN_VOCABULARY_DETECTION>animals'`.  And in  `post_process_generation`, it should be `<OPEN_VOCABULARY_DETECTION>`. 

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
