### PR TITLE
Fix: `model_type` may not read properly when it's not provided in training args

### DIFF
--- a/swift/llm/model/register.py
+++ b/swift/llm/model/register.py
@@ -456,9 +456,8 @@ def _get_model_info(model_dir: str, model_type: Optional[str], quantization_conf
         model_type = _read_args_json_model_type(model_dir)
     # check config first
     if model_type is None:
-        hf_model_type = HfConfigFactory.get_config_attr(config, 'model_type')
-        # incase it's empty str
-        model_type = hf_model_type if hf_model_type else None
+    if model_type is None:
+        model_type = HfConfigFactory.get_config_attr(config, 'model_type') or None
     if model_type is None:
         architectures = HfConfigFactory.get_config_attr(config, 'architectures')
         model_types = get_matched_model_types(architectures)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information


Original model_type read model_type from CLI tool, traning config, arg.json and finally fallback into huggingface's model config

This step seem's reasonable, but it read `architectures` from models's config.json instead of `model_type`, nowadays most of models provide model_type natively, we don't have to infer model_type from `architectures`

For example, in Qwen3's config.json, we have `model_type`

<img width="376" height="389" alt="Screenshot 2025-07-23 at 15 05 58" src="https://github.com/user-attachments/assets/ce30fb90-94cb-441c-a9e7-7276c18a7ee5" />

So I modify the _get_model_info, read `model_type` first, and then fallback into `architectures` if it's empty of not set.



## Experiment results

Paste your experiment result here(if needed).

Minor change, no need
