### PR TITLE
enable `--extra_eval_args` parameter for swift sft.

### DIFF
--- a/swift/trainers/arguments.py
+++ b/swift/trainers/arguments.py
@@ -68,6 +68,7 @@ class TrainArgumentsMixin:
     eval_dataset_args: Optional[Union[str, dict]] = None
     eval_limit: Optional[int] = None
     eval_generation_config: Optional[Union[str, dict]] = None
+    extra_eval_args: Optional[Union[str, dict]] = None
 
     # dlrover flash_checkpoint
     use_flash_ckpt: bool = False
@@ -126,6 +127,7 @@ class TrainArgumentsMixin:
                 raise ImportError('evalscope is not installed, please install it by `pip install evalscope`')
             self.eval_dataset_args = json_parse_to_dict(self.eval_dataset_args)
             self.eval_generation_config = json_parse_to_dict(self.eval_generation_config)
+            self.extra_eval_args = json_parse_to_dict(self.extra_eval_args)
 
         super().__post_init__()
 

--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -776,6 +776,7 @@ class SwiftMixin:
             work_dir=os.path.join(self.args.output_dir, 'eval'),
             eval_batch_size=max_batch_size,
             generation_config=self.args.eval_generation_config or {'max_tokens': 512},
+            **(self.args.extra_eval_args or {}),
         )
         # start evaluation
         eval_report = run_task(task_config)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

example
```
read -r -d '' EXTRA_ARGS_JSON <<'EOF'
{"ignore_errors": true, "debug": true}
EOF

CUDA_VISIBLE_DEVICES=0 \
swift sft \
   --extra_eval_args "$EXTRA_ARGS_JSON"

```

## Experiment results

Paste your experiment result here(if needed).
