### PR TITLE
[bugfix] remove response before filter encoded failed data

### DIFF
--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -1453,6 +1453,7 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
             while True:
                 try:
                     # Attempt to encode the current sample.
+                    remove_response(current_data['messages'])
                     template.encode(current_data)
                     # If successful, store the result and update the last valid data.
                     inputs[i] = current_data


### PR DESCRIPTION
As mentioned in https://github.com/modelscope/ms-swift/issues/6313, when truncation_strategy is set to delete, the template may dynamically resample data that failed encoding. When the dataset contains the response field, it should be removed before encoding to prevent the response length from being incorrectly included in length calculations.