### PR TITLE
[sp] remove deprecated tokenizer

### DIFF
--- a/swift/trainers/sequence_parallel/utils.py
+++ b/swift/trainers/sequence_parallel/utils.py
@@ -500,7 +500,7 @@ def _get_per_token_logps_grpo(self, model, inputs, sp_instance):
     _, _, labels, _, _, _ = sp_instance.pad_and_split_inputs(None, None, input_ids.clone(), None, None, None)
 
     shape1 = logits.shape[1]
-    labels = torch.where(labels == -100, self.tokenizer.pad_token_id, labels)
+    labels = torch.where(labels == -100, self.processing_class.pad_token_id, labels)
     # calculate padding size for example, 9 to 10 if sp=2
     padding_size = shape1 * sp_instance.sp_world_size - origin_length
     # left shift one token to leave the last token


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
Replace tokenizer with processing_class to avoid the frequent warning Trainer.tokenizer is now deprecated. You should use Trainer.processing_class instead. during training.

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
