### PR TITLE
[model] support MiniMax/MiniMax-M2

### DIFF
--- a/docs/source/Instruction/支持的模型和数据集.md
+++ b/docs/source/Instruction/支持的模型和数据集.md
@@ -536,6 +536,7 @@
 |[MiniMax/MiniMax-Text-01](https://modelscope.cn/models/MiniMax/MiniMax-Text-01)|minimax|minimax|-|&#x2718;|-|[MiniMaxAI/MiniMax-Text-01](https://huggingface.co/MiniMaxAI/MiniMax-Text-01)|
 |[MiniMax/MiniMax-M1-40k](https://modelscope.cn/models/MiniMax/MiniMax-M1-40k)|minimax_m1|minimax_m1|-|&#x2718;|-|[MiniMaxAI/MiniMax-M1-40k](https://huggingface.co/MiniMaxAI/MiniMax-M1-40k)|
 |[MiniMax/MiniMax-M1-80k](https://modelscope.cn/models/MiniMax/MiniMax-M1-80k)|minimax_m1|minimax_m1|-|&#x2718;|-|[MiniMaxAI/MiniMax-M1-80k](https://huggingface.co/MiniMaxAI/MiniMax-M1-80k)|
+|[MiniMax/MiniMax-M2](https://modelscope.cn/models/MiniMax/MiniMax-M2)|minimax_m2|minimax_m2|-|&#x2718;|-|[MiniMaxAI/MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2)|
 |[AI-ModelScope/gemma-2b-it](https://modelscope.cn/models/AI-ModelScope/gemma-2b-it)|gemma|gemma|transformers>=4.38|&#x2718;|-|[google/gemma-2b-it](https://huggingface.co/google/gemma-2b-it)|
 |[AI-ModelScope/gemma-2b](https://modelscope.cn/models/AI-ModelScope/gemma-2b)|gemma|gemma|transformers>=4.38|&#x2718;|-|[google/gemma-2b](https://huggingface.co/google/gemma-2b)|
 |[AI-ModelScope/gemma-7b](https://modelscope.cn/models/AI-ModelScope/gemma-7b)|gemma|gemma|transformers>=4.38|&#x2718;|-|[google/gemma-7b](https://huggingface.co/google/gemma-7b)|

--- a/docs/source_en/Instruction/Supported-models-and-datasets.md
+++ b/docs/source_en/Instruction/Supported-models-and-datasets.md
@@ -536,6 +536,7 @@ The table below introduces the models integrated with ms-swift:
 |[MiniMax/MiniMax-Text-01](https://modelscope.cn/models/MiniMax/MiniMax-Text-01)|minimax|minimax|-|&#x2718;|-|[MiniMaxAI/MiniMax-Text-01](https://huggingface.co/MiniMaxAI/MiniMax-Text-01)|
 |[MiniMax/MiniMax-M1-40k](https://modelscope.cn/models/MiniMax/MiniMax-M1-40k)|minimax_m1|minimax_m1|-|&#x2718;|-|[MiniMaxAI/MiniMax-M1-40k](https://huggingface.co/MiniMaxAI/MiniMax-M1-40k)|
 |[MiniMax/MiniMax-M1-80k](https://modelscope.cn/models/MiniMax/MiniMax-M1-80k)|minimax_m1|minimax_m1|-|&#x2718;|-|[MiniMaxAI/MiniMax-M1-80k](https://huggingface.co/MiniMaxAI/MiniMax-M1-80k)|
+|[MiniMax/MiniMax-M2](https://modelscope.cn/models/MiniMax/MiniMax-M2)|minimax_m2|minimax_m2|-|&#x2718;|-|[MiniMaxAI/MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2)|
 |[AI-ModelScope/gemma-2b-it](https://modelscope.cn/models/AI-ModelScope/gemma-2b-it)|gemma|gemma|transformers>=4.38|&#x2718;|-|[google/gemma-2b-it](https://huggingface.co/google/gemma-2b-it)|
 |[AI-ModelScope/gemma-2b](https://modelscope.cn/models/AI-ModelScope/gemma-2b)|gemma|gemma|transformers>=4.38|&#x2718;|-|[google/gemma-2b](https://huggingface.co/google/gemma-2b)|
 |[AI-ModelScope/gemma-7b](https://modelscope.cn/models/AI-ModelScope/gemma-7b)|gemma|gemma|transformers>=4.38|&#x2718;|-|[google/gemma-7b](https://huggingface.co/google/gemma-7b)|

--- a/swift/llm/model/constant.py
+++ b/swift/llm/model/constant.py
@@ -105,6 +105,7 @@ class LLMModelType:
 
     minimax = 'minimax'
     minimax_m1 = 'minimax_m1'
+    minimax_m2 = 'minimax_m2'
 
     gemma = 'gemma'
     gemma2 = 'gemma2'

--- a/swift/llm/model/model/minimax.py
+++ b/swift/llm/model/model/minimax.py
@@ -158,3 +158,14 @@ register_model(
         TemplateType.minimax_m1,
         get_model_tokenizer_minimax_text,
         architectures=['MiniMaxM1ForCausalLM']))
+
+register_model(
+    ModelMeta(
+        LLMModelType.minimax_m2, [
+            ModelGroup([
+                Model('MiniMax/MiniMax-M2', 'MiniMaxAI/MiniMax-M2'),
+            ]),
+        ],
+        TemplateType.minimax_m2,
+        get_model_tokenizer_with_flash_attn,
+        architectures=['MiniMaxM2ForCausalLM']))

--- a/swift/llm/template/constant.py
+++ b/swift/llm/template/constant.py
@@ -36,6 +36,7 @@ class LLMTemplateType:
 
     minimax = 'minimax'
     minimax_m1 = 'minimax_m1'
+    minimax_m2 = 'minimax_m2'
     minimax_vl = 'minimax_vl'
 
     numina = 'numina'

--- a/swift/llm/template/template/minimax.py
+++ b/swift/llm/template/template/minimax.py
@@ -119,3 +119,14 @@ class MinimaxVLTemplate(Template):
 
 
 register_template(MinimaxTemplateMeta(LLMTemplateType.minimax_vl, template_cls=MinimaxVLTemplate))
+
+register_template(
+    TemplateMeta(
+        LLMTemplateType.minimax_m2,
+        prefix=[']~!b[]~b]system\n{{SYSTEM}}[e~[\n'],
+        prompt=[']~b]user\n{{QUERY}}[e~[\n]~b]ai\n'],
+        chat_sep=['[e~[\n'],
+        suffix=['[e~['],
+        default_system='You are a helpful assistant.',
+        response_prefix='<think>\n',
+    ))


### PR DESCRIPTION

```
uv pip install 'triton-kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels'  vllm --extra-index-url https://wheels.vllm.ai/nightly --prerelease=allow

CUDA_VISIBLE_DEVICES=0,1,2,3 \
swift infer \
    --model MiniMax/MiniMax-M2 \
    --vllm_max_model_len 8192 \
    --vllm_enable_expert_parallel --vllm_tensor_parallel_size 4 \
    --infer_backend vllm
```

<img width="765" height="199" alt="截屏2025-10-27 13 40 14" src="https://github.com/user-attachments/assets/8b639de7-a34b-46c2-9e88-a407bf08657c" />

