### PR TITLE
[megatron, GRPO] fix: CP/padding_free repeat_interleave mismatch

### DIFF
--- a/swift/megatron/trainers/grpo_trainer.py
+++ b/swift/megatron/trainers/grpo_trainer.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from contextlib import contextmanager, nullcontext
 from copy import copy, deepcopy
 from functools import partial
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import json
 import pandas as pd
@@ -497,40 +497,27 @@ class MegatronGRPOTrainer(MegatronRLHFTrainer):
         def _get_encoded_batch(rollout_batch, advantages):
             template = self.template
             with self._template_context(template):
-                encoded_batch = [template.encode(data, return_length=True) for data in rollout_batch]
+                encoded_list = [template.encode(data, return_length=True) for data in rollout_batch]
+                lengths_tensor = torch.tensor([item['length'] for item in encoded_list],
+                                              dtype=torch.long,
+                                              device=self.device)
                 encoded_batch = to_device(
-                    template.data_collator(encoded_batch, padding_to=get_padding_to(args)), self.device)
+                    template.data_collator(encoded_list, padding_to=get_padding_to(args)), self.device)
             labels = encoded_batch['labels']
             assert self.template.padding_free
-            position_ids = encoded_batch.get('text_position_ids')
-            if position_ids is None:
-                position_ids = encoded_batch.get('position_ids')
-            squeezed_position_ids = position_ids.squeeze()
-            assert squeezed_position_ids is not None
-            # Remove trailing padding zeros from position_ids to avoid interference
-            # Find the last non-zero position
-            last_nonzero_idx = (squeezed_position_ids != 0).nonzero(as_tuple=True)[0]
-            if len(last_nonzero_idx) > 0:
-                # Keep only up to the last non-zero position + 1 to include the last valid position
-                squeezed_position_ids = squeezed_position_ids[:last_nonzero_idx[-1] + 1]
-
-            # Calculate lengths based on sequence boundaries (position_ids == 0)
-            lengths = torch.diff(
-                torch.cat([(squeezed_position_ids == 0).nonzero(as_tuple=True)[0],
-                           torch.tensor([len(squeezed_position_ids)]).to(squeezed_position_ids.device)]))
-            advantages = torch.repeat_interleave(advantages, lengths)
+            advantages = torch.repeat_interleave(advantages, lengths_tensor)
             truncated_mask = torch.tensor([b['is_truncated'] for b in rollout_batch],
                                           dtype=torch.bool,
                                           device=self.device)
-            truncated_mask = torch.repeat_interleave(truncated_mask, lengths).unsqueeze(0)
-            padding_length = labels.shape[1] - truncated_mask.shape[1]
+            truncated_mask = torch.repeat_interleave(truncated_mask, lengths_tensor).unsqueeze(0)
+            actual_tokens = lengths_tensor.sum().item()
+            padding_length = labels.shape[1] - actual_tokens
             if padding_length > 0:
                 padding = torch.zeros((1, padding_length), device=truncated_mask.device, dtype=truncated_mask.dtype)
                 truncated_mask = torch.cat([truncated_mask, padding], dim=1)
             # Pad advantages to match the original position_ids length
-            original_length = position_ids.shape[1]
-            if advantages.shape[0] < original_length:
-                padding_length = original_length - advantages.shape[0]
+            if advantages.shape[0] < labels.shape[1]:
+                padding_length = labels.shape[1] - advantages.shape[0]
                 padding = torch.zeros(padding_length, device=advantages.device, dtype=advantages.dtype)
                 advantages = torch.cat([advantages, padding])
 
@@ -540,7 +527,7 @@ class MegatronGRPOTrainer(MegatronRLHFTrainer):
                 'truncated_mask': truncated_mask,
                 'advantages': advantages,
                 'num_samples': len(rollout_batch),
-                'seq_lengths': lengths,
+                'seq_lengths': lengths_tensor,
             })
 
             return encoded_batch
@@ -1054,9 +1041,37 @@ class MegatronGRPOTrainer(MegatronRLHFTrainer):
                                                  + 1] - packed_seq_params.cu_seqlens_q[:micro_batch_size]
         lengths_with_padding = packed_seq_params.cu_seqlens_q[1:] - packed_seq_params.cu_seqlens_q[:-1]
 
+        target_token_count = completion_mask.shape[-1]
+        lengths_total = lengths_with_padding.sum().item()
+        if lengths_total != target_token_count:
+            lengths_with_padding = lengths_with_padding.clone()
+            diff = target_token_count - lengths_total
+            lengths_with_padding[-1] = lengths_with_padding[-1] + diff
+            if lengths_with_padding[-1] <= 0:
+                raise RuntimeError('Invalid packed sequence metadata: negative padded length after adjustment.')
+
+        def _pad_or_trim_last_dim(tensor: Optional[torch.Tensor], target_len: int) -> Optional[torch.Tensor]:
+            if tensor is None:
+                return None
+            current_len = tensor.shape[-1]
+            if current_len == target_len:
+                return tensor
+            if current_len < target_len:
+                pad_shape = (*tensor.shape[:-1], target_len - current_len)
+                padding = torch.zeros(pad_shape, device=tensor.device, dtype=tensor.dtype)
+                return torch.cat([tensor, padding], dim=-1)
+            return tensor[..., :target_len]
+
         # get_logps with per_token=True now returns full sequences (all_gather in CP mode)
         per_token_logps = self.get_logps(
             output_tensor, labels, packed_seq_params, packed_seq_params.num_samples, per_token=True)
+        per_token_logps = _pad_or_trim_last_dim(per_token_logps, target_token_count)
+
+        if self.beta != 0.0:
+            data['ref_per_token_logps'] = _pad_or_trim_last_dim(data.get('ref_per_token_logps'), target_token_count)
+
+        if data.get('old_per_token_logps') is not None:
+            data['old_per_token_logps'] = _pad_or_trim_last_dim(data['old_per_token_logps'], target_token_count)
 
         if self.args.overlong_filter and truncated_mask.any():
             completion_mask = completion_mask & (~truncated_mask)


### PR DESCRIPTION
# PR type
- [X] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR fix the logic to ensure template encoding captures true packed lengths and propagates them through seq_lengths, advantages expansion, and truncation masks. It normalizes packed-sequence metadata in loss_func by aligning lengths_with_padding with the completion tensor width and padding/trimming per-token log-probabilities so downstream splits stay consistent. It guards against invalid metadata by validating the adjusted final length and reusing the helper for ref/old log-probs.

Error stack trace:
```logs
Traceback (most recent call last):
 File "ms-swift/swift/cli/_megatron/rlhf.py", line 5, in <module>
   megatron_rlhf_main()
 File "ms-swift/swift/megatron/train/rlhf.py", line 70, in megatron_rlhf_main
   return MegatronRLHF(args).main()
 File "ms-swift/swift/llm/base.py", line 49, in main
   result = self.run()
 File "ms-swift/swift/megatron/train/sft.py", line 63, in run
   self.trainer.train(train_dataset, val_dataset, data_collator)
 File "ms-swift/swift/megatron/trainers/grpo_trainer.py", line 66, in train
   super().train(train_dataset, val_dataset, data_collator)
 File "ms-swift/swift/megatron/trainers/base.py", line 990, in train
   pretrain(
 File "megatron/training/training.py", line 710, in pretrain
   iteration, num_floating_point_operations_so_far = train(
 File "megatron/training/training.py", line 2122, in train
   ) = train_step(
 File "ms-swift/swift/megatron/trainers/base.py", line 496, in train_step
   new_data_iterator = self._replace_data_iterator(data_iterator, model)
 File "ms-swift/swift/megatron/trainers/grpo_trainer.py", line 468, in _replace_data_iterator
   micro_batch_data = self._generate_and_score_completions(rollout_batch)
 File "ms-swift/swift/megatron/trainers/grpo_trainer.py", line 557, in _generate_and_score_completions
   micro_batch_data = _get_encoded_batch(micro_batch_data, micro_batch_advantages)
 File "ms-swift/swift/megatron/trainers/grpo_trainer.py", line 521, in _get_encoded_batch
   advantages = torch.repeat_interleave(advantages, lengths)
RuntimeError: repeats must have the same size as input along dim, but got repeats.size(0) = 2 and input.size(0) = 1
```

## Experiment results

Script to reproduce on with 8 GPUs:

```bash
HF_HOME=${HF_HOME:-"/models"}
MODEL=${MODEL:-"Qwen/Qwen3-30B-A3B"}
LORA_RANK=${LORA_RANK:-8}
LORA_ALPHA=${LORA_ALPHA:-16}
COMMON_TP=${COMMON_TP:-4}
COMMON_EP=${COMMON_EP:-8}
COMMON_PP=${COMMON_PP:-1}
COMMON_CP=${COMMON_CP:-2}
INFER_TP=${INFER_TP:-4}

CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
NNODES=1 \
NODE_RANK=0 \
MASTER_ADDR=127.0.0.1 \
MASTER_PORT=29500 \
NPROC_PER_NODE=8 \
PYTORCH_CUDA_ALLOC_CONF='expandable_segments:True' \
megatron rlhf \
    --rlhf_type grpo \
    --model "$HF_HOME/$MODEL" \
    --load_safetensors true \
    --save_safetensors true \
    --context_parallel_size $COMMON_CP \
    --tensor_model_parallel_size $COMMON_TP \
    --expert_model_parallel_size $COMMON_EP \
    --expert_tensor_parallel_size 1 \
    --pipeline_model_parallel_size $COMMON_PP \
    --dataset 'zouxuhong/Countdown-Tasks-3to4#50000' \
    --system 'You are a helpful assistant. You first thinks about the reasoning process in the mind and then provides the user with the answer.' \
    --max_epochs 1 \
    --global_batch_size 16 \
    --micro_batch_size 1 \
    --steps_per_generation 2 \
    --num_generations 8 \
    --external_plugins /workspace/ms-swift/examples/train/grpo/plugin/plugin.py \
    --reward_funcs external_countdown format \
    --use_vllm true \
    --vllm_mode colocate \
    --vllm_gpu_memory_utilization 0.3 \
    --vllm_tensor_parallel_size $INFER_TP \
    --vllm_max_model_len 4096 \
    --max_length 2048 \
    --max_completion_length 2048 \
    --train_type lora \
    --lora_rank $LORA_RANK \
    --lora_alpha $LORA_ALPHA \
    --lr 5e-5 \
    --bf16 true \
    --beta 0.001 \
    --importance_sampling_level sequence \
    --epsilon 3e-4 \
    --epsilon_high 4e-4 \
    --dynamic_sample false \
    --overlong_filter true \
    --loss_type grpo \
    --sleep_level 2 \
    --offload_model false \
    --offload_optimizer true \
    --log_interval 1 \
    --recompute_granularity full \
    --recompute_method uniform \
    --recompute_num_layers 1 \
    --finetune \
    --num_workers 8 \
    --dataset_num_proc 8 \
    --no_save_optim \
    --no_save_rng \
    --attention_backend flash \
    --temperature 1.0 \
    --padding_free true \
    --sequence_parallel true \
    --log_completions true
```

<sub>✨ Presented to you with <a href="https://macaron.im">Mind Lab</a> - A Lab for Experiential Intelligence.</sub> 