### PR TITLE
[npu] Fix the failure in mcore version check on NPU device

### DIFF
--- a/swift/megatron/init.py
+++ b/swift/megatron/init.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from packaging import version
 from tqdm import tqdm
+from transformers.utils import is_torch_npu_available
 
 from swift.llm import git_clone_github
 from swift.utils import (get_logger, is_flash_attn_3_available, is_megatron_available, safe_ddp_context, split_list,
@@ -791,6 +792,9 @@ def _patch_mrope():
 
 
 def _patch_unified_memory():
+    if is_torch_npu_available():
+        return
+
     mcore_015 = version.parse(importlib.metadata.version('megatron-core')) >= version.parse('0.15.0rc0')
     if not mcore_015:
         return


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

When using Mindspeed + Megatron on NPU devices, `version.parse(importlib.metadata.version('megatron-core'))` fails to correctly retrieve the mcore version and raises the error:

`importlib.metadata.PackageNotFoundError: No package metadata was found for megatron-core`.

So, skip `_patch_unified_memory` on NPU devices temporarily.

## Experiment results

Paste your experiment result here(if needed).
