### PR TITLE
Fix NCCL timeout issues that may occur in multi-node training

### DIFF
--- a/swift/llm/argument/base_args/base_args.py
+++ b/swift/llm/argument/base_args/base_args.py
@@ -88,6 +88,7 @@ class BaseArguments(CompatArguments, GenerationArguments, QuantizeArguments, Dat
         default=None, metadata={'help': 'SDK token can be found in https://modelscope.cn/my/myaccesstoken'})
     # dist
     ddp_timeout: int = 18000000
+    os.environ['DDP_TIMEOUT'] = str(ddp_timeout)
     ddp_backend: Optional[str] = None
 
     # extra

--- a/swift/utils/env.py
+++ b/swift/utils/env.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 import torch
 import torch.distributed as dist
 from transformers.utils import strtobool
+from datetime import timedelta
 
 from .logger import get_logger
 
@@ -96,7 +97,8 @@ def is_dist_ta() -> bool:
         if not dist.is_initialized():
             import torchacc as ta
             # Initialize in advance
-            dist.init_process_group(backend=ta.dist.BACKEND_NAME)
+            timeout = timedelta(int(os.environ['DDP_TIMEOUT']))
+            dist.init_process_group(backend=ta.dist.BACKEND_NAME, timeout=timeout)
         return True
     else:
         return False

--- a/swift/utils/env.py
+++ b/swift/utils/env.py
@@ -97,7 +97,7 @@ def is_dist_ta() -> bool:
         if not dist.is_initialized():
             import torchacc as ta
             # Initialize in advance
-            timeout = timedelta(int(os.environ['DDP_TIMEOUT']))
+            timeout = timedelta(seconds=int(os.environ['DDP_TIMEOUT']))
             dist.init_process_group(backend=ta.dist.BACKEND_NAME, timeout=timeout)
         return True
     else:


### PR DESCRIPTION

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Because the previous setting about ddp_timeout will not be executed in some cases. In the process of saving the eval or model checkpoint of multi-node multi-gpu training, there is a probability that the NCCL timeout will be caused by cluster performance and other problems, which will lead to the suspension of the training process. 

This PR solves this problem by synchronizing ddp_timeout parameters in different situations through environment variables.

## Experiment results

Paste your experiment result here(if needed).
