### PR TITLE
[bugfix] fix Qwen3ForSequenceClassification zero3

### DIFF
--- a/swift/llm/model/model/qwen.py
+++ b/swift/llm/model/model/qwen.py
@@ -1117,7 +1117,7 @@ register_model(
         task_type='reranker'))
 
 
-def patch_Qwen3SeqClassification():
+def patch_qwen3_sequence_classification():
     # https://github.com/modelscope/ms-swift/issues/5812
     try:
         from transformers.models.qwen3.modeling_qwen3 import Qwen3ForSequenceClassification
@@ -1134,4 +1134,4 @@ def patch_Qwen3SeqClassification():
         return
 
 
-patch_Qwen3SeqClassification()
+patch_qwen3_sequence_classification()

--- a/swift/llm/model/model/qwen.py
+++ b/swift/llm/model/model/qwen.py
@@ -1115,22 +1115,3 @@ register_model(
         get_model_tokenizer_with_flash_attn,
         architectures=['Qwen3ForCausalLM'],
         task_type='reranker'))
-
-
-def patch_qwen3_sequence_classification():
-    # https://github.com/modelscope/ms-swift/issues/5812
-    try:
-        from transformers.models.qwen3.modeling_qwen3 import Qwen3ForSequenceClassification
-        cls = Qwen3ForSequenceClassification
-        if '__init__' not in cls.__dict__:  # avoid patch twice
-
-            def init_method(self, *args, **kwargs):
-                super(cls, self).__init__(*args, **kwargs)
-
-            cls.__init__ = init_method
-
-    except ImportError:
-        return
-
-
-patch_qwen3_sequence_classification()

--- a/swift/llm/model/model/qwen.py
+++ b/swift/llm/model/model/qwen.py
@@ -1125,10 +1125,9 @@ def patch_qwen3_sequence_classification():
         if '__init__' not in cls.__dict__:  # avoid patch twice
 
             def init_method(self, *args, **kwargs):
-                from transformers.models.qwen3.modeling_qwen3 import Qwen3ForSequenceClassification
-                super(Qwen3ForSequenceClassification, self).__init__(*args, **kwargs)
+                super(cls, self).__init__(*args, **kwargs)
 
-            Qwen3ForSequenceClassification.__init__ = init_method
+            cls.__init__ = init_method
 
     except ImportError:
         return

--- a/swift/llm/model/model/qwen.py
+++ b/swift/llm/model/model/qwen.py
@@ -1115,3 +1115,23 @@ register_model(
         get_model_tokenizer_with_flash_attn,
         architectures=['Qwen3ForCausalLM'],
         task_type='reranker'))
+
+
+def patch_Qwen3SeqClassification():
+    # https://github.com/modelscope/ms-swift/issues/5812
+    try:
+        from transformers.models.qwen3.modeling_qwen3 import Qwen3ForSequenceClassification
+        cls = Qwen3ForSequenceClassification
+        if '__init__' not in cls.__dict__:  # avoid patch twice
+
+            def init_method(self, *args, **kwargs):
+                from transformers.models.qwen3.modeling_qwen3 import Qwen3ForSequenceClassification
+                super(Qwen3ForSequenceClassification, self).__init__(*args, **kwargs)
+
+            Qwen3ForSequenceClassification.__init__ = init_method
+
+    except ImportError:
+        return
+
+
+patch_Qwen3SeqClassification()

--- a/swift/llm/model/patcher.py
+++ b/swift/llm/model/patcher.py
@@ -260,6 +260,13 @@ def patch_automodel_for_sequence_classification(model_info, model_meta, **kwargs
 
     @classmethod
     def _new_from_pretrained(cls, *args, **kwargs):
+        # https://github.com/modelscope/ms-swift/issues/5812
+        def init_method(self, *args, **kwargs):
+            super(cls, self).__init__(*args, **kwargs)
+
+        if '__init__' not in cls.__dict__:
+            cls.__init__ = init_method
+
         __init__ = cls.__init__
 
         def __new_init__(self, *args, **kwargs):

--- a/swift/llm/model/patcher.py
+++ b/swift/llm/model/patcher.py
@@ -255,65 +255,93 @@ def _patch_sequence_classification(model, model_meta):
 
 
 @contextmanager
-def patch_automodel_for_sequence_classification(model_info, model_meta, **kwargs):
+def patch_automodel_for_sequence_classification(model_info=None,
+                                                model_meta=None,
+                                                patch_from_pretrained=True,
+                                                patch_missing_init=True,
+                                                **kwargs):
+    """
+    Context manager for patching AutoModel sequence classification.
+
+    Args:
+        model_info: Model information
+        model_meta: Model metadata
+        patch_from_pretrained (bool): Whether to patch PreTrainedModel.from_pretrained
+        patch_missing_init (bool): Whether to patch missing __init__ methods
+        **kwargs: Additional keyword arguments
+    """
     from_pretrained = PreTrainedModel.from_pretrained.__func__
 
-    @classmethod
-    def _new_from_pretrained(cls, *args, **kwargs):
-        __init__ = cls.__init__
+    # Patch 1: from_pretrained method
+    _new_from_pretrained = None
+    if patch_from_pretrained:
 
-        def __new_init__(self, *args, **kwargs):
-            __init__(self, *args, **kwargs)
-            _patch_sequence_classification(self, model_meta)
+        @classmethod
+        def _new_from_pretrained(cls, *args, **kwargs):
+            __init__ = cls.__init__
 
-        cls.__init__ = __new_init__
-        if hasattr(cls, '_tp_plan'):  # fix tp_plan
-            cls._tp_plan = cls._tp_plan or {}
-        res = from_pretrained(cls, *args, **kwargs)
-        cls.__init__ = __init__
-        return res
+            def __new_init__(self, *args, **kwargs):
+                __init__(self, *args, **kwargs)
+                _patch_sequence_classification(self, model_meta)
 
-    def get_all_subclasses(cls, include_root=True):
-        subclass_list = []
+            cls.__init__ = __new_init__
+            if hasattr(cls, '_tp_plan'):  # fix tp_plan
+                cls._tp_plan = cls._tp_plan or {}
+            res = from_pretrained(cls, *args, **kwargs)
+            cls.__init__ = __init__
+            return res
 
-        def recurse(cl):
-            for subclass in cl.__subclasses__():
-                subclass_list.append(subclass)
-                recurse(subclass)
-
-        recurse(cls)
-
-        ret = set(subclass_list)
-        if include_root:
-            ret.add(cls)
-        return ret
-
-    def create_default_init(cls):
-        """Create a default __init__ method that calls super().__init__"""
-
-        def default_init(self, *args, **kwargs):
-            super(cls, self).__init__(*args, **kwargs)
-
-        return default_init
-
+    # Patch 2: missing __init__ methods
+    # https://github.com/modelscope/ms-swift/pull/5820
     patched_classes = []
-    for subclass in get_all_subclasses(torch.nn.modules.module.Module):
-        if '__init__' not in subclass.__dict__:
-            subclass.__init__ = create_default_init(subclass)
-            patched_classes.append(subclass)
+    if patch_missing_init:
 
-    PreTrainedModel.from_pretrained = _new_from_pretrained
+        def get_all_subclasses(cls, include_root=True):
+            subclass_list = []
+
+            def recurse(cl):
+                for subclass in cl.__subclasses__():
+                    subclass_list.append(subclass)
+                    recurse(subclass)
+
+            recurse(cls)
+
+            ret = set(subclass_list)
+            if include_root:
+                ret.add(cls)
+            return ret
+
+        def create_default_init(cls):
+            """Create a default __init__ method that calls super().__init__"""
+
+            def default_init(self, *args, **kwargs):
+                super(cls, self).__init__(*args, **kwargs)
+
+            return default_init
+
+        for subclass in get_all_subclasses(torch.nn.modules.module.Module, include_root=False):
+            if '__init__' not in subclass.__dict__:
+                subclass.__init__ = create_default_init(subclass)
+                patched_classes.append(subclass)
+
+    # Apply patches
+    if patch_from_pretrained:
+        PreTrainedModel.from_pretrained = _new_from_pretrained
 
     try:
         yield
     finally:
-        PreTrainedModel.from_pretrained = classmethod(from_pretrained)
-        for subclass in patched_classes:
-            try:
-                if '__init__' in subclass.__dict__:
-                    del subclass.__init__
-            except (AttributeError, TypeError):
-                pass
+        # Restore patches
+        if patch_from_pretrained:
+            PreTrainedModel.from_pretrained = classmethod(from_pretrained)
+
+        if patch_missing_init:
+            for subclass in patched_classes:
+                try:
+                    if '__init__' in subclass.__dict__:
+                        del subclass.__init__
+                except (AttributeError, TypeError):
+                    pass
 
 
 @contextmanager

--- a/swift/llm/model/patcher.py
+++ b/swift/llm/model/patcher.py
@@ -334,7 +334,6 @@ def patch_automodel_for_sequence_classification(model_info=None,
                 subclass.__init__ = create_default_init(subclass)
                 patched_classes.append(subclass)
 
-    # Apply patches
     if patch_from_pretrained:
         PreTrainedModel.from_pretrained = _new_from_pretrained
 

--- a/swift/llm/model/register.py
+++ b/swift/llm/model/register.py
@@ -249,19 +249,19 @@ def get_model_tokenizer_from_local(model_dir: str,
     if load_model:
         _patch_awq_compat(model_info)
         logger.info(f'model_kwargs: {model_kwargs}')
-        # fix seq_cls
-        if model_info.task_type == 'seq_cls' and automodel_class is None:
-            try:
-                model = AutoModelForSequenceClassification.from_pretrained(
-                    model_dir, config=model_config, torch_dtype=torch_dtype, trust_remote_code=True, **model_kwargs)
-            except ValueError:
-                model = None
-        elif model_info.task_type == 'reranker' and automodel_class is None:
-            try:
-                model = AutoModelForSequenceClassification.from_pretrained(
-                    model_dir, config=model_config, torch_dtype=torch_dtype, trust_remote_code=True, **model_kwargs)
-            except ValueError:
-                model = None
+        with patch_automodel_for_sequence_classification(patch_from_pretrained=False):
+            if model_info.task_type == 'seq_cls' and automodel_class is None:
+                try:
+                    model = AutoModelForSequenceClassification.from_pretrained(
+                        model_dir, config=model_config, torch_dtype=torch_dtype, trust_remote_code=True, **model_kwargs)
+                except ValueError:
+                    model = None
+            elif model_info.task_type == 'reranker' and automodel_class is None:
+                try:
+                    model = AutoModelForSequenceClassification.from_pretrained(
+                        model_dir, config=model_config, torch_dtype=torch_dtype, trust_remote_code=True, **model_kwargs)
+                except ValueError:
+                    model = None
 
         automodel_class = automodel_class or AutoModelForCausalLM
         model_meta = kwargs['model_meta']

--- a/swift/llm/model/register.py
+++ b/swift/llm/model/register.py
@@ -249,7 +249,7 @@ def get_model_tokenizer_from_local(model_dir: str,
     if load_model:
         _patch_awq_compat(model_info)
         logger.info(f'model_kwargs: {model_kwargs}')
-        with patch_automodel_for_sequence_classification(patch_from_pretrained=False):
+        with patch_automodel_for_sequence_classification(model_config=model_config, patch_from_pretrained=False):
             if model_info.task_type == 'seq_cls' and automodel_class is None:
                 try:
                     model = AutoModelForSequenceClassification.from_pretrained(


### PR DESCRIPTION
## Fix context manager bug for classes without explicit __init__ method

### Issue Description

`Qwen3ForSequenceClassification` doesn't define its own `__init__` method:

```python
class Qwen3ForSequenceClassification(GenericForSequenceClassification, Qwen3PreTrainedModel):
    pass
```

This causes a bug when used with DeepSpeed's Zero context manager, which patches all module init methods during entry and restores them during exit:

```python
    # enter context
    def unpatch_init_and_builtins(self):
        ...
        def _enable_class(cls):
            if '__init__' in cls.__dict__:
                cls._old_init = cls.__init__
                cls.__init__ = partition_after(cls.__init__)

        # Replace .__init__() for all existing subclasses of torch.nn.Module recursively
        for subclass in get_all_subclasses(torch.nn.modules.module.Module):
            _enable_class(subclass)

    # exit context
    def unpatch_init_and_builtins(self):
        if self.patched:

            def _disable_class(cls):
                if hasattr(cls, '_old_init'):
                    cls.__init__ = cls._old_init

            for subclass in get_all_subclasses(torch.nn.modules.module.Module):
                _disable_class(subclass)
```

### Root Cause

The bug occurs due to the asymmetric patching/unpatching logic:

**During context entry (patching):**
1. `Qwen3ForSequenceClassification` has no explicit `__init__`, so it skips the `'__init__' in cls.__dict__` check and is not patched
2. `GenericForSequenceClassification` is not a subclass of `torch.nn.Module`, so it's not patched
3. `Qwen3PreTrainedModel` gets patched and receives the `_old_init` attribute

**During context exit (unpatching):**
Since `Qwen3ForSequenceClassification` inherits from `Qwen3PreTrainedModel` which has the `_old_init` attribute, the unpatching logic incorrectly overwrites `Qwen3ForSequenceClassification.__init__` with `Qwen3PreTrainedModel`'s original `__init__` method, breaking the inheritance chain.

### Solution

Add an explicit `__init__` method to the class that don't define one before the patching process begins. This ensures symmetric patching and unpatching behavior.