### PR TITLE
[bugfix] getattr error for activation_offloading in RM training

### DIFF
--- a/swift/trainers/rlhf_trainer/reward_trainer.py
+++ b/swift/trainers/rlhf_trainer/reward_trainer.py
@@ -26,7 +26,7 @@ class RewardTrainer(RLHFTrainerMixin, SwiftMixin, HFRewardTrainer):
         super().__init__(*args, **kwargs)
         try:
             from trl.models import get_act_offloading_ctx_manager
-            if self.args.activation_offloading:
+            if getattr(self.args, 'activation_offloading', False):
                 self.maybe_activation_offload_context = get_act_offloading_ctx_manager(model=self.model)
             else:
                 self.maybe_activation_offload_context = nullcontext()


### PR DESCRIPTION
Fix a bug with TRL < 0.24, where rm_config does not have the activation_offloading attribute.