### PR TITLE
fix type_type=rm eval trl>=0.25

### DIFF
--- a/swift/trainers/rlhf_trainer/reward_trainer.py
+++ b/swift/trainers/rlhf_trainer/reward_trainer.py
@@ -6,7 +6,9 @@ from typing import Any, Dict, Tuple, Union
 import pandas as pd
 import torch
 import torch.nn as nn
+import trl
 from accelerate.utils import gather_object
+from packaging import version
 from transformers import PreTrainedModel
 from trl import RewardTrainer as HFRewardTrainer
 from trl.trainer.utils import print_rich_table
@@ -33,9 +35,10 @@ class RewardTrainer(RLHFTrainerMixin, SwiftMixin, HFRewardTrainer):
         except ImportError:
             self.maybe_activation_offload_context = nullcontext()
         self._metrics = {'train': defaultdict(list), 'eval': defaultdict(list)}
-        # During evaluation, Trainer calls compute_loss() only if can_return_loss is True and label_names is empty.
-        self.can_return_loss = True
-        self.label_names = []
+        if version.parse(trl.__version__) >= version.parse('0.24'):
+            # During evaluation, Trainer calls compute_loss() only if can_return_loss is True and label_names is empty.
+            self.can_return_loss = True
+            self.label_names = []
 
     def compute_loss(self,
                      model: Union[PreTrainedModel, nn.Module],


### PR DESCRIPTION
Error:
```
[rank0]: KeyError: "The `metric_for_best_model` training argument is set to 'eval_loss', which is not found in the evaluation metrics. The available evaluation metrics are: ['eval_runtime', 'eval_samples_per_second', 'eval_steps_per_second', 'epoch', 'global_step/max_steps', 'percentage', 'elapsed_time', 'remaining_time', 'memory(GiB)', 'train_speed(iter/s)']. Consider changing the `metric_for_best_model` via the TrainingArguments."
```