### PR TITLE
Add npu fused operators supported in modeling_qwen2

### DIFF
--- a/swift/llm/model/__init__.py
+++ b/swift/llm/model/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
+from transformers.utils import is_torch_npu_available
+
 from . import model
 from .constant import LLMModelType, MLLMModelType, ModelType
 from .model_arch import MODEL_ARCH_MAPPING, ModelArch, ModelKeys, MultiModelKeys, get_model_arch, register_model_arch
@@ -7,3 +9,6 @@ from .register import (MODEL_MAPPING, Model, ModelGroup, ModelMeta, fix_do_sampl
                        get_model_tokenizer, get_model_tokenizer_multimodal, get_model_tokenizer_with_flash_attn,
                        load_by_unsloth, register_model)
 from .utils import HfConfigFactory, ModelInfo, get_llm_model, git_clone_github, safe_snapshot_download
+
+if is_torch_npu_available():
+    from . import npu_patcher

--- a/swift/llm/model/npu_patcher.py
+++ b/swift/llm/model/npu_patcher.py
@@ -1,0 +1,38 @@
+# Copyright (c) Alibaba, Inc. and its affiliates.
+import torch
+import torch_npu
+from torch import nn
+from transformers.models.qwen2 import modeling_qwen2
+
+
+class NpuRMSNorm(nn.Module):
+
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        return torch_npu.npu_rms_norm(hidden_states, self.weight, epsilon=self.variance_epsilon)[0]
+
+    def extra_repr(self):
+        return f'{tuple(self.weight.shape)}, eps={self.variance_epsilon}'
+
+
+def npu_apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors."""
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = torch_npu.npu_rotary_mul(q, cos, sin)
+    k_embed = torch_npu.npu_rotary_mul(k, cos, sin)
+    return q_embed, k_embed
+
+
+def npu_swiglu_forward(self, hidden_state):
+    return self.down_proj(
+        torch_npu.npu_swiglu(torch.cat((self.gate_proj(hidden_state), self.up_proj(hidden_state)), dim=-1), dim=-1))
+
+
+modeling_qwen2.Qwen2RMSNorm = NpuRMSNorm
+modeling_qwen2.apply_rotary_pos_emb = npu_apply_rotary_pos_emb
+modeling_qwen2.Qwen2MLP.forward = npu_swiglu_forward


### PR DESCRIPTION
Add npu fused operators supported in modeling_qwen2, include RMSNorm, SwiGLU and RoPE

# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR adds support for NPU fused operators in ms-swift, enhance the training performance on ascend npu.

This PR now adapt flowing fused operators for Qwen2:  RMSNorm, SwiGLU and RoPE.In future, we can add more supported models and fused operators.

## Experiment results

Paste your experiment result here(if needed).
