### PR TITLE
[bugfix] Reset prefix cache when syncing only LoRA adapters

### DIFF
--- a/swift/trainers/rlhf_trainer/rollout_mixin.py
+++ b/swift/trainers/rlhf_trainer/rollout_mixin.py
@@ -362,7 +362,7 @@ class RolloutTrainerMixin(RLHFTrainerMixin):
         if self.vllm_mode == 'server' and self.accelerator.is_main_process:
             self.vllm_client.reset_prefix_cache()
         elif self.vllm_mode == 'colocate':
-            self.engine.engine.reset_prefix_cache()  
+            self.engine.engine.reset_prefix_cache()
 
     def _move_adapter_to_vllm(self):
         """Transfer LoRA adapter weights to vLLM engine"""


### PR DESCRIPTION
Fix bug where prefix cache is not reset when only synchronizing LoRA adapters