### PR TITLE
Initialize chord dataset after accelerator setup in GRPOTrainer

### DIFF
--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -81,6 +81,7 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
         reward_templates = kwargs.pop('reward_template', None)
         self._prepare_algorithm_params()
         super().__init__(model, ref_model, *_args, **kwargs)
+        self._prepare_chord_dataset()
         self.prepare_rollout()
         self._prepare_rewards(reward_funcs, reward_model, reward_templates)
 
@@ -1868,6 +1869,7 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
         self.advantage_estimator = args.advantage_estimator
         self.kl_in_reward = args.kl_in_reward
 
+    def _prepare_chord_dataset(self):
         # CHORD, https://arxiv.org/abs/2508.11408
         self.chord_sft_iterator = None
         if self.chord_sft_dataset:


### PR DESCRIPTION
# PR type
- [*] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
The get_chord_sft_dataloader() method relies on the existence of attribute "GRPOTrainer.accelerator", but it was called before the parent class (super().\_\_init__()) finished initializing the attribute "accelerator" (This initialization occurs in swift/trainers/rlhf_trainer/grpo_trainer.py, line 82).  As a result, calling get_chord_sft_dataloader() raises an exception because the "accelerator" attribute does not yet exist.

Hope it helps. Thank you.

## Experiment results
Command:
swift rlhf
--model Qwen/Qwen3-VL-8B-Instruct --dataset /data/pokemon/data.json --split_dataset_ratio 0.01 --num_train_epochs 8 --eval_steps 100 --save_steps 100 --save_total_limit 5 --logging_steps 50 --warmup_r
atio 0.1 --dataloader_num_workers 8 --dataset_num_proc 2 --lr_scheduler_type cosine --load_from_cache_file true --gradient_checkpointing true --report_to all --use_hf true --torch_dtype bfloat16 --log_completions true --deepspeed zero3 --max_le
ngth 4096 --max_completion_length 2048 --freeze_vit true --target_modules all-linear --per_device_train_batch_size 1 --per_device_eval_batch_size 2 --gradient_accumulation_steps 4 --rlhf_type grpo --num_generations 8 --temperature 1.0 --bet
a 0.001 --external_plugins /pokemon.py --reward_funcs pokemon_grpo_format pokemon_grpo_acc repetition --use_vllm true --vllm_mode colocate --vllm_gpu_memory_utilization 0.4 --vllm_tensor
_parallel_size 1 --vllm_max_model_len 4096 --vllm_data_parallel_size 8
--train_type lora --output_dir saved/grpo-e3-r8-b1-beta3-chord --learning_rate 1e-3 --lora_rank 8 --lora_alpha 16
--chord_sft_per_device_train_batch_size 1 --chord_sft_dataset /data/pokemon/data.json --chord_enable_phi_function false --chord_mu_warmup_steps 25 --chord_mu_decay_steps 300 --chord_mu_pea
k 0.75 --chord_mu_valley 0.15

Exception (in rank1):
[rank1]: Traceback (most recent call last):
[rank1]: File "/ms-swift/swift/cli/rlhf.py", line 7, in
[rank1]: rlhf_main()
[rank1]: File "/ms-swift/swift/llm/train/rlhf.py", line 227, in rlhf_main
[rank1]: return SwiftRLHF(args).main()
[rank1]: ^^^^^^^^^^^^^^^^^^^^^^
[rank1]: File "/ms-swift/swift/llm/base.py", line 49, in main
[rank1]: result = self.run()
[rank1]: ^^^^^^^^^^
[rank1]: File "/ms-swift/swift/ray/base.py", line 170, in wrapper
[rank1]: return func(self, *args, **kwargs)
[rank1]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]: File "/ms-swift/swift/llm/train/sft.py", line 196, in run
[rank1]: trainer = trainer_cls(
[rank1]: ^^^^^^^^^^^^
[rank1]: File "/ms-swift/swift/trainers/rlhf_trainer/grpo_trainer.py", line 81, in init
[rank1]: self._prepare_algorithm_params()
[rank1]: File "/ms-swift/swift/trainers/rlhf_trainer/grpo_trainer.py", line 1867, in _prepare_algorithm_params
[rank1]: self.chord_sft_iterator = make_chord_sft_dataset(self, self.chord_sft_dataset) [rank1]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [rank1]: File "/ms-swift/swift/trainers/rlhf_trainer/utils.py", line 934, in make_chord_sft_dataset [rank1]: chord_sft_dataloader = get_chord_sft_dataloader( [rank1]: ^^^^^^^^^^^^^^^^^^^^^^^^^ [rank1]: File "/ms-swift/swift/trainers/rlhf_trainer/utils.py", line 920, in get_chord_sft_dataloader
[rank1]: dataloader = trainer.accelerator.prepare(DataLoader(dataset, **dataloader_params))
[rank1]: ^^^^^^^^^^^^^^^^^^^
[rank1]: AttributeError: 'GRPOTrainer' object has no attribute 'accelerator'

