### PR TITLE
fix: attribute get logic in _init_mulimodel_full

### DIFF
--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -979,9 +979,9 @@ class BaseMegatronTrainer(ABC):
         args = get_args()
         visual_cls = self.args.megatron_model_meta.visual_cls
         if args.train_type == 'full' and args.is_multimodal and visual_cls is not None:
-            vision_tower = [f'visual.{vit}' for vit in visual_cls._vision_tower]
-            aligner = [f'visual.{aligner}' for aligner in visual_cls._aligner]
-            generator = [f'visual.{generator}' for generator in visual_cls._generator]
+            vision_tower = [f'visual.{vit}' for vit in getattr(visual_cls, '_vision_tower', [])]
+            aligner = [f'visual.{aligner}' for aligner in getattr(visual_cls, '_aligner', [])]
+            generator = [f'visual.{generator}' for generator in getattr(visual_cls, '_generator', [])]
             if args.freeze_llm:
                 args.freeze_parameters.append('language_model')
             if args.freeze_vit:


### PR DESCRIPTION
# PR type
- [ x ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

The main branch ignore the fact that Qwen3VL_Vit doesn't have _generator for Qwen3Omni

## Experiment results

Paste your experiment result here(if needed).
