### PR TITLE
Fix: when use PPOTrainer for rlhf, custom callbacks will not work

### DIFF
--- a/swift/trainers/rlhf_trainer/ppo_trainer.py
+++ b/swift/trainers/rlhf_trainer/ppo_trainer.py
@@ -39,7 +39,7 @@ class PPOTrainer(SwiftMixin, HFPPOTrainer):
             new_kwargs = {
                 k: v
                 for k, v in kwargs.items()
-                if k in ['train_dataset', 'data_collator', 'reward_model', 'value_model', 'eval_dataset']
+                if k in ['train_dataset', 'data_collator', 'reward_model', 'value_model', 'eval_dataset', 'callbacks']
             }
             parameters = inspect.signature(ppo_trainer_init).parameters
             if 'config' in parameters:


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
When use PPOTrainer for rlhf, custom callbacks will not work.
But callback works for other worker.

After checking out ppo_trainer's code, I found out you removed hf's ppo_trainer_init to avoid python's MRO class init, and manually init hf's ppo_trainer.

```python
ppo_trainer_init = HFPPOTrainer.__init__
del HFPPOTrainer.__init__
```

But you use some kind of filter to keep useful args during init, it also removed `callbacks` arg, this move may lead user's custom callback unfunctional.

```python
def __init__(self, model: PreTrainedModel, ref_model: PreTrainedModel, *_args, **kwargs):
        super().__init__(model, *_args, **{k: v for k, v in kwargs.items() if k not in {'reward_model', 'value_model'}})
        with self._patch_dataloader(kwargs['data_collator']):
            new_kwargs = {
                k: v
                for k, v in kwargs.items()
                if k in ['train_dataset', 'data_collator', 'reward_model', 'value_model', 'eval_dataset'] # this line filter out uncommon args, but also removed `callbacks`
            }
            parameters = inspect.signature(ppo_trainer_init).parameters
            if 'config' in parameters:
                new_kwargs['config'] = kwargs['args']
            else:
                new_kwargs['args'] = kwargs['args']
            if 'processing_class' in parameters:
                new_kwargs['processing_class'] = self.tokenizer
            else:
                new_kwargs['tokenizer'] = self.tokenizer
            ppo_trainer_init(self, model=model, ref_model=ref_model, **new_kwargs)
        unwrap_model = self.accelerator.unwrap_model(self.model)
        patch_getattr(unwrap_model.__class__, 'policy')
```

I fix this by adding `callbacks` back

## Experiment results

Paste your experiment result here(if needed).
