### PR TITLE
fix(export_args): set default test_convert_dtype to torch_dtype

### DIFF
--- a/docs/source/Instruction/命令行参数.md
+++ b/docs/source/Instruction/命令行参数.md
@@ -647,8 +647,8 @@ App参数继承于[部署参数](#部署参数), [Web-UI参数](#Web-UI参数)�
 - to_hf: Megatron格式权重转成HF格式。默认为False。
 - mcore_model: mcore格式模型路径。默认为None。
 - thread_count: `--to_mcore true`时的模型切片数。默认为None，根据模型大小自动设置，使得最大分片小于10GB。
-- 🔥test_convert_precision: 测试HF和Megatron格式权重转换的精度误差。默认为False。
 - test_convert_dtype: 测试转换的dtype，默认使用`torch_dtype`。
+- 🔥test_convert_precision: 测试HF和Megatron格式权重转换的精度误差。默认为False。
 - 🔥push_to_hub: 是否推送hub，默认为False。例子参考[这里](https://github.com/modelscope/ms-swift/blob/main/examples/export/push_to_hub.sh)。
 - hub_model_id: 推送的model_id，默认为None。
 - hub_private_repo: 是否是private repo，默认为False。

--- a/docs/source/Instruction/命令行参数.md
+++ b/docs/source/Instruction/命令行参数.md
@@ -648,6 +648,7 @@ App参数继承于[部署参数](#部署参数), [Web-UI参数](#Web-UI参数)�
 - mcore_model: mcore格式模型路径。默认为None。
 - thread_count: `--to_mcore true`时的模型切片数。默认为None，根据模型大小自动设置，使得最大分片小于10GB。
 - 🔥test_convert_precision: 测试HF和Megatron格式权重转换的精度误差。默认为False。
+- test_convert_dtype: 测试转换的dtype，默认使用`torch_dtype`。
 - 🔥push_to_hub: 是否推送hub，默认为False。例子参考[这里](https://github.com/modelscope/ms-swift/blob/main/examples/export/push_to_hub.sh)。
 - hub_model_id: 推送的model_id，默认为None。
 - hub_private_repo: 是否是private repo，默认为False。

--- a/docs/source_en/Instruction/Command-line-parameters.md
+++ b/docs/source_en/Instruction/Command-line-parameters.md
@@ -667,6 +667,7 @@ Export Arguments include the [basic arguments](#base-arguments) and [merge argum
 - to_hf: Convert weights from Megatron format to HF format. Default is False.
 - mcore_model: Path to the mcore format model. Default is None.
 - thread_count: The number of model slices when `--to_mcore true` is set. Defaults to None, and is automatically configured based on the model size, ensuring that the largest slice is less than 10GB.
+- test_convert_dtype: The dtype used for testing weight conversion precision, defaults to `torch_dtype`.
 - 🔥test_convert_precision: Test the precision error when converting weights between HF and Megatron formats. Default is False.
 - 🔥push_to_hub: Whether to push to the hub, with the default being False. Examples can be found [here](https://github.com/modelscope/ms-swift/blob/main/examples/export/push_to_hub.sh).
 - hub_model_id: Model ID for pushing, default is None.

--- a/swift/llm/argument/export_args.py
+++ b/swift/llm/argument/export_args.py
@@ -54,7 +54,7 @@ class ExportArguments(MergeArguments, BaseArguments):
     mcore_adapters: List[str] = field(default_factory=list)
     thread_count: Optional[int] = None
     test_convert_precision: bool = False
-    test_convert_dtype: str = 'float32'
+    test_convert_dtype: str = None
 
     # push to ms hub
     push_to_hub: bool = False
@@ -115,6 +115,7 @@ class ExportArguments(MergeArguments, BaseArguments):
 
         BaseArguments.__post_init__(self)
         self._init_output_dir()
+        self.test_convert_dtype = self.test_convert_dtype or self.torch_dtype
         self.test_convert_dtype = HfConfigFactory.to_torch_dtype(self.test_convert_dtype)
         if self.quant_method in {'gptq', 'awq'} and len(self.dataset) == 0:
             raise ValueError(f'self.dataset: {self.dataset}, Please input the quant dataset.')


### PR DESCRIPTION
… to torch_dtype

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix test_convert_precision default value from float32 -> model’s torch_dtype.
When testing a bfloat16 model with float32 (with FLA), an exception occurs: 
```shell
Traceback (most recent call last):
  File "..../python3.10/site-packages/swift/cli/export.py", line 5, in <module>
    export_main()
  File "..../python3.10/site-packages/swift/llm/export/export.py", line 53, in export_main
    return SwiftExport(args).main()
  File "..../python3.10/site-packages/swift/llm/base.py", line 49, in main
    result = self.run()
  File "..../python3.10/site-packages/swift/llm/export/export.py", line 40, in run
    convert_hf2mcore(args)
  File "..../python3.10/site-packages/swift/megatron/utils/convert.py", line 234, in convert_hf2mcore
    test_convert_precision(hf_model, mg_model, template, args.test_convert_dtype)
  File "..../python3.10/site-packages/swift/megatron/utils/convert.py", line 151, in test_convert_precision
    hf_logits = hf_model(**inputs).logits
  File "..../python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "..../python3.10/site-packages/torch/nn/modules/module.py", line 1857, in _call_impl
    return inner()
  File "..../python3.10/site-packages/torch/nn/modules/module.py", line 1805, in inner
    result = forward_call(*args, **kwargs)
  File "..../python3.10/site-packages/accelerate/hooks.py", line 175, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "..../python3.10/site-packages/transformers/utils/generic.py", line 916, in wrapper
    output = func(self, *args, **kwargs)
  File "..../python3.10/site-packages/transformers/models/qwen3_next/modeling_qwen3_next.py", line 1211, in forward
    outputs: MoeModelOutputWithPast = self.model(
  File "..../python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "..../python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "..../python3.10/site-packages/transformers/utils/generic.py", line 1062, in wrapper
    outputs = func(self, *args, **kwargs)
  File "..../python3.10/site-packages/transformers/models/qwen3_next/modeling_qwen3_next.py", line 1036, in forward
    hidden_states = decoder_layer(
  File "..../python3.10/site-packages/transformers/modeling_layers.py", line 94, in __call__
    return super().__call__(*args, **kwargs)
  File "..../python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "..../python3.10/site-packages/torch/nn/modules/module.py", line 1857, in _call_impl
    return inner()
  File "..../python3.10/site-packages/torch/nn/modules/module.py", line 1805, in inner
    result = forward_call(*args, **kwargs)
  File "..../python3.10/site-packages/accelerate/hooks.py", line 175, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "..../python3.10/site-packages/transformers/utils/deprecation.py", line 172, in wrapped_func
    return func(*args, **kwargs)
  File "..../python3.10/site-packages/transformers/models/qwen3_next/modeling_qwen3_next.py", line 920, in forward
    hidden_states = self.linear_attn(
  File "..../python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "..../python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "..../python3.10/site-packages/accelerate/hooks.py", line 175, in new_forward
    output = module._old_forward(*args, **kwargs)
  File "..../python3.10/site-packages/transformers/models/qwen3_next/modeling_qwen3_next.py", line 739, in forward
    core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
  File "..../python3.10/site-packages/torch/_dynamo/eval_frame.py", line 838, in _fn
    return fn(*args, **kwargs)
  File "..../python3.10/site-packages/fla/ops/gated_delta_rule/chunk.py", line 300, in chunk_gated_delta_rule
    assert q.dtype != torch.float32, "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
AssertionError: ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16.
```

## Experiment results
- 
