### PR TITLE
[template] fix suffix of ChatML template

### DIFF
--- a/swift/llm/template/template/utils.py
+++ b/swift/llm/template/template/utils.py
@@ -15,7 +15,7 @@ class ChatmlTemplateMeta(TemplateMeta):
     prefix: Prompt = field(default_factory=list)
     prompt: Prompt = field(default_factory=lambda: ['<|im_start|>user\n{{QUERY}}<|im_end|>\n<|im_start|>assistant\n'])
     chat_sep: Optional[Prompt] = field(default_factory=lambda: ['<|im_end|>\n'])
-    suffix: Prompt = field(default_factory=lambda: ['<|im_end|>'])
+    suffix: Prompt = field(default_factory=lambda: ['<|im_end|>\n'])
     system_prefix: Optional[Prompt] = field(default_factory=lambda: ['<|im_start|>system\n{{SYSTEM}}<|im_end|>\n'])
     auto_add_bos: bool = True
 


### PR DESCRIPTION
The input_ids obtained by executing apply_chat_template via HF processor still contain a \n (newline character) following <|im_end|>.

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
