### PR TITLE
Fix: Defer MathAccuracy initialization to __init__ to avoid import-time dependency check

### DIFF
--- a/swift/plugin/multi_turn.py
+++ b/swift/plugin/multi_turn.py
@@ -24,9 +24,12 @@ class MultiTurnScheduler(ABC):
 
 
 class MathTipsScheduler(MultiTurnScheduler):
-    from .orm import MathAccuracy
     tips_prompt = 'But wait... It seems I made a mistake,'
-    acc_func = MathAccuracy()
+
+    def __init__(self, max_turns=None, *args, **kwargs):
+        from .orm import MathAccuracy
+        super().__init__(max_turns, *args, **kwargs)
+        self.acc_func = kwargs.get('acc_function', MathAccuracy())
 
     def check_finished(self, infer_request: RolloutInferRequest, result: RolloutResponseChoice,
                        current_turn: int) -> bool:


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Move the `acc_func = MathAccuracy()` assignment from the class body into the `__init__` method of `MathTipsScheduler`. This change ensures that importing the module does not trigger an immediate dependency check or side effects from instantiating `MathAccuracy`. Now, the dependency will only be checked when an object is actually instantiated.

## Experiment results

Paste your experiment result here(if needed).
