### PR TITLE
Bug fix: eval OOM due to deepcopy of torch model

### DIFF
--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -779,35 +779,40 @@ class SwiftMixin:
 
     @torch.no_grad()
     def _evalscope_eval(self):
-        from ..llm.eval.utils import EvalModel  # registry here
+        from ..llm.eval.utils import EvalModel, register_eval_model, unregister_eval_model  # registry here
         from evalscope import TaskConfig, run_task
 
         self.model.eval()
 
-        task_config_kwargs = dict(
-            model=f'model-step{self.state.global_step}',
-            model_args=dict(
-                model=self.model,
-                template=self.template,
-            ),
-            eval_type='swift_custom',
-            datasets=self.args.eval_dataset,
-            dataset_args=self.args.eval_dataset_args,
-            limit=self.args.eval_limit,
-            work_dir=os.path.join(self.args.output_dir, 'eval'),
-            eval_batch_size=self.args.per_device_eval_batch_size,
-            generation_config=self.args.eval_generation_config or {'max_tokens': 512},
-        )
-        task_config_kwargs.update(self.args.extra_eval_args or {})
-        task_config = TaskConfig(**task_config_kwargs)
-        # start evaluation
-        eval_report = run_task(task_config)
-        # convert to dict
-        eval_dict = {f'test_{k}': v.score for k, v in eval_report.items()}
-        self.log(eval_dict)
+        # Register current model+template with a lightweight key to avoid passing the whole torch model
+        model_key = f'swift_eval_model_{os.getpid()}_{self.state.global_step}'
+        register_eval_model(model_key, self.model, self.template)
 
-        self.model.train()
-        return eval_dict
+        try:
+            task_config_kwargs = dict(
+                model=f'model-step{self.state.global_step}',
+                model_args=dict(
+                    model_ref=model_key,
+                ),
+                eval_type='swift_custom',
+                datasets=self.args.eval_dataset,
+                dataset_args=self.args.eval_dataset_args,
+                limit=self.args.eval_limit,
+                work_dir=os.path.join(self.args.output_dir, 'eval'),
+                eval_batch_size=self.args.per_device_eval_batch_size,
+                generation_config=self.args.eval_generation_config or {'max_tokens': 512},
+            )
+            task_config_kwargs.update(self.args.extra_eval_args or {})
+            task_config = TaskConfig(**task_config_kwargs)
+            # start evaluation
+            eval_report = run_task(task_config)
+            # convert to dict
+            eval_dict = {f'test_{k}': v.score for k, v in eval_report.items()}
+            self.log(eval_dict)
+            return eval_dict
+        finally:
+            unregister_eval_model(model_key)
+            self.model.train()
 
     def prepare_logits_to_keep(self, inputs):
         labels = inputs['labels']

--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -791,9 +791,7 @@ class SwiftMixin:
         try:
             task_config_kwargs = dict(
                 model=f'model-step{self.state.global_step}',
-                model_args=dict(
-                    model_ref=model_key,
-                ),
+                model_args=dict(model_ref=model_key, ),
                 eval_type='swift_custom',
                 datasets=self.args.eval_dataset,
                 dataset_args=self.args.eval_dataset_args,


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# Issues and fixes
- When evalscope dumps the taskConfig, it deep copies the config, which triggers cloning large model tensors, causing OOM.
- By passing model_ref instead of torch model, this PR prevent evalscope's deepcopying behavior.

## Reproduce
```
import os, json
from swift.llm.train.sft import sft_main

def main():
    os.environ['CUDA_VISIBLE_DEVICES'] = '0'
    args = [
        '--model', 'Qwen/Qwen2.5-0.5B-Instruct',
        '--model_type', 'qwen2_5',
        '--train_type', 'lora',
        '--dataset', 'swift/self-cognition#10',
        '--torch_dtype', 'float32',
        '--num_train_epochs', '3',
        '--per_device_train_batch_size', '1',
        '--learning_rate', '5e-4',
        '--lora_rank', '4',
        '--lora_alpha', '8',
        '--target_modules', 'q_proj',
        '--gradient_accumulation_steps', '1',
        '--eval_steps', '6',
        '--save_steps', '30',
        '--logging_steps', '1',
        '--max_length', '2048',
        '--output_dir', 'dev/output',
        '--warmup_ratio', '0.05',
        '--dataloader_num_workers', '0',
        '--model_author', 'author',
        '--model_name', 'name',
        '--eval_use_evalscope',
        '--per_device_eval_batch_size', '1',
        '--eval_dataset', 'gsm8k',
        '--eval_dataset_args', '{"gsm8k":{"few_shot_num":0}}',
        '--eval_limit', '2',
        '--report_to', 'none',
    ]
    sft_main(args)

if __name__ == '__main__':
    main()

```