### PR TITLE
register qwen3_coder

### DIFF
--- a/swift/megatron/model/gpt/__init__.py
+++ b/swift/megatron/model/gpt/__init__.py
@@ -43,6 +43,7 @@ register_megatron_model(
             ModelType.qwen2_moe,
             ModelType.qwen3_moe,
             ModelType.qwen3_moe_thinking,
+            ModelType.qwen3_coder,
             ModelType.internlm3,
             ModelType.mimo,
             ModelType.mimo_rl,


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

The `qwen3_coder` model type was not registered causing the `megatron_model_meta` to being set to None causing a crash.

## Experiment results

Paste your experiment result here(if needed).
