### PR TITLE
fix: trainer state strict saving

### DIFF
--- a/swift/llm/train/sft.py
+++ b/swift/llm/train/sft.py
@@ -173,7 +173,7 @@ class SwiftSft(SwiftPipeline, TunerMixin):
         })
         if is_master():
             jsonl_path = os.path.join(training_args.output_dir, 'logging.jsonl')
-            append_to_jsonl(jsonl_path, self.train_msg)
+            append_to_jsonl(jsonl_path, self.train_msg, strict=False)
         return self.train_msg
 
     def train(self, trainer):


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information

Write the detail information belongs to this PR.

Fix storing trainer state on storage systems that do not support append or delete operations, which previously could cause training to be incorrectly marked as failed

On storage systems like HDFS that do not allow file modification or deletion, attempting to update trainer state or logging (e.g., logging.jsonl) at the end of training could fail. This caused the training job to exit abnormally and be marked as failed, even though training itself had completed successfully.

## Experiment results

Paste your experiment result here(if needed).
