### PR TITLE
[Feature] Update loss_scale method call to pass through inputs.extra_kwargs

### DIFF
--- a/swift/llm/template/base.py
+++ b/swift/llm/template/base.py
@@ -1146,7 +1146,8 @@ class Template(ProcessorMixin):
         if template_meta.auto_add_bos and sep_token:
             res_context_list.append(sep_token)
             res_context_types.append(ContextType.SUFFIX)
-        res_context_list, loss_scale_list = self.loss_scale(res_context_list, res_context_types, inputs.messages)
+        res_context_list, loss_scale_list = self.loss_scale(res_context_list, res_context_types, inputs.messages,
+                                                            **inputs.extra_kwargs)
         if self.is_training:
             answer_len = len(extra_context_list) + bool(response is not None)
         else:
@@ -1673,7 +1674,7 @@ class Template(ProcessorMixin):
                 seq_len = max(seq_lens) if padding_to is None else padding_to
                 res['attention_mask'] = torch.tril(torch.ones(
                     (len(seq_lens), seq_len, seq_len), dtype=torch.bool)).view(len(seq_lens), 1, seq_len, seq_len)
-                assert res['attention_mask'].dtype is torch.bool, f'attention_mask.dtype: {res["attention_mask"].dtype}'
+                assert res['attention_mask'].dtype is torch.bool, f'attention_mask.dtype: {res['attention_mask'].dtype}'
                 for i, seq_len in enumerate(seq_lens):
                     res['attention_mask'][i, :, seq_len:] = 0
 


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## 问题描述
在 `swift/llm/template/base.py` 中调用 `self.loss_scale` 时，没有将额外的参数传递给底层的 `get_loss_scale` 函数，导致用户无法通过数据集样本自定义参数来灵活控制 loss_scale行为。

## 修改内容
**文件：** `swift/llm/template/base.py`

**修改前：**
```python
res_context_list, loss_scale_list = self.loss_scale(res_context_list, res_context_types, inputs.messages)
```

**修改后：**
```python
res_context_list, loss_scale_list = self.loss_scale(res_context_list, res_context_types, inputs.messages,
                                                            **inputs.extra_kwargs)
```
get_loss_scale 函数签名原本就支持额外的 **kwargs 参数：
```python
def get_loss_scale(self, context: str, context_type: ContextType, is_last_round: bool, **kwargs) -> Tuple[List[str], List[float]]:
```
但在template base.py的调用处没有利用这一特性，导致额外的参数无法传递

- 用户现在可以在数据集的样本中定义 extra_kwargs，通过这些参数来自定义loss_scale
- 无破坏性修改：完全向后兼容，不影响现有代码的正常运行
- 支持高级用法：例如：
    基于样本难度动态调整损失权重
    根据任务类型应用不同的缩放策略

## Experiment results

已在qwen3-omni模型的megatron sft训练和qwen2.5-omni模型的deepspeed sft 训练中试验了该功能。具体为：在样本中增加extra_kwargs ，自定义loss_scale根据这些extra_kwargs 调整 loss_scale , 模型性能提升。

该修改为框架基础设施优化，不直接影响模型性能指标，但显著提升了框架的灵活性和可定制性，为用户实现更精细化的训练控制提供了可能。
