### PR TITLE
fix: stepfun-stepaudio2mini template

### DIFF
--- a/swift/llm/template/template/stepfun.py
+++ b/swift/llm/template/template/stepfun.py
@@ -267,12 +267,8 @@ class StepAudio2MiniTemplate(Template):
         return encoded
 
     def _data_collator(self, batch: List[Dict[str, Any]], *, padding_to: Optional[int] = None) -> Dict[str, Any]:
-        # batch_wavs, batch_wav_lens = self.padding_mels(list(itertools.chain.from_iterable([e['mels'] for e in batch])))
         combined_mels = list(itertools.chain.from_iterable([e.get('mels', []) for e in batch]))
-        if combined_mels:
-            batch_wavs, batch_wav_lens = self.padding_mels(combined_mels)
-        else:
-            batch_wavs, batch_wav_lens = None, None
+        batch_wavs, batch_wav_lens = self.padding_mels(combined_mels) if combined_mels else (None, None)
         res = super()._data_collator(batch, padding_to=padding_to)
         res['wav_lens'] = batch_wav_lens
         res['wavs'] = batch_wavs


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
## What does this PR do?
Fixes a KeyError that occurs when a batch contains samples without audio features, allowing **StepAudio2Mini** to accept mixed audio/text inputs.

## Root Cause
The original code assumes every sample contains the `'mels'` key:
``` python
batch_wavs, batch_wav_lens = self.padding_mels(
    list(itertools.chain.from_iterable([e['mels'] for e in batch]))
)
```
When any sample lacks `'mels'`, a KeyError is raised.

## Fix Details
Safely fetch `'mels'` with `e.get('mels', [])`; if zero audio tensors exist, return `(None, None)` so here can handle text-only samples.
``` python
combined_mels = list(itertools.chain.from_iterable(
    [e.get('mels', []) for e in batch]
))
if combined_mels:
    batch_wavs, batch_wav_lens = self.padding_mels(combined_mels)
else:
    batch_wavs, batch_wav_lens = None, None
```

## File & Location
`ms-swift/swift/llm/template/template/stepfun.py`, line 1 of _data_collator method inside `StepAudio2MiniTemplate` class.

## Breaking Changes?
None. The model already supports `wavs=None` for pure-text forward.

## Experiment results
We tested the revised code on a mixed dataset (audio + text samples).
- No KeyError is raised; text-only batches are handled correctly.
- Training and inference workflows remain identical to the original all-audio case.
- No performance degradation or breaking change is observed.
