### PR TITLE
[bugfix] fix grpo padding-free get logps

### DIFF
--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -1212,6 +1212,9 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
         use_local_entropy = not hasattr(super(), '_get_per_token_logps_and_entropies') and compute_entropy
 
         can_use_super = (not self.is_multimodal and 'logits_to_keep' in parameters and not use_local_entropy)
+        if 'attention_mask' not in inputs:
+            # when set padding_free true, the attention_mask is not in inputs
+            can_use_super = False
 
         if can_use_super:
             # save memory


### PR DESCRIPTION
When padding_free is enabled, the inputs do not contain attention_mask information; in this case, the internal get_logps function should be used.