### PR TITLE
[bugfix] fix vllm sleep&wake_up produces meaningless output

### DIFF
--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -894,6 +894,8 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
                     outputs = self._infer_single_or_multi_turn(inputs, self.request_config)
 
             if self.vllm_mode == 'colocate' and self.args.sleep_level > 0:
+                # Reset prefix cache before sleeping to prevent using stale cache upon waking up
+                # https://github.com/modelscope/ms-swift/pull/5143
                 self.engine.engine.reset_prefix_cache()
                 self.engine.engine.sleep(level=self.args.sleep_level)
                 empty_cache()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
https://github.com/vllm-project/vllm/issues/17103

Fix a bug: When the vllm engine executes `sleep` + `wake_up` without calling `reset_prefix_cache`, it may produce incorrect outputs.

Impact: In GRPO colocate mode, when validate is enabled, all outputs from the first step of validation until the next training step will be abnormal.

Solution: Call `reset_prefix_cache` before each `sleep` operation.

A simple reproduction code:

```python
  from swift.llm import InferEngine, InferRequest, RequestConfig
  from swift.plugin import InferStats
  model = 'Qwen/Qwen2.5-0.5B-Instruct'
  from swift.llm import VllmEngine
  engine = VllmEngine(model, gpu_memory_utilization=0.6, enable_prefix_caching=True, max_model_len=8192,enable_sleep_mode=True)
  req = InferRequest(messages=[{'role': 'user', 'content': '你是谁？'}])
  # engine.engine.reset_prefix_cache()
  output = engine.infer([req] * 10, RequestConfig(n=1))
  engine.engine.reset_prefix_cache()
  engine.engine.sleep(1)
  engine.engine.wake_up()
  output2 = engine.infer([req] * 10, RequestConfig(n=1))
  engine.engine.reset_prefix_cache()
  output3 = engine.infer([req] * 10, RequestConfig(n=1))
```


Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
