### PR TITLE
Fix: Use DDP for PPO traning will cause `AttributeError: 'DistributedDataParallel' object has no attribute 'policy'`

### DIFF
--- a/swift/trainers/rlhf_trainer/ppo_trainer.py
+++ b/swift/trainers/rlhf_trainer/ppo_trainer.py
@@ -69,11 +69,10 @@ class PPOTrainer(SwiftMixin, HFPPOTrainer):
     def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False):
         # https://github.com/huggingface/trl/issues/2122
         backup_model = self.model
-        # Unwrap DDP model if needed to access the policy
-        if isinstance(self.model, DistributedDataParallel):
-            self.model = self.model.module.policy  # save only the policy
-        else:
-            self.model = self.model.policy  # save only the policy
+
+        # Unwrap model if needed to access the policy
+        unwrapped_model = self.accelerator.unwrap_model(self.model)
+        self.model = unwrapped_model.policy  # save only the policy
 
         Trainer.save_model(self, output_dir, _internal_call)
 

--- a/swift/trainers/rlhf_trainer/ppo_trainer.py
+++ b/swift/trainers/rlhf_trainer/ppo_trainer.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import transformers
 from packaging import version
+from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data import DataLoader
 from transformers import PreTrainedModel, Trainer
 from trl import PPOTrainer as HFPPOTrainer
@@ -68,7 +69,11 @@ class PPOTrainer(SwiftMixin, HFPPOTrainer):
     def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False):
         # https://github.com/huggingface/trl/issues/2122
         backup_model = self.model
-        self.model = self.model.policy  # save only the policy
+        # Unwrap DDP model if needed to access the policy
+        if isinstance(self.model, DistributedDataParallel):
+            self.model = self.model.module.policy  # save only the policy
+        else:
+            self.model = self.model.policy  # save only the policy
 
         Trainer.save_model(self, output_dir, _internal_call)
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

When use DDP for ppo, after train succss, and save model will return AttributeError. 
See this issue https://github.com/modelscope/ms-swift/issues/2289. 

Found similar issue in trl repo, and someone gave a solution https://github.com/huggingface/trl/issues/2375#issuecomment-2837664502

After manually unwrap ddp model, problem solved


## Experiment results

When use ppo, after train succss, and save model will return AttributeError
```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/app/main.py", line 355, in <module>
[rank0]:     main()
[rank0]:   File "/app/main.py", line 332, in main
[rank0]:     raise e
[rank0]:   File "/app/main.py", line 320, in main
[rank0]:     runner.run()
[rank0]:   File "/app/finetune/v2/ppo.py", line 100, in run
[rank0]:     return self.train(trainer)
[rank0]:   File "/app/.venv/lib/python3.10/site-packages/swift/llm/train/sft.py", line 183, in train
[rank0]:     trainer.train(trainer.args.resume_from_checkpoint)
[rank0]:   File "/app/.venv/lib/python3.10/site-packages/swift/trainers/rlhf_trainer/ppo_trainer.py", line 59, in train
[rank0]:     super().train()
[rank0]:   File "/app/.venv/lib/python3.10/site-packages/swift/trainers/mixin.py", line 422, in train
[rank0]:     res = super().train(*args, **kwargs)
[rank0]:   File "/app/.venv/lib/python3.10/site-packages/trl/trainer/ppo_trainer.py", line 650, in train
[rank0]:     self._save_checkpoint(model, trial=None)
[rank0]:   File "/app/.venv/lib/python3.10/site-packages/swift/trainers/rlhf_trainer/ppo_trainer.py", line 66, in _save_checkpoint
[rank0]:     return super()._save_checkpoint(*args, **kwargs)
[rank0]:   File "/app/.venv/lib/python3.10/site-packages/swift/trainers/mixin.py", line 311, in _save_checkpoint
[rank0]:     result = super()._save_checkpoint(*args, **kwargs)
[rank0]:   File "/app/.venv/lib/python3.10/site-packages/transformers/trainer.py", line 3199, in _save_checkpoint
[rank0]:     self.save_model(output_dir, _internal_call=True)
[rank0]:   File "/app/.venv/lib/python3.10/site-packages/swift/trainers/rlhf_trainer/ppo_trainer.py", line 71, in save_model
[rank0]:     self.model = self.model.policy  # save only the policy
[rank0]:   File "/app/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1940, in __getattr__
[rank0]:     raise AttributeError(
[rank0]: AttributeError: 'DistributedDataParallel' object has no attribute 'policy'
```

Paste your experiment result here(if needed).
