### PR TITLE
[infer] fix lmdeploy ddp infer

### DIFF
--- a/examples/infer/lmdeploy/batch_ddp.sh
+++ b/examples/infer/lmdeploy/batch_ddp.sh
@@ -1,0 +1,8 @@
+NPROC_PER_NODE=4 \
+CUDA_VISIBLE_DEVICES=0,1,2,3 \
+swift infer \
+    --model Qwen/Qwen2.5-1.5B-Instruct \
+    --infer_backend lmdeploy \
+    --val_dataset AI-ModelScope/alpaca-gpt4-data-zh#1000 \
+    --max_batch_size 16 \
+    --max_new_tokens 512

--- a/swift/llm/infer/infer_engine/lmdeploy_engine.py
+++ b/swift/llm/infer/infer_engine/lmdeploy_engine.py
@@ -52,6 +52,7 @@ class LmdeployEngine(InferEngine):
         vision_batch_size: int = 1,  # max_batch_size in VisionConfig
         engine_kwargs: Optional[Dict[str, Any]] = None,
         template: Optional[Template] = None,
+        devices: Optional[List[int]] = None,
     ) -> None:
         if engine_kwargs is None:
             engine_kwargs = {}
@@ -74,6 +75,7 @@ class LmdeployEngine(InferEngine):
             cache_max_entry_count=cache_max_entry_count,
             quant_policy=quant_policy,
             vision_batch_size=vision_batch_size,
+            devices=devices,
             **engine_kwargs)
 
         self.config.torch_dtype = torch_dtype or self.model_info.torch_dtype
@@ -87,11 +89,14 @@ class LmdeployEngine(InferEngine):
                                cache_max_entry_count: float = 0.8,
                                quant_policy: int = 0,
                                vision_batch_size: int = 1,
+                               devices: Optional[List[int]] = None,
                                **engine_kwargs):
         engine_kwargs['tp'] = tp
         engine_kwargs['session_len'] = session_len
         engine_kwargs['cache_max_entry_count'] = cache_max_entry_count
         engine_kwargs['quant_policy'] = quant_policy
+        if 'devices' in inspect.signature(TurbomindEngineConfig).parameters:
+            engine_kwargs['devices'] = devices
         backend_config = TurbomindEngineConfig(**engine_kwargs)
         backend_config = autoget_backend_config(self.model_dir, backend_config)
         self.backend_config = backend_config


### PR DESCRIPTION
Fix a bug in LMDeploy DDP inference

```
[rank1]: TypeError: LmdeployEngine.__init__() got an unexpected keyword argument 'devices'
```