### PR TITLE
[hub] Enable trust_remote_code in HFHub model download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-# Custom
-_datasets/*
-_my/*
-_output/*
-Megatron-LM/*
-
 # Byte-compiled / optimized / DLL files
 tmp
 *.ttf


### PR DESCRIPTION
`swift.llm.dataset.loader.DatasetLoader._load_repo_dataset` forcibly sets `use_hf=True`, which leads to some issues:

When the dataset is loaded, it gets routed to `swift.hub.hub.HFHub.load_dataset`, but the return value of this function does not include the parameter `trust_remote_code=True`.

Therefore, this PR adds `trust_remote_code=True` to the returned value.