### PR TITLE
[Feature] Add Swanlab Slack notification

### DIFF
--- a/docs/source/Instruction/命令行参数.md
+++ b/docs/source/Instruction/命令行参数.md
@@ -516,8 +516,10 @@ soft overlong 奖励参数
 - swanlab_project: swanlab的project，需要在页面中预先创建好:[https://swanlab.cn/space/~](https://swanlab.cn/space/~)。
 - swanlab_workspace: 默认为None，会使用api-key对应的username。
 - swanlab_exp_name: 实验名，可以为空，为空时默认传入--output_dir的值。
+- swanlab_notification_methods: 推送方式。可以为空，可以为多个值，可选值为`['slack', 'lark']`。
 - swanlab_lark_webhook_url: 默认为None。swanlab的lark webhook url，用于推送实验结果到飞书。
 - swanlab_lark_secret: 默认为None。swanlab的lark secret，用于推送实验结果到飞书。
+- swanlab_slack_webhook_url: 默认为None。swanlab的slack webhook url，用于推送实验结果到slack。
 - swanlab_mode: 可选cloud和local，云模式或者本地模式。
 
 ### 推理参数

--- a/docs/source_en/Instruction/Command-line-parameters.md
+++ b/docs/source_en/Instruction/Command-line-parameters.md
@@ -536,8 +536,10 @@ Soft overlong reward parameters:
 - **swanlab_project**: SwanLab's project, which needs to be created in advance on the page: [https://swanlab.cn/space/~](https://swanlab.cn/space/~)
 - **swanlab_workspace**: Defaults to `None`, will use the username associated with the API key
 - **swanlab_exp_name**: Experiment name, can be left empty. If empty, the value of `--output_dir` will be used by default
+- swanlab_notification_methods: Ways to send notifications by SwanLab, can be left empty or multiple values from `slack` or `lark`.
 - swanlab_lark_webhook_url: Defaults to None. SwanLab's Lark webhook URL, used for pushing experiment results to Lark.
 - swanlab_lark_secret: Defaults to None. SwanLab's Lark secret, used for pushing experiment results to Lark.
+- swanlab_slack_webhook_url: Defaults to None. SwanLab's Slack webhook URL, used for pushing experiment results to Slack.
 - **swanlab_mode**: Optional values are `cloud` and `local`, representing cloud mode or local mode
 
 

--- a/swift/ui/llm_train/report_to.py
+++ b/swift/ui/llm_train/report_to.py
@@ -47,6 +47,12 @@ class ReportTo(BaseUI):
                 'en': 'Experiment of SwanLab'
             },
         },
+        'swanlab_notification_methods': {
+            'label': {
+                'zh': 'SwanLab通知方式',
+                'en': 'Notification methods of SwanLab'
+            },
+        },
         'swanlab_lark_webhook_url': {
             'label': {
                 'zh': 'SwanLab飞书Webhook地址',
@@ -57,6 +63,12 @@ class ReportTo(BaseUI):
             'label': {
                 'zh': 'SwanLab飞书Secret',
                 'en': 'Secret of SwanLab Lark Callback'
+            },
+        },
+        'swanlab_slack_webhook_url': {
+            'label': {
+                'zh': 'SwanLab Slack Webhook地址',
+                'en': 'Webhook URL of SwanLab Slack Callback'
             },
         },
         'swanlab_mode': {
@@ -81,9 +93,20 @@ class ReportTo(BaseUI):
                         scale=20)
                     gr.Textbox(elem_id='swanlab_token', lines=1, scale=20)
                     gr.Textbox(elem_id='swanlab_project', lines=1, scale=20)
+
+                with gr.Row():
+                    gr.Dropdown(
+                        elem_id='swanlab_notification_methods',
+                        multiselect=True,
+                        is_list=True,
+                        choices=['lark', 'slack'],
+                        allow_custom_value=True,
+                        scale=20)
                 with gr.Row():
                     gr.Textbox(elem_id='swanlab_lark_webhook_url', lines=1, scale=20)
                     gr.Textbox(elem_id='swanlab_lark_secret', lines=1, scale=20)
+                with gr.Row():
+                    gr.Textbox(elem_id='swanlab_slack_webhook_url', lines=1, scale=20)
                 with gr.Row():
                     gr.Textbox(elem_id='swanlab_workspace', lines=1, scale=20)
                     gr.Textbox(elem_id='swanlab_exp_name', lines=1, scale=20)


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information
Adds support for Swanlab notifications via Slack.

This change introduces the `swanlab_notification_methods` parameter, allowing users to specify which notification channels (Lark and/or Slack) should be used to receive experiment updates. It also includes corresponding parameters for the Lark and Slack webhook URLs and necessary logic to register the appropriate callbacks based on the selected notification methods.

Related PR https://github.com/modelscope/ms-swift/pull/4830 and Issue https://github.com/modelscope/ms-swift/issues/4829.

## Experiment results
`cli`
<img width="828" alt="Screenshot 2025-07-09 at 16 32 21" src="https://github.com/user-attachments/assets/a6744293-9542-43e4-903f-3620bf11c5a4" />

`slack`
<img width="624" alt="Slack 2025-07-09 16 48 58" src="https://github.com/user-attachments/assets/f47f30bb-5b5b-4987-922a-52c6230c3ddf" />

`web-ui`
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/25ece987-e778-445e-b125-0a9b6f9cc391" />
