### PR TITLE
fix: Fix bug in EarlyStop plugin patience counter

### DIFF
--- a/swift/plugin/callback.py
+++ b/swift/plugin/callback.py
@@ -19,6 +19,7 @@ class EarlyStopCallback(TrainerCallback):
         operator = np.greater if args.greater_is_better else np.less
         if self.best_metric is None or operator(state.best_metric, self.best_metric):
             self.best_metric = state.best_metric
+            self.interval = 0
         else:
             self.interval += 1
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

The patience counter in the EarlyStopping plugin was not reset after a new best loss was found, leading to premature termination of training. This patch resets the counter on improvement.

## Experiment results

Paste your experiment result here(if needed).
