### PR TITLE
[grpo] Support PYTORCH_CUDA_ALLOC_CONF environment variable

### DIFF
--- a/swift/trainers/rlhf_trainer/utils.py
+++ b/swift/trainers/rlhf_trainer/utils.py
@@ -534,3 +534,4 @@ def set_expandable_segments(enable: bool) -> None:
     if torch.cuda.is_available():
         torch.cuda.memory._set_allocator_settings(f'expandable_segments:{enable}')
         _EXPANDABLE_SEGMENTS_SET = True
+        os.environ['PYTORCH_CUDA_ALLOC_CONF'] = f'expandable_segments:{enable}'

--- a/swift/trainers/rlhf_trainer/utils.py
+++ b/swift/trainers/rlhf_trainer/utils.py
@@ -524,14 +524,36 @@ _EXPANDABLE_SEGMENTS_SET = 'expandable_segments' in os.environ.get('PYTORCH_CUDA
 
 
 def set_expandable_segments(enable: bool) -> None:
-    """Enable or disable expandable segments for cuda.
+    """
+    Enable or disable expandable segments for CUDA memory allocation.
+
+    This function provides a safe way to configure CUDA expandable segments without
+    overriding user preferences. It only takes effect when the user has previously
+    set the PYTORCH_CUDA_ALLOC_CONF environment variable, ensuring that explicit
+    user configurations are respected.
+
+    Expandable segments allow PyTorch to grow memory pools dynamically, which can
+    help prevent out-of-memory (OOM) errors during long-running reinforcement
+    learning training sessions by reducing memory fragmentation.
+
     Args:
-        enable (bool): Whether to enable expandable segments. Used to avoid OOM.
+        enable (bool): Whether to enable expandable segments. When True, allows
+            CUDA memory pools to expand dynamically to reduce fragmentation and
+            mitigate OOM issues.
+
+    Note:
+        - Only takes effect if PYTORCH_CUDA_ALLOC_CONF was previously set by the user
+        - Requires CUDA to be available
+        - Changes apply to both the PyTorch allocator settings and environment variable
+
+    Example:
+        >>> # Only works if user has already set PYTORCH_CUDA_ALLOC_CONF
+        >>> set_expandable_segments(True)  # Enable to help with OOM issues
+        >>> set_expandable_segments(False) # Disable for more predictable memory usage
     """
     global _EXPANDABLE_SEGMENTS_SET
     if not _EXPANDABLE_SEGMENTS_SET:
         return
     if torch.cuda.is_available():
         torch.cuda.memory._set_allocator_settings(f'expandable_segments:{enable}')
-        _EXPANDABLE_SEGMENTS_SET = True
         os.environ['PYTORCH_CUDA_ALLOC_CONF'] = f'expandable_segments:{enable}'


### PR DESCRIPTION
Support the environment variable PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True" in GRPO when using vLLM