### PR TITLE
Fix: Defer MathAccuracy initialization to __init__ to avoid import-time dependency check

### DIFF
--- a/swift/cli/main.py
+++ b/swift/cli/main.py
@@ -62,7 +62,7 @@ def cli_main(route_mapping: Optional[Dict[str, str]] = None) -> None:
     file_path = importlib.util.find_spec(route_mapping[method_name]).origin
     torchrun_args = get_torchrun_args()
     python_cmd = sys.executable
-    if torchrun_args is None or method_name not in {'pt', 'sft', 'rlhf', 'infer'}:
+    if torchrun_args is None or method_name not in {'pt', 'sft', 'rlhf', 'infer', 'rollout'}:
         args = [python_cmd, file_path, *argv]
     else:
         args = [python_cmd, '-m', 'torch.distributed.run', *torchrun_args, file_path, *argv]

--- a/swift/llm/argument/deploy_args.py
+++ b/swift/llm/argument/deploy_args.py
@@ -93,3 +93,7 @@ class RolloutArguments(DeployArguments):
                 self.use_async_engine = True
             else:
                 self.use_async_engine = False
+
+    def _init_eval_human(self):
+        # to skip DDP check in InferArguments._init_ddp
+        self.eval_human = True


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Move the `acc_func = MathAccuracy()` assignment from the class body into the `__init__` method of `MathTipsScheduler`. This change ensures that importing the module does not trigger an immediate dependency check or side effects from instantiating `MathAccuracy`. Now, the dependency will only be checked when an object is actually instantiated.

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
