### PR TITLE
[Megatron] Convert Megatron adapter to Huggingface adapter without merging

### DIFF
--- a/swift/llm/argument/export_args.py
+++ b/swift/llm/argument/export_args.py
@@ -50,6 +50,7 @@ class ExportArguments(MergeArguments, BaseArguments):
     # megatron
     to_mcore: bool = False
     to_hf: bool = False
+    to_hf_adapters: bool = False
     mcore_model: Optional[str] = None
     mcore_adapters: List[str] = field(default_factory=list)
     thread_count: Optional[int] = None

--- a/swift/megatron/utils/convert.py
+++ b/swift/megatron/utils/convert.py
@@ -302,7 +302,7 @@ def convert_mcore2hf(args: ExportArguments) -> None:
             logger.info('Merge LoRA...')
             mg_model = peft_model.merge_and_unload()
     logger.info('Megatron model created successfully.')
-    if args.to_hf:
+    if args.to_hf and not args.to_hf_adapter:
         megatron_model_meta.convert_mcore2hf(hf_model, mg_model)
         if args.test_convert_precision:
             test_convert_precision(hf_model, mg_model, template, args.test_convert_dtype)


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

It is currently not possible to convert a Megatron LoRA adapter to Huggingface adapter without merging into the full model. Having only the adapter weights is useful in the case of multi-lora inference.

TODO:
- generalize LoraConfig

## Experiment results

TBD
- running perplexity measurements against private test set