### PR TITLE
Bug fix: Enable LoRA on MoE experts with 'all-linear'

### DIFF
--- a/swift/tuners/peft.py
+++ b/swift/tuners/peft.py
@@ -95,8 +95,8 @@ def _create_and_replace_hook(self, peft_config, adapter_name, target, *args, **k
 
     if isinstance(target_modules, str) and not any(
         [name in target.__class__.__name__.lower()
-         for name in all_supported_names]) and not any(
-            [isinstance(target, type_) for type_ in all_supported_types]) and not target_parameters:
+         for name in all_supported_names]) and not any([isinstance(target, type_)
+                                                        for type_ in all_supported_types]) and not target_parameters:
         return
 
     if target.__class__.__name__ == 'NonDynamicallyQuantizableLinear':


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR resolves an issue in LoRA training for MoE models (e.g., Qwen/Qwen3-VL-30B-A3B-Instruct). When both --target_modules all-linear and --target-parameters were specified, the LoRA adapters for the expert layers were being improperly filtered out instead of being applied.

## Experiment results

Paste your experiment result here(if needed).
