### PR TITLE
[vllm] Filter out None values in vLLM initialization

### DIFF
--- a/swift/llm/infer/infer_engine/vllm_engine.py
+++ b/swift/llm/infer/infer_engine/vllm_engine.py
@@ -205,7 +205,8 @@ class VllmEngine(InferEngine):
                 'mm_processor_cache_gb'
         ]:
             if key in parameters:
-                engine_kwargs[key] = locals()[key]
+                if locals()[key] is not None:
+                    engine_kwargs[key] = locals()[key]
             else:
                 logger.warning(f'The current version of vLLM does not support `{key}`. Ignored.')
         for key in ['task', 'seed']:


### PR DESCRIPTION
Check for None-valued parameters and filter them out before initialization, using vLLM's default logic to avoid triggering Pydantic validation.

https://github.com/modelscope/ms-swift/issues/6290