### PR TITLE
[Fix Bug] Enhance `ProgressCallbackNew` to initialize training bar with current step

### DIFF
--- a/swift/trainers/callback.py
+++ b/swift/trainers/callback.py
@@ -44,11 +44,10 @@ def add_train_message(logs, state, start_time) -> None:
 class ProgressCallbackNew(ProgressCallback):
 
     def on_train_begin(self, args, state, control, **kwargs):
-        initial_step = state.global_step if state.global_step is not None else 0
+        initial_step = state.global_step or 0
         if state.is_world_process_zero:
             bar_initial = min(initial_step, state.max_steps) if state.max_steps else initial_step
-            self.training_bar = tqdm(
-                desc='Train', total=state.max_steps, initial=bar_initial, dynamic_ncols=True)
+            self.training_bar = tqdm(desc='Train', total=state.max_steps, initial=bar_initial, dynamic_ncols=True)
         self.current_step = initial_step
         self.start_time = time.time()
 


### PR DESCRIPTION
# PR type
- [X] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# Bug information

I found that if I pass the `resume_from_checkpoint` parameter, tqdm function in the `swift/trainers/callback.py` calculate the progress incorrectly.

# PR information

This pull request makes a minor improvement to the training progress bar initialization in the `ProgressCallbackNew` class. The main change ensures that the progress bar accurately reflects the current training step when resuming from a checkpoint or a non-zero step.

- Progress bar initialization improvement:
  * The progress bar in `ProgressCallbackNew.on_train_begin` now starts at the correct step (`state.global_step` or 0) instead of always starting at zero. This ensures accurate progress reporting when training is resumed from a checkpoint. (`swift/trainers/callback.py`)
