### PR TITLE
fix bug

### DIFF
--- a/swift/llm/train/rlhf.py
+++ b/swift/llm/train/rlhf.py
@@ -54,12 +54,18 @@ class SwiftRLHF(SwiftSft):
             else:
                 from transformers import AutoConfig
                 model_config = AutoConfig.from_pretrained(model_dir, trust_remote_code=True)
-                if hasattr(model_config, 'num_labels'):
-                    num_labels = model_config.num_labels
+                if hasattr(model_config, 'architectures'):
+                    for arch in model_config.architectures:
+                        if 'sequenceclassification' in arch.lower():
+                            task_type = 'seq_cls'
+                            break
 
-                # PretrainedConfig default num_labels = 2
-                if num_labels == 1:
-                    task_type = 'seq_cls'
+                if task_type is None:
+                    if hasattr(model_config, 'num_labels'):
+                        num_labels = model_config.num_labels
+                        # PretrainedConfig default num_labels = 2
+                        if num_labels == 1:
+                            task_type = 'seq_cls'
 
             model, processor = args.get_model_processor(
                 model=model_id_or_path,


### PR DESCRIPTION
[ ] Bug Fix

# PR information

在PPO训练时，reward model如果不是swift训出来的，就没有args.json，在这一块就会出bug。没法将普通的seq_cls模型识别出来，错误的初始化为casual model，导致算reward的时候找不到score头。所以对于没有args.json的模型，得从config.json中取architecture检查。原代码已经取出来config了，但是没加以处理。