### PR TITLE
[misc] set default group_port for vllm client

### DIFF
--- a/swift/megatron/argument/megatron_args.py
+++ b/swift/megatron/argument/megatron_args.py
@@ -82,7 +82,7 @@ class RLHFMegatronArgumentsMixin:
     vllm_server_host: Optional[List[str]] = None
     vllm_server_port: List[int] = field(default_factory=lambda: [8000])
     vllm_server_timeout: float = 240.0
-    vllm_server_group_port: List[int] = field(default_factory=lambda: [51216])
+    vllm_server_group_port: Optional[List[int]] = None
 
     reward_funcs: List[str] = field(default_factory=list)
     reward_weights: List[float] = None

--- a/swift/trainers/arguments.py
+++ b/swift/trainers/arguments.py
@@ -433,7 +433,7 @@ class RolloutTrainerArgumentsMixin(VllmArguments):
     vllm_server_port: List[int] = field(default_factory=lambda: [8000])
     vllm_server_timeout: float = 240.0
     vllm_client = None  # Not required to set, used for client instantiation
-    vllm_server_group_port: List[int] = field(default_factory=lambda: [51216])
+    vllm_server_group_port: Optional[List[int]] = None
     enable_flattened_weight_sync: bool = True
     async_generate: bool = False
 

--- a/swift/trainers/rlhf_trainer/vllm_client.py
+++ b/swift/trainers/rlhf_trainer/vllm_client.py
@@ -43,7 +43,7 @@ class VLLMClient:
                  base_urls: Optional[List[str]] = None,
                  hosts: List[str] = ['0.0.0.0'],
                  server_ports: List[int] = [8000],
-                 group_ports: Union[int, List[int]] = 51216,
+                 group_ports: Optional[Union[int, List[int]]] = None,
                  connection_timeout: float = 240.0):
         if not is_vllm_available():
             raise ImportError('vLLM is not installed. Please install it with `pip install vllm`.')
@@ -65,6 +65,9 @@ class VLLMClient:
             self.hosts = hosts
 
         self.num_servers = len(self.base_urls)
+
+        if group_ports is None:
+            group_ports = [51216 + i for i in range(self.num_servers)]
 
         self.sessions = [requests.Session() for _ in range(self.num_servers)]
 


### PR DESCRIPTION
When the user does not explicitly set `vllm_server_group_port`, it is set to the default port list based on the number of servers.