### PR TITLE
chord support loss_scale & update template loss_scale is_binary

### DIFF
--- a/swift/llm/template/base.py
+++ b/swift/llm/template/base.py
@@ -24,6 +24,7 @@ from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.utils import strtobool
 
 from swift.llm import to_device
+from swift.plugin.loss_scale.loss_scale import LossScale
 from swift.utils import get_env_args, get_logger
 from ..utils import Processor, ProcessorMixin
 from .template_inputs import InferRequest, StdTemplateInputs, TemplateInputs
@@ -112,7 +113,7 @@ class Template(ProcessorMixin):
         self.template_backend = template_backend
         self.max_length = max_length
         self.truncation_strategy = truncation_strategy
-        self.loss_scale = loss_scale_map[loss_scale]()
+        self.loss_scale: LossScale = loss_scale_map[loss_scale]()
         self.max_pixels = max_pixels
         self.padding_side = padding_side
         self.sequence_parallel_size = sequence_parallel_size
@@ -956,9 +957,9 @@ class Template(ProcessorMixin):
                 labels += token_list
             else:
                 labels += [-100] * len(token_list)
-            if not self.loss_scale.is_binary:
+            if not self.loss_scale.is_loss_scale_binary:
                 loss_scale.extend([loss_weight] * len(token_list))
-        if self.loss_scale.is_binary:
+        if self.loss_scale.is_loss_scale_binary:
             loss_scale = None
         return input_ids, labels, loss_scale
 

--- a/swift/plugin/loss_scale/config/ignore_empty_think.json
+++ b/swift/plugin/loss_scale/config/ignore_empty_think.json
@@ -1,4 +1,4 @@
 {
-    "<think>\\s*</think>\\s*": [2.0],
+    "<think>\\s*</think>\\s*": [0.0],
     "<seed:think><seed:cot_budget_reflect>The current thinking budget is 0, so I will directly start answering the question.</seed:cot_budget_reflect>\n\n</seed:think>\\s*": [0.0]
 }

--- a/swift/plugin/loss_scale/config/ignore_empty_think.json
+++ b/swift/plugin/loss_scale/config/ignore_empty_think.json
@@ -1,4 +1,4 @@
 {
-    "<think>\\s*</think>\\s*": [0.0],
+    "<think>\\s*</think>\\s*": [2.0],
     "<seed:think><seed:cot_budget_reflect>The current thinking budget is 0, so I will directly start answering the question.</seed:cot_budget_reflect>\n\n</seed:think>\\s*": [0.0]
 }

--- a/swift/plugin/loss_scale/loss_scale.py
+++ b/swift/plugin/loss_scale/loss_scale.py
@@ -77,7 +77,7 @@ class LossScale:
 
     @property
     def is_loss_scale_binary(self):
-        if self.is_binary:
+        if self.is_binary is not None:
             return self.is_binary
         if self.loss_scale_map is None:
             return True

--- a/swift/plugin/loss_scale/loss_scale.py
+++ b/swift/plugin/loss_scale/loss_scale.py
@@ -15,7 +15,6 @@ class LossScale:
     # acceleration techniques such as liger_kernel.
     # If set to False, an additional 'loss_scale' key will be stored and the
     # corresponding loss function will be used.
-    is_binary = False
     loss_scale_config = None  # path
 
     def __init__(self):
@@ -75,13 +74,18 @@ class LossScale:
             res_loss_scale += loss_scale
         return res_context_list, res_loss_scale
 
+    @property
+    def is_binary(self):
+        if self.loss_scale_map is None:
+            return True
+        return all(scale == 0.0 or scale == 1.0 for lst in self.loss_scale_map.values() for scale in lst)
+
 
 class DefaultLossScale(LossScale):
-    is_binary = True
+    pass
 
 
 class LastRoundLossScale(LossScale):
-    is_binary = True
 
     def get_loss_scale(self, context: str, context_type: ContextType, is_last_round: bool, **kwargs):
         if context_type == ContextType.RESPONSE:
@@ -130,7 +134,6 @@ class AlphaUmiLossScale(REACTLossScale):
 
 
 class TrainAllLossScale(LossScale):
-    is_binary = True
 
     def get_loss_scale(self, context: str, context_type: ContextType, *args, **kwargs):
         return [context], [1.]
@@ -138,12 +141,10 @@ class TrainAllLossScale(LossScale):
 
 class IgnoreEmptyThink(REACTLossScale):
     loss_scale_config = 'ignore_empty_think.json'
-    is_binary = True
 
 
 class LastRoundWithIgnoreEmptyThink(LossScale):
     loss_scale_config = 'ignore_empty_think.json'
-    is_binary = True
 
     def get_loss_scale(self,
                        context: str,

--- a/swift/plugin/loss_scale/loss_scale.py
+++ b/swift/plugin/loss_scale/loss_scale.py
@@ -16,6 +16,7 @@ class LossScale:
     # If set to False, an additional 'loss_scale' key will be stored and the
     # corresponding loss function will be used.
     loss_scale_config = None  # path
+    is_binary = None
 
     def __init__(self):
         if self.loss_scale_config is not None:
@@ -75,7 +76,9 @@ class LossScale:
         return res_context_list, res_loss_scale
 
     @property
-    def is_binary(self):
+    def is_loss_scale_binary(self):
+        if self.is_binary:
+            return self.is_binary
         if self.loss_scale_map is None:
             return True
         return all(scale == 0.0 or scale == 1.0 for lst in self.loss_scale_map.values() for scale in lst)

--- a/swift/trainers/rlhf_trainer/utils.py
+++ b/swift/trainers/rlhf_trainer/utils.py
@@ -15,7 +15,7 @@ from peft.tuners import lora
 from peft.tuners.lora import LoraLayer
 from PIL import Image
 from torch import nn
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, RandomSampler
 from transformers import Trainer
 
 from swift.utils import is_swanlab_available, is_wandb_available
@@ -447,7 +447,7 @@ def get_chord_sft_dataloader(trainer,
 
     if not isinstance(dataset, torch.utils.data.IterableDataset):
         if sampler_fn is not None:
-            dataloader_params['sampler'] = sampler_fn(trainer, dataset)
+            dataloader_params['sampler'] = sampler_fn(dataset)
         dataloader_params['drop_last'] = trainer.args.dataloader_drop_last
         dataloader_params['prefetch_factor'] = trainer.args.dataloader_prefetch_factor
         if is_training:
@@ -474,7 +474,7 @@ def make_chord_sft_dataset(trainer, chord_sft_dataset):
             dataset=chord_sft_dataset,
             description='Training',
             batch_size=trainer.args.chord_sft_per_device_train_batch_size,
-            sampler_fn=Trainer._get_train_sampler,  # TODO
+            sampler_fn=RandomSampler,
             is_training=True,
         )
         return create_cyclic_iterator(chord_sft_dataloader)

--- a/swift/trainers/rlhf_trainer/utils.py
+++ b/swift/trainers/rlhf_trainer/utils.py
@@ -503,7 +503,7 @@ def compute_chord_loss(trainer, grpo_loss: torch.Tensor) -> torch.Tensor:
         sft_inputs = to_device(trainer.template.data_collator(sft_inputs), trainer.accelerator.device)
 
         labels = sft_inputs.pop('labels')
-        loss_scale = inputs.pop('loss_scale', None)
+        loss_scale = sft_inputs.pop('loss_scale', None)
         outputs = trainer.model(**sft_inputs)
         chord_sft_loss = per_token_loss_func(outputs, labels)
 
@@ -512,7 +512,7 @@ def compute_chord_loss(trainer, grpo_loss: torch.Tensor) -> torch.Tensor:
             phi = per_token_probs * (1 - per_token_probs)
             chord_sft_loss *= phi
 
-        if loss_scale:
+        if loss_scale is not None:
             loss_scale = torch.roll(loss_scale, shifts=-1, dims=-1).view(-1)
             chord_sft_loss *= loss_scale
 


### PR DESCRIPTION
1. Add loss-scale support for chord SFT loss.
2. Update the is_binary-checking logic in the template  loss_scale.
3. Ensure chord remains compatible with earlier transformers versions (e.g., 4.51).