### PR TITLE
fix vllm inference issue when multiple types of media exist

### DIFF
--- a/swift/llm/infer/infer_engine/vllm_engine.py
+++ b/swift/llm/infer/infer_engine/vllm_engine.py
@@ -321,11 +321,11 @@ class VllmEngine(InferEngine):
                 media_data = inputs.get(key) or []
                 if media_data:
                     if self._version_ge('0.6'):
-                        mm_data = {key.rstrip('s'): media_data[0] if len(media_data) == 1 else media_data}
+                        mm_data[key.rstrip('s')] = media_data[0] if len(media_data) == 1 else media_data
                     else:
                         assert len(media_data) == 1, (
                             f'The current version of vllm only supports single {key}. Please upgrade to vllm >= 0.6.0')
-                        mm_data = {key.rstrip('s'): media_data[0]}
+                        mm_data[key.rstrip('s')] = media_data[0]
             if mm_data:
                 llm_inputs['multi_modal_data'] = mm_data
             mm_processor_kwargs = inputs.get('mm_processor_kwargs')


### PR DESCRIPTION
# PR type
- [ x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Fix: Resolve multimodal data loss when processing mixed image and video inputs in vLLM engines

### Problem
When processing requests containing both images and videos simultaneously, the image data was being lost during inference in vLLM-based engines (`VllmEngine`). Only the video processing logs were visible, and the final inference lacked image information.

### Root Cause
The issue was in the multimodal data preparation loop where `mm_data` dictionary was being reassigned instead of updated:

```python
# Incorrect - overwrites previous data
mm_data = {key.rstrip('s'): media_data[0] if len(media_data) == 1 else media_data}
```

When both images and videos were present, the video processing would completely overwrite the image data.

### Solution
Changed the assignment to dictionary update to preserve all media types:

```python
# Correct - preserves all media data
mm_data[key.rstrip('s')] = media_data[0] if len(media_data) == 1 else media_data
```

### Files Changed
- `swift/llm/infer/infer_engine/vllm_engine.py`

### Testing
This fix ensures that when requests contain mixed image and video inputs, both media types are correctly passed to the vLLM engine for inference.

## Experiment results

Paste your experiment result here(if needed).
