### PR TITLE
bug fix: RuntimeError when training GRPO with LoRA and PtEngine

### DIFF
--- a/swift/llm/infer/infer_engine/pt_engine.py
+++ b/swift/llm/infer/infer_engine/pt_engine.py
@@ -461,7 +461,7 @@ class PtEngine(InferEngine):
             return await queue.get()
 
     # Ensure `template._post_encode` has no gradient.
-    @torch.no_grad()
+    @torch.inference_mode()
     def _infer(
         self,
         infer_requests: List[InferRequest],

--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -1254,7 +1254,7 @@ class GRPOTrainer(RLHFTrainerMixin, SwiftMixin, HFGRPOTrainer):
                 torch.stack([data['advantages'] for data in batch])
             })
 
-            with torch.no_grad():
+            with torch.inference_mode():
                 batch_encoded_inputs['old_per_token_logps'] = (
                     self._get_per_token_logps_and_entropies(self.model, batch_encoded_inputs)[0]
                     if self.old_policy() else None)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
During PEFT training, to obtain the logps of the reference model, `GRPOTrainer` uses `null_ref_context()` to temporarily disable PEFT. Upon exiting this context, re-enabling PEFT requires setting `requires_grad_(True)` on each layer. However, the model was previously used in `PtEngine` within the context of `@torch.inference_mode()`, which results in the error **"RuntimeError: Setting requires_grad=True on inference tensor outside InferenceMode is not allowed."** Switching from `@torch.inference_mode()` to `@torch.no_grad()` can resolve this issue but may lead to a trade-off in performance. I'm uncertain if there is a better solution.

