### PR TITLE
[grpo] compatible with trl 0.2

### DIFF
--- a/swift/llm/argument/rlhf_args.py
+++ b/swift/llm/argument/rlhf_args.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from swift.llm import MODEL_MAPPING
 from swift.trainers import GRPOArgumentsMixin, RLHFArgumentsMixin
-from swift.utils import get_logger, is_master, is_mp, set_default_ddp_config
+from swift.utils import get_current_device, get_logger, is_master, is_mp, set_default_ddp_config
 from .train_args import TrainArguments
 
 logger = get_logger()
@@ -230,7 +230,7 @@ class RLHFArguments(TeacherModelArguments, GRPOArguments, PPOArguments, RewardMo
                 hosts=self.vllm_server_host,
                 server_ports=self.vllm_server_port,
                 connection_timeout=self.vllm_server_timeout)
-            self.vllm_client.init_communicator()
+            self.vllm_client.init_communicator(device=get_current_device())
 
     def _set_default(self):
         if self.beta is None:

--- a/swift/llm/infer/protocol.py
+++ b/swift/llm/infer/protocol.py
@@ -406,6 +406,7 @@ class InitCommunicatorRequest(BaseModel):
     host: str
     port: int
     world_size: int
+    client_device_uuid: Optional[str] = None
 
 
 class UpdateWeightsRequest(BaseModel):

--- a/swift/llm/infer/rollout.py
+++ b/swift/llm/infer/rollout.py
@@ -251,7 +251,12 @@ class SwiftRolloutDeploy(SwiftPipeline):
         # The function init_communicator is called this way: init_communicator(host, port, world_size)
         # So with collective_rpc we need to call it this way:
         # llm.collective_rpc(method="init_communicator", args=(host, port, world_size))
-        kwargs = {'method': 'init_communicator', 'args': (request.host, request.port, world_size)}
+        kwargs = {
+            'method':
+            'init_communicator',
+            'args': (request.host, request.port, world_size, *(() if request.client_device_uuid is None else
+                                                               (request.client_device_uuid, )))
+        }
         for connection in self.connections:
             connection.send({'type': 'fire_and_forget', 'method': 'collective_rpc', 'kwargs': kwargs})
 

--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -190,6 +190,10 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
         self.async_generate = args.async_generate
         vllm_client = kwargs.pop('vllm_client')  # for external vllm
 
+        self.model_kwarg_keys = (
+            inspect.signature(model.forward).parameters.keys() if not hasattr(model, 'get_base_model') else
+            inspect.signature(model.get_base_model().forward).parameters.keys())
+
         super().__init__(model, ref_model, *_args, **kwargs)
         if self.args.eval_strategy != 'no':
             total_eval_batch_size = self.args.per_device_eval_batch_size * \
@@ -1141,6 +1145,16 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
                 batch_encoded_inputs['old_per_token_logps'] = (
                     self._get_per_token_logps_and_entropies(self.model, batch_encoded_inputs)[0]
                     if self.old_policy() else None)
+                if self.beta == 0.0:
+                    ref_per_token_logps = None
+                elif self.ref_model is not None:
+                    ref_per_token_logps = \
+                        self._get_per_token_logps_and_entropies(self.ref_model, batch_encoded_inputs)[0]
+                else:
+                    with self.accelerator.unwrap_model(self.model).disable_adapter():
+                        ref_per_token_logps = \
+                            self._get_per_token_logps_and_entropies(self.model, batch_encoded_inputs)[0]
+                batch_encoded_inputs['ref_per_token_logps'] = ref_per_token_logps
 
             ga_batch_encoded_inputs.append(batch_encoded_inputs)
 
@@ -1261,13 +1275,7 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
 
         # Compute the KL divergence between the model and the reference model
         if self.beta != 0.0:
-            with torch.no_grad():
-                if self.ref_model is not None:
-                    ref_per_token_logps, _ = self._get_per_token_logps_and_entropies(self.ref_model, inputs)
-                else:
-                    with self.accelerator.unwrap_model(self.model).disable_adapter():
-                        ref_per_token_logps, _ = self._get_per_token_logps_and_entropies(self.model, inputs)
-
+            ref_per_token_logps = inputs['ref_per_token_logps']
             per_token_kl = (
                 torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1)
 
@@ -1452,7 +1460,8 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
                     'truncated_mask'
                 ]
             }
-
+            if 'logits_to_keep' in self.model_kwarg_keys:
+                inputs['logits_to_keep'] = logits_to_keep + 1
             with self._template_context(self.template), self.padding_free_context(model):
                 logits = model(**inputs).logits
             # exclude the last logit: it corresponds to the next token pred
@@ -1482,7 +1491,12 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
                     'truncated_mask'
                 ]
             }
-            with self._template_context(self.template):
+            if 'logits_to_keep' in self.model_kwarg_keys:
+                inputs['logits_to_keep'] = logits_to_keep + 1
+
+            try:
+                last_hidden_state = unwrapped_model.model(**inputs).last_hidden_state
+            except Exception:
                 outputs = unwrapped_model(**inputs, output_hidden_states=True)
                 last_hidden_state = outputs.hidden_states[-1]
 
@@ -1498,16 +1512,6 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
         completion_ids = input_ids[:, -logits_to_keep:]
         completion_mask = inputs['completion_mask']
 
-        # Compute the KL divergence between the model and the reference model
-        ref_per_token_logps = None
-        if self.beta != 0.0:
-            with torch.no_grad():
-                if self.ref_model is not None:
-                    ref_per_token_logps, _ = self._get_per_token_logps_and_entropies(self.ref_model, inputs)
-                else:
-                    with self.accelerator.unwrap_model(self.model).disable_adapter():
-                        ref_per_token_logps, _ = self._get_per_token_logps_and_entropies(self.model, inputs)
-
         # get the last hidden state of the model
         last_hidden_state = self._get_last_hidden_state(unwrapped_model, inputs, logits_to_keep)
         # compute loss and metrics using liger grpo loss
@@ -1518,8 +1522,8 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
             attention_mask=completion_mask,
             advantages=inputs['advantages'],
             bias=unwrapped_model.lm_head.bias,
-            old_per_token_logps=inputs['old_per_token_logps'],
-            ref_per_token_logps=ref_per_token_logps,
+            old_per_token_logps=inputs.get('old_per_token_logps'),
+            ref_per_token_logps=inputs.get('ref_per_token_logps'),
         )
         # Extract metrics from the liger_grpo_loss output
         # KL divergence is the first metric when beta is non-zero

--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -1494,11 +1494,7 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
             if 'logits_to_keep' in self.model_kwarg_keys:
                 inputs['logits_to_keep'] = logits_to_keep + 1
 
-            try:
-                last_hidden_state = unwrapped_model.model(**inputs).last_hidden_state
-            except Exception:
-                outputs = unwrapped_model(**inputs, output_hidden_states=True)
-                last_hidden_state = outputs.hidden_states[-1]
+            last_hidden_state = unwrapped_model.model(**inputs).last_hidden_state
 
         last_hidden_state = last_hidden_state[:, :-1, :]  # (B, L-1, H)
         if logits_to_keep is not None:

--- a/swift/trainers/rlhf_trainer/vllm_client.py
+++ b/swift/trainers/rlhf_trainer/vllm_client.py
@@ -13,7 +13,7 @@ from dacite import from_dict
 from packaging import version
 from requests import ConnectionError
 from torch import nn
-from transformers.utils import is_torch_npu_available
+from transformers.utils import is_torch_cuda_available
 
 from swift.llm import AdapterRequest, RolloutInferRequest, Template
 from swift.llm.infer.protocol import (ChatCompletionResponse, ChatCompletionResponseChoice, GymRolloutResponseChoice,
@@ -30,7 +30,7 @@ if is_vllm_available():
 
 if is_trl_available():
     import trl
-    trl_verison = trl.__version__
+    trl_verison = version.parse(trl.__version__)
 
 logger = logging.getLogger(__name__)
 
@@ -178,8 +178,8 @@ class VLLMClient:
             rank = vllm_world_size
             kwargs = {}
             if trl_verison >= version.parse('0.20.0'):
-                if is_torch_npu_available():
-                    raise NotImplementedError('NPU is not supported for trl >= 0.20.0' 'Please use trl < 0.20.0')
+                if not is_torch_cuda_available():
+                    raise NotImplementedError('trl >= 0.20.0 only support CUDA deivce. Please use trl < 0.20.0')
                 client_device_uuid = str(torch.cuda.get_device_properties(device).uuid)
                 kwargs['client_device_uuid'] = client_device_uuid
 

--- a/swift/trainers/rlhf_trainer/vllm_client.py
+++ b/swift/trainers/rlhf_trainer/vllm_client.py
@@ -10,14 +10,16 @@ from urllib.parse import urlparse
 import requests
 import torch
 from dacite import from_dict
+from packaging import version
 from requests import ConnectionError
 from torch import nn
+from transformers.utils import is_torch_npu_available
 
 from swift.llm import AdapterRequest, RolloutInferRequest, Template
 from swift.llm.infer.protocol import (ChatCompletionResponse, ChatCompletionResponseChoice, GymRolloutResponseChoice,
                                       RequestConfig, RolloutResponseChoice)
 from swift.plugin import Metric
-from swift.utils import is_vllm_ascend_available, is_vllm_available
+from swift.utils import is_trl_available, is_vllm_ascend_available, is_vllm_available
 
 if is_vllm_available():
     from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
@@ -25,6 +27,10 @@ if is_vllm_available():
 
     if is_vllm_ascend_available():
         from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator as PyNcclCommunicator  # noqa
+
+if is_trl_available():
+    import trl
+    trl_verison = trl.__version__
 
 logger = logging.getLogger(__name__)
 
@@ -160,9 +166,8 @@ class VLLMClient:
 
         return [res for server_results in results for res in server_results]
 
-    def init_communicator(self):
+    def init_communicator(self, device: Union[int, str] = 0):
         self.pynccl_comms = []
-
         for i in range(self.num_servers):
             response = self.sessions[i].get(f'{self.base_urls[i]}/get_world_size/')
             if response.status_code != 200:
@@ -171,13 +176,20 @@ class VLLMClient:
 
             world_size = vllm_world_size + 1
             rank = vllm_world_size
+            kwargs = {}
+            if trl_verison >= version.parse('0.20.0'):
+                if is_torch_npu_available():
+                    raise NotImplementedError('NPU is not supported for trl >= 0.20.0' 'Please use trl < 0.20.0')
+                client_device_uuid = str(torch.cuda.get_device_properties(device).uuid)
+                kwargs['client_device_uuid'] = client_device_uuid
 
             response = self.sessions[i].post(
                 f'{self.base_urls[i]}/init_communicator/',
                 json={
                     'host': '0.0.0.0',
                     'port': self.group_ports[i],
-                    'world_size': world_size
+                    'world_size': world_size,
+                    **kwargs
                 })
             if response.status_code != 200:
                 raise Exception(f'Server {i} init failed: {response.text}')

--- a/swift/utils/__init__.py
+++ b/swift/utils/__init__.py
@@ -3,7 +3,8 @@
 from .env import (get_dist_setting, get_hf_endpoint, get_node_setting, get_pai_tensorboard_dir, is_deepspeed_enabled,
                   is_dist, is_local_master, is_master, is_mp, is_mp_ddp, is_pai_training_job, use_hf_hub)
 from .import_utils import (is_liger_available, is_lmdeploy_available, is_megatron_available, is_swanlab_available,
-                           is_unsloth_available, is_vllm_ascend_available, is_vllm_available, is_wandb_available)
+                           is_trl_available, is_unsloth_available, is_vllm_ascend_available, is_vllm_available,
+                           is_wandb_available)
 from .io_utils import JsonlWriter, append_to_jsonl, download_ms_file, get_file_mm_type, read_from_jsonl, write_to_jsonl
 from .logger import get_logger, ms_logger_context
 from .np_utils import get_seed, stat_array, transform_jsonl_to_df

--- a/swift/utils/import_utils.py
+++ b/swift/utils/import_utils.py
@@ -48,6 +48,10 @@ def is_wandb_available() -> bool:
     return importlib.util.find_spec('wandb') is not None
 
 
+def is_trl_available() -> bool:
+    return importlib.util.find_spec('trl') is not None
+
+
 class _LazyModule(ModuleType):
     """
     Module class that surfaces all objects but only performs associated imports when the objects are requested.


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
1. Set 'self.model_kwarg_keys' to be compatible with trl 0.2.
2. Optimize the logic for retrieving 'last_hidden_state' in liger_loss calculation, and add parameter checking for 'logits_to_keep'.
3. Move the logic for computing 'ref_logps' to the rollout phase to avoid redundant calculations when 'num_iterations' > 1.
4. add optional 'device' argument for server mode in init_communicator method

## Experiment results

Paste your experiment result here(if needed).
