### PR TITLE
[model] support glm-4.5 agent

### DIFF
--- a/swift/llm/template/template/glm.py
+++ b/swift/llm/template/template/glm.py
@@ -65,6 +65,10 @@ class GLM4_0414TemplateMeta(GLM4TemplateMeta):
     agent_template: str = 'glm4_0414'
 
 
+@dataclass
+class GLM4_5TemplateMeta(GLM4_0414TemplateMeta):
+    agent_template: str = 'glm4_5'
+
 class GLM4_1VTemplateMeta(GLM4_0414TemplateMeta):
     system_prefix: Optional[Prompt] = field(default_factory=lambda: ['[gMASK]<sop><|system|>{{SYSTEM}}'])
 
@@ -234,8 +238,17 @@ class GLM4_5Template(ThinkingTemplate):
     no_think_prefix = '<think></think>\n'
     history_think_prefix = '<think></think>\n'
 
+    def _swift_encode(self, inputs: StdTemplateInputs):
+        res_context_list, loss_scale_list, answer_len = super()._swift_encode(inputs)
+        # When it's a tool_call, avoid generating <|observation|><|user|>
+        penultimate_content = res_context_list[-2] if len(res_context_list) >= 2 else None
+        if isinstance(penultimate_content, str) and penultimate_content.endswith('<|observation|>') and res_context_list[-1] == '<|user|>':
+            res_context_list = res_context_list[:-1]
+            answer_len -= 1
+        return res_context_list, loss_scale_list, answer_len
 
-register_template(GLM4_0414TemplateMeta(LLMTemplateType.glm4_5, template_cls=GLM4_5Template))
+
+register_template(GLM4_5TemplateMeta(LLMTemplateType.glm4_5, template_cls=GLM4_5Template))
 
 register_template(GLM4_1VTemplateMeta(MLLMTemplateType.glm4_1v, template_cls=GLM4_1VTemplate))
 

--- a/swift/llm/template/template/glm.py
+++ b/swift/llm/template/template/glm.py
@@ -69,6 +69,7 @@ class GLM4_0414TemplateMeta(GLM4TemplateMeta):
 class GLM4_5TemplateMeta(GLM4_0414TemplateMeta):
     agent_template: str = 'glm4_5'
 
+
 class GLM4_1VTemplateMeta(GLM4_0414TemplateMeta):
     system_prefix: Optional[Prompt] = field(default_factory=lambda: ['[gMASK]<sop><|system|>{{SYSTEM}}'])
 
@@ -242,7 +243,8 @@ class GLM4_5Template(ThinkingTemplate):
         res_context_list, loss_scale_list, answer_len = super()._swift_encode(inputs)
         # When it's a tool_call, avoid generating <|observation|><|user|>
         penultimate_content = res_context_list[-2] if len(res_context_list) >= 2 else None
-        if isinstance(penultimate_content, str) and penultimate_content.endswith('<|observation|>') and res_context_list[-1] == '<|user|>':
+        if isinstance(penultimate_content,
+                      str) and penultimate_content.endswith('<|observation|>') and res_context_list[-1] == '<|user|>':
             res_context_list = res_context_list[:-1]
             answer_len -= 1
         return res_context_list, loss_scale_list, answer_len

--- a/swift/plugin/agent_template/__init__.py
+++ b/swift/plugin/agent_template/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 from .base import BaseAgentTemplate
 from .extra import ReactGRPOAgentTemplate
-from .glm4 import GLM4_0414AgentTemplate, GLM4AgentTemplate
+from .glm4 import GLM4_0414AgentTemplate, GLM4AgentTemplate, GLM4_5AgentTemplate
 from .hermes import HermesAgentTemplate, HunyuanHermesAgentTemplate
 from .llama import Llama3AgentTemplate, Llama4AgentTemplate
 from .mistral import MistralAgentTemplate
@@ -23,6 +23,7 @@ agent_templates = {
     'toolbench': ToolBenchAgentTemplate,  # ref: https://modelscope.cn/datasets/swift/ToolBench
     'glm4': GLM4AgentTemplate,
     'glm4_0414': GLM4_0414AgentTemplate,  # ref: https://modelscope.cn/models/ZhipuAI/GLM-4-9B-0414
+    'glm4_5': GLM4_5AgentTemplate,
     'llama3': Llama3AgentTemplate,
     'llama4': Llama4AgentTemplate,
     # extra

--- a/swift/plugin/agent_template/__init__.py
+++ b/swift/plugin/agent_template/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
 from .base import BaseAgentTemplate
 from .extra import ReactGRPOAgentTemplate
-from .glm4 import GLM4_0414AgentTemplate, GLM4AgentTemplate, GLM4_5AgentTemplate
+from .glm4 import GLM4_5AgentTemplate, GLM4_0414AgentTemplate, GLM4AgentTemplate
 from .hermes import HermesAgentTemplate, HunyuanHermesAgentTemplate
 from .llama import Llama3AgentTemplate, Llama4AgentTemplate
 from .mistral import MistralAgentTemplate

--- a/swift/plugin/agent_template/glm4.py
+++ b/swift/plugin/agent_template/glm4.py
@@ -113,7 +113,9 @@ class GLM4_5AgentTemplate(BaseAgentTemplate):
         ]
         for tool in tools:
             tool_descs.append(f'{json.dumps(tool, ensure_ascii=False)}')
-        tool_descs.append('</tools>\n\nFor each function call, output the function name and arguments within the following XML format:\n<tool_call>{function-name}\n<arg_key>{arg-key-1}</arg_key>\n<arg_value>{arg-value-1}</arg_value>\n<arg_key>{arg-key-2}</arg_key>\n<arg_value>{arg-value-2}</arg_value>\n...\n</tool_call>')
+        tool_descs.append(
+            '</tools>\n\nFor each function call, output the function name and arguments within the following XML format:\n<tool_call>{function-name}\n<arg_key>{arg-key-1}</arg_key>\n<arg_value>{arg-value-1}</arg_value>\n<arg_key>{arg-key-2}</arg_key>\n<arg_value>{arg-value-2}</arg_value>\n...\n</tool_call>'
+        )
         tool_descs = '\n'.join(tool_descs)
         if system.strip():
             tool_descs += '<|system|>\n' + system.strip()
@@ -130,7 +132,7 @@ class GLM4_5AgentTemplate(BaseAgentTemplate):
         res = []
         for _, tool_message in enumerate(tool_messages):
             tool_content = tool_message['content']
-            res.append(f"\n<tool_response>\n{tool_content}\n</tool_response>")
+            res.append(f'\n<tool_response>\n{tool_content}\n</tool_response>')
         res.append('<|assistant|>\n')
         return assistant_content, res
 
@@ -139,7 +141,7 @@ class GLM4_5AgentTemplate(BaseAgentTemplate):
         for message in tool_call_messages:
             tool_call = self._parse_tool_call(message['content'])
             tool_calls.append(f"<tool_call>{tool_call['name']}")
-            for arg_key, arg_value in tool_call["arguments"].items():
-                tool_calls.append(f"<arg_key>{arg_key}</arg_key>\n<arg_value>{arg_value}</arg_value>")
-            tool_calls.append("</tool_call>")
+            for arg_key, arg_value in tool_call['arguments'].items():
+                tool_calls.append(f'<arg_key>{arg_key}</arg_key>\n<arg_value>{arg_value}</arg_value>')
+            tool_calls.append('</tool_call>')
         return '\n'.join(tool_calls) + '<|observation|>'

--- a/swift/plugin/agent_template/glm4.py
+++ b/swift/plugin/agent_template/glm4.py
@@ -22,7 +22,6 @@ class GLM4AgentTemplate(BaseAgentTemplate):
         matches = pattern.findall(single_content)
         if not matches:
             return
-
         name, arguments = matches[0]
         return Function(name=name, arguments=arguments)
 
@@ -77,3 +76,70 @@ class GLM4AgentTemplate(BaseAgentTemplate):
 
 class GLM4_0414AgentTemplate(GLM4AgentTemplate):
     is_glm4_0414 = True
+
+
+class GLM4_5AgentTemplate(BaseAgentTemplate):
+
+    @staticmethod
+    def _find_function_call(single_content: str) -> Optional['Function']:
+        from swift.llm.infer import Function
+        single_content = single_content.strip()
+        func_name_match = re.match(r'^([^\n<]+)', single_content)
+        if not func_name_match:
+            return None
+        func_name = func_name_match.group(1).strip()
+        keys = re.findall(r'<arg_key>(.*?)</arg_key>', single_content, re.DOTALL)
+        values = re.findall(r'<arg_value>(.*?)</arg_value>', single_content, re.DOTALL)
+        if len(keys) != len(values):
+            return None
+        args = {k.strip(): v.strip() for k, v in zip(keys, values)}
+        return Function(name=func_name, arguments=json.dumps(args, ensure_ascii=False))
+
+    def get_toolcall(self, response: str) -> List['Function']:
+        toolcall_list = re.findall(r'<tool_call>(.*?)</tool_call>', response, re.DOTALL)
+        functions = []
+        for toolcall in toolcall_list:
+            function = self._find_function_call(toolcall)
+            if function:
+                functions.append(function)
+        if len(functions) == 0:
+            # compat react_en
+            return super().get_toolcall(response)
+        return functions
+
+    def _format_tools(self, tools: List[Union[str, dict]], system: str, user_message=None) -> str:
+        tool_descs = [
+            '# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>'
+        ]
+        for tool in tools:
+            tool_descs.append(f'{json.dumps(tool, ensure_ascii=False)}')
+        tool_descs.append('</tools>\n\nFor each function call, output the function name and arguments within the following XML format:\n<tool_call>{function-name}\n<arg_key>{arg-key-1}</arg_key>\n<arg_value>{arg-value-1}</arg_value>\n<arg_key>{arg-key-2}</arg_key>\n<arg_value>{arg-value-2}</arg_value>\n...\n</tool_call>')
+        tool_descs = '\n'.join(tool_descs)
+        if system.strip():
+            tool_descs += '<|system|>\n' + system.strip()
+        return tool_descs
+
+    def _format_tool_responses(
+        self,
+        assistant_content: str,
+        tool_messages,
+    ) -> Tuple[str, 'Prompt']:
+        with_action = self.keyword.action in assistant_content and self.keyword.action_input in assistant_content
+        if with_action:
+            return super()._format_tool_responses(assistant_content, tool_messages)
+        res = []
+        for _, tool_message in enumerate(tool_messages):
+            tool_content = tool_message['content']
+            res.append(f"\n<tool_response>\n{tool_content}\n</tool_response>")
+        res.append('<|assistant|>\n')
+        return assistant_content, res
+
+    def _format_tool_calls(self, tool_call_messages) -> str:
+        tool_calls = []
+        for message in tool_call_messages:
+            tool_call = self._parse_tool_call(message['content'])
+            tool_calls.append(f"<tool_call>{tool_call['name']}")
+            for arg_key, arg_value in tool_call["arguments"].items():
+                tool_calls.append(f"<arg_key>{arg_key}</arg_key>\n<arg_value>{arg_value}</arg_value>")
+            tool_calls.append("</tool_call>")
+        return '\n'.join(tool_calls) + '<|observation|>'


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [x] More Models or Datasets Support

# PR information

This PR adds support for GLM-4.5 agent (function call) training in ms-swift.

Key updates:
1. Added GLM4_5AgentTemplate in plugin/agent_template/glm4.py to support training GLM-4.5 function call agents.
2. Enhanced suffix appending logic: in the final generation round, check if the output already ends with a stop word, and skip appending the suffix if so to avoid redundancy.

## Experiment results
- Training successfully runs on 8×A100 (80GB) with GLM-4.5 agent configuration.

