### PR TITLE
[template] fix/pixtral/pixel_values & image_sizes

### DIFF
--- a/swift/llm/template/template/pixtral.py
+++ b/swift/llm/template/template/pixtral.py
@@ -1,6 +1,8 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 from typing import Any, Dict, List, Optional
 
+import torch
+
 from ..base import Template
 from ..constant import MLLMTemplateType
 from ..register import TemplateMeta, register_template
@@ -22,8 +24,8 @@ class PixtralTemplate(Template):
         idx_list = findall(input_ids, 10)
         if idx_list:
             image_inputs = processor.image_processor(images, patch_size=processor.patch_size, return_tensors='pt')
-            encoded['pixel_values'] = image_inputs['pixel_values'][0]
-            image_sizes = image_inputs['image_sizes'][0]
+            encoded['pixel_values'] = image_inputs['pixel_values']
+            image_sizes = image_inputs['image_sizes']
 
             def _get_new_tokens(i):
                 height, width = image_sizes[i]
@@ -46,6 +48,7 @@ class PixtralTemplate(Template):
         pixel_values = self.gather_list(batch, 'pixel_values')
         res = super()._data_collator(batch, padding_to=padding_to)
         if pixel_values:
+            pixel_values = torch.stack(pixel_values)
             res['pixel_values'] = pixel_values
         return res
 

--- a/swift/llm/template/template/pixtral.py
+++ b/swift/llm/template/template/pixtral.py
@@ -25,7 +25,7 @@ class PixtralTemplate(Template):
         if idx_list:
             image_inputs = processor.image_processor(images, patch_size=processor.patch_size, return_tensors='pt')
             encoded['pixel_values'] = image_inputs['pixel_values']
-            image_sizes = image_inputs['image_sizes']
+            encoded['image_sizes'] = image_sizes = image_inputs['image_sizes']
 
             def _get_new_tokens(i):
                 height, width = image_sizes[i]
@@ -46,10 +46,14 @@ class PixtralTemplate(Template):
 
     def _data_collator(self, batch: List[Dict[str, Any]], *, padding_to: Optional[int] = None) -> Dict[str, Any]:
         pixel_values = self.gather_list(batch, 'pixel_values')
+        image_sizes = self.gather_list(batch, 'image_sizes')
         res = super()._data_collator(batch, padding_to=padding_to)
         if pixel_values:
             pixel_values = torch.stack(pixel_values)
             res['pixel_values'] = pixel_values
+        if image_sizes:
+            image_sizes = torch.stack(image_sizes)
+            res['image_sizes'] = image_sizes  
         return res
 
 

--- a/swift/llm/template/template/pixtral.py
+++ b/swift/llm/template/template/pixtral.py
@@ -53,7 +53,7 @@ class PixtralTemplate(Template):
             res['pixel_values'] = pixel_values
         if image_sizes:
             image_sizes = torch.stack(image_sizes)
-            res['image_sizes'] = image_sizes  
+            res['image_sizes'] = image_sizes
         return res
 
 


### PR DESCRIPTION
# PR type
- [√ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

在修复loss_scale过程中，发现swift/llm/template/pixtral.PixtralTemplate._encode () 方法存在两个问题：
1. pixel_values 取值，类型传递问题
2. image_sizes 取值问题

详细说明如下：

## Experiment results

## 1. fix  value of "pixel_values" 


原始代码:
```python
#/swift/llm/template/template/pixtral.PixtralTemplate._encode()
        if idx_list:
            image_inputs = processor.image_processor(images, patch_size=processor.patch_size, return_tensors='pt')

            encoded['pixel_values'] = image_inputs['pixel_values'][0]
            image_sizes = image_inputs['image_sizes'][0]

```

**问题:**
```python
encoded['pixel_values'] = image_inputs['pixel_values'][0] 多加了一个[0], 
```

- 本应传入一个四位的tensor (批次,通道,高,宽), 但实际取了第一个,传入了一个三位的tensor(通道,高,宽), 导致
```python
transformer.models.pixtral.modeling_pixtral.forward()中的
     batch_size, _, height, width = pixel_values.shape
报错:
ValueError: not enough values to unpack (expected 4, got 3)
```

**复现:**

<img width="1714" height="796" alt="image-37" src="https://github.com/user-attachments/assets/85042d55-44f4-416b-8bbb-5c6379613603" />
<img width="738" height="128" alt="image-40" src="https://github.com/user-attachments/assets/e0948174-afcc-4eee-b0b3-a2572941ea55" />
<img width="1052" height="59" alt="image-39" src="https://github.com/user-attachments/assets/50dd6ec1-dc7b-49c7-a446-33e16338428e" />


## 2. fix value of "image_sizes"



原始代码:
```python
#/swift/llm/template/template/pixtral.PixtralTemplate._encode()
        if idx_list:
            image_inputs = processor.image_processor(images, patch_size=processor.patch_size, return_tensors='pt')

            encoded['pixel_values'] = image_inputs['pixel_values'][0]
            image_sizes = image_inputs['image_sizes'][0]

```

**问题:**
```python
image_sizes = image_inputs['image_sizes'][0] 同样多加了一个[0], 
```
- 本应(批次,(高,宽)), 但实际取了第一个,传入了一个二维的tensor(高,宽), 导致
```python
def _get_new_tokens(i):
    height, width = image_sizes[i]
```
只解析出高, 而不知道宽, 导致后续处理时出错.

**复现:**
<img width="1714" height="796" alt="image-37" src="https://github.com/user-attachments/assets/85042d55-44f4-416b-8bbb-5c6379613603" />
<img width="1016" height="594" alt="image-38" src="https://github.com/user-attachments/assets/74df0523-41ec-4c62-8370-121443147516" />



## 3 fix type of "pixel_values"

**swift原始代码**
```python
#/swift/llm/template/template/pixtral.PixtralTemplate._data_collator()
    def _data_collator(self, batch: List[Dict[str, Any]], *, padding_to: Optional[int] = None) -> Dict[str, Any]:
        pixel_values = self.gather_list(batch, 'pixel_values')
        res = super()._data_collator(batch, padding_to=padding_to)
        if pixel_values:

            # type为list
            res['pixel_values'] = pixel_values
        return res

```

**transformers原始(部分)代码**
```python
#transformers==4.52.4
#/transformers/models/pixtral/modeling_pixtral.PixtralVisionModel.forward()

    @can_return_tuple
    @auto_docstring
    def forward(
        self,
        #要求type为tensor
        pixel_values: torch.Tensor,
        image_sizes: Optional[torch.Tensor] = None,
        ...
    ) -> Union[Tuple, BaseModelOutput]:
        if image_sizes is None:
            batch_size, _, height, width = pixel_values.shape
            image_sizes = [(height, width)] * batch_size
```

**问题:**
swift传出的pixel_values类型为list, 但传到transformers中时, 要求type为tensor, 导致报错.

在github上查看最新transformers源码, 依旧要求type为tensor,排除transformers版本的因素

**复现:**

设置:
--per_device_train_batch_size 4
<img width="1642" height="662" alt="image" src="https://github.com/user-attachments/assets/555b4d9f-258b-4c71-83ce-9aa11a7d6ef4" />
<img width="1685" height="923" alt="image-65" src="https://github.com/user-attachments/assets/a4523bad-5ea3-44d7-86b2-970b80af02e3" />
<img width="1352" height="866" alt="image-66" src="https://github.com/user-attachments/assets/09ae031e-bded-4caa-b1b5-10b68a59a686" />
<img width="2232" height="540" alt="image-68" src="https://github.com/user-attachments/assets/b0a7c5e6-bef5-4f80-80aa-c81210c0f974" />


**解决方案:**
```python
#/swift/llm/template/template/pixtral.PixtralTemplate._data_collator()
    def _data_collator(self, batch: List[Dict[str, Any]], *, padding_to: Optional[int] = None) -> Dict[str, Any]:
        pixel_values = self.gather_list(batch, 'pixel_values')
        res = super()._data_collator(batch, padding_to=padding_to)
        if pixel_values:

            # type改为tensor
            pixel_values = torch.stack(pixel_values)
            res['pixel_values'] = pixel_values
        return res
```
更改后, 再次运行, 问题解决.
<img width="2280" height="228" alt="image-67" src="https://github.com/user-attachments/assets/238648d2-b042-49d1-a197-ef7f74bca885" />
