### PR TITLE
Add the support for vLLM data parallel configuration in SwiftDeploy

### DIFF
--- a/swift/llm/infer/deploy.py
+++ b/swift/llm/infer/deploy.py
@@ -35,8 +35,7 @@ class SwiftDeploy(SwiftInfer):
         if isinstance(args, DeployArguments) and args.infer_backend == 'vllm' and args.vllm_data_parallel_size > 1:
             if not args.vllm_use_async_engine:
                 raise ValueError('vLLM data parallel requires `vllm_use_async_engine=True` in deploy mode.')
-            engine_kwargs = kwargs.pop('engine_kwargs', None) or {}
-            engine_kwargs = dict(engine_kwargs)
+            engine_kwargs = (kwargs.get('engine_kwargs') or {}).copy()
             engine_kwargs.setdefault('data_parallel_size', args.vllm_data_parallel_size)
             kwargs['engine_kwargs'] = engine_kwargs
             logger.info(f'Enable vLLM data parallel with size {args.vllm_data_parallel_size}.')


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [X] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This pull request introduces an enhancement to the deployment logic for the inference engine, specifically to support vLLM data parallelism in deploy mode. The main change is the addition of a static method to configure the inference engine with appropriate parameters when using vLLM with data parallelism.

Enhancements to vLLM deployment support:

* Added a static method `get_infer_engine` to `SwiftDeploy` that configures the inference engine for vLLM data parallelism, ensuring that `vllm_use_async_engine` is enabled and setting the `data_parallel_size` parameter as needed. This helps prevent misconfiguration and improves support for distributed inference.
* Updated imports to include `InferArguments` from `swift.llm`, which is required for the new method.

Solved #6097.

## Experiment results

example script:

```
CUDA_VISIBLE_DEVICES=0,1 \
MAX_PIXELS=1003520 \
swift deploy \
    --model model/Qwen/Qwen2.5-VL-7B-Instruct \
    --infer_backend vllm \
    --vllm_data_parallel_size 2 \
    --gpu_memory_utilization 0.9 \
    --max_model_len 32768 \
    --max_new_tokens 2048 \
    --served_model_name Qwen2.5-VL-7B-Instruct \
```

