### PR TITLE
[grpo] Pass through vllm_server_group_port

### DIFF
--- a/docs/source/Instruction/Command-line-parameters.md
+++ b/docs/source/Instruction/Command-line-parameters.md
@@ -574,6 +574,7 @@ reward模型参数将在PPO、GRPO中使用。
   - vllm_server_host: vLLM server host地址，默认为None。
   - vllm_server_port: vLLM server 服务端口，默认为8000。
   - vllm_server_base_url: vLLM server的Base URL(比如 http://local_host:8000), 默认为None。设置后，忽略host和port设置。
+  - vllm_server_group_port: vllm server 内部通信端口，除非端口被占用，一般无需设置，默认为51216。
   - vllm_server_timeout: 连接vLLM server的超时时间，默认为 240s。
   - vllm_server_pass_dataset: 透传额外的数据集信息到vLLM server，用于多轮训练。
   - async_generate: 异步rollout以提高训练速度，注意开启时采样会使用上一轮更新的模型进行采样，不支持多轮场景。默认`false`.

--- a/docs/source_en/Instruction/Command-line-parameters.md
+++ b/docs/source_en/Instruction/Command-line-parameters.md
@@ -588,6 +588,7 @@ The meanings of the following parameters can be referenced [here](https://huggin
   - vllm_server_base_url: Base URL for the vLLM server (e.g., 'http://localhost:8000'). If provided, `vllm_server_host` " "and `vllm_server_port` are ignored. Default is None.
   - vllm_server_timeout: The connection timeout for the vLLM server. Default is 240 seconds.
   - vllm_server_pass_dataset: pass additional dataset information through to the vLLM server for multi-turn training.
+  - vllm_server_group_port: The internal communication port for the vLLM server. Generally, there is no need to set it unless the port is occupied. The default value is 51216.
   - async_generate: Use async rollout to improve train speed. Note that rollout will use the model updated in the previous round when enabled. Multi-turn scenarios are not supported. Default is `false`.
   - enable_flattened_weight_sync: Whether to use flattened tensor for weight synchronization. When enabled, multiple parameters are packed into a single contiguous tensor for transfer, which can improve synchronization efficiency; Only takes effect in Server Mode. Default is True.
   - SWIFT_UPDATE_WEIGHTS_BUCKET_SIZE: An environment variable that controls the bucket size (in MB) for flattened tensor weight synchronization during full-parameter training in Server Mode. Default is 512 MB.

--- a/swift/llm/argument/rlhf_args.py
+++ b/swift/llm/argument/rlhf_args.py
@@ -420,6 +420,7 @@ class RLHFArguments(TeacherModelArguments, GRPOArguments, PPOArguments, RewardMo
                 base_urls=self.vllm_server_base_url,
                 hosts=self.vllm_server_host,
                 server_ports=self.vllm_server_port,
+                group_ports=self.vllm_server_group_port,
                 connection_timeout=self.vllm_server_timeout)
             self.vllm_client.close_communicator()
             self.vllm_client.init_communicator(device=get_current_device())

--- a/swift/megatron/argument/megatron_args.py
+++ b/swift/megatron/argument/megatron_args.py
@@ -78,7 +78,7 @@ class RLHFMegatronArgumentsMixin:
     vllm_server_host: Optional[List[str]] = None
     vllm_server_port: List[int] = field(default_factory=lambda: [8000])
     vllm_server_timeout: float = 240.0
-    vllm_group_port: List[int] = field(default_factory=lambda: [51216])
+    vllm_server_group_port: List[int] = field(default_factory=lambda: [51216])
 
     reward_funcs: List[str] = field(default_factory=list)
     reward_weights: List[float] = None

--- a/swift/megatron/train/rlhf.py
+++ b/swift/megatron/train/rlhf.py
@@ -59,7 +59,7 @@ class MegatronRLHF(MegatronSft):
                 base_urls=self.args.vllm_server_base_url,
                 hosts=self.args.vllm_server_host,
                 server_ports=self.args.vllm_server_port,
-                group_ports=self.args.vllm_group_port,
+                group_ports=self.args.vllm_server_group_port,
                 connection_timeout=self.args.vllm_server_timeout)
             vllm_client.close_communicator()
             vllm_client.init_communicator(device=get_current_device())

--- a/swift/trainers/arguments.py
+++ b/swift/trainers/arguments.py
@@ -432,7 +432,7 @@ class RolloutTrainerArgumentsMixin(VllmArguments):
     vllm_server_port: List[int] = field(default_factory=lambda: [8000])
     vllm_server_timeout: float = 240.0
     vllm_client = None  # Not required to set, used for client instantiation
-    vllm_group_port: List[int] = field(default_factory=lambda: [51216])
+    vllm_server_group_port: List[int] = field(default_factory=lambda: [51216])
     enable_flattened_weight_sync: bool = True
     async_generate: bool = False
 


### PR DESCRIPTION
Pass through vllm_server_group_port in case the default 51216 port is occupied