### PR TITLE
qwen3_vl_fuse

### DIFF
--- a/swift/llm/model/npu_patcher.py
+++ b/swift/llm/model/npu_patcher.py
@@ -1,4 +1,6 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
+from typing import Any
+
 import torch
 import torch.nn.functional as F
 import torch_npu
@@ -6,6 +8,7 @@ from torch import nn
 from transformers.models.qwen2 import modeling_qwen2
 from transformers.models.qwen3 import modeling_qwen3
 from transformers.models.qwen3_moe import modeling_qwen3_moe
+from transformers.models.qwen3_vl_moe import modeling_qwen3_vl_moe
 
 
 class NpuRMSNorm(nn.Module):
@@ -127,14 +130,124 @@ def npu_moe_block_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
     return final_hidden_states, router_logits
 
 
-modeling_qwen2.Qwen2RMSNorm = NpuRMSNorm
-modeling_qwen2.apply_rotary_pos_emb = npu_apply_rotary_pos_emb
-modeling_qwen2.Qwen2MLP.forward = npu_swiglu_forward
+class GmmFunction(torch.autograd.Function):
 
-modeling_qwen3.Qwen3RMSNorm = NpuRMSNorm
-modeling_qwen3.apply_rotary_pos_emb = npu_apply_rotary_pos_emb
-modeling_qwen3.Qwen3MLP.forward = npu_swiglu_forward
+    @staticmethod
+    def forward(ctx, x, weight, group_list):
+        ctx.save_for_backward(x, weight)
+        ctx.group_list = group_list
 
-modeling_qwen3_moe.Qwen3MoeRMSNorm = NpuRMSNorm
-modeling_qwen3_moe.Qwen3MoeSparseMoeBlock.forward = npu_moe_block_forward
-modeling_qwen3_moe.apply_rotary_pos_emb = npu_apply_rotary_pos_emb
+        fwd_output = torch_npu.npu_grouped_matmul([x], [weight],
+                                                  bias=None,
+                                                  group_list=group_list,
+                                                  split_item=2,
+                                                  group_type=0,
+                                                  group_list_type=1)[0]
+        return fwd_output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input_tensor, weight = ctx.saved_tensors
+        group_list = ctx.group_list
+
+        weight = torch.transpose(weight, 1, 2)
+        grad_input = torch_npu.npu_grouped_matmul([grad_output], [weight],
+                                                  bias=None,
+                                                  group_list=group_list,
+                                                  split_item=2,
+                                                  group_type=0,
+                                                  group_list_type=1)[0]
+        grad_weight = torch_npu.npu_grouped_matmul(
+            [input_tensor.T],
+            [grad_output],
+            bias=None,
+            group_list=group_list,
+            split_item=3,
+            group_type=2,
+            group_list_type=1,
+        )[0]
+        return grad_input, grad_weight, None
+
+
+class NpuMoeFused:
+
+    @staticmethod
+    def npu_moe_experts_forward(self, hidden_states: torch.Tensor, routing_weights: torch.Tensor,
+                                router_indices: torch.Tensor) -> torch.Tensor:
+        batch_size = hidden_states.shape[0]
+        hidden_states = hidden_states.reshape(-1, self.hidden_size)
+        permuted_hidden_states, row_ids_map = torch_npu.npu_moe_token_permute(hidden_states,
+                                                                              router_indices.to(torch.int32))
+        tokens_per_expert = torch.histc(router_indices, bins=self.num_experts, min=0, max=self.num_experts)
+        intermediate_hidden_states = GmmFunction.apply(permuted_hidden_states, self.gate_up_proj, tokens_per_expert)
+        intermediate_activations = torch_npu.npu_swiglu(intermediate_hidden_states, dim=-1)
+        output = GmmFunction.apply(intermediate_activations, self.down_proj, tokens_per_expert)
+        next_states = torch_npu.npu_moe_token_unpermute(output, row_ids_map, probs=routing_weights)
+        next_states = next_states.view(batch_size, -1, self.hidden_size)
+        return next_states
+
+    @staticmethod
+    def npu_moe_sparse_block_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size = hidden_states.shape[0]
+        hidden_states = hidden_states.reshape(-1, self.hidden_size)
+        router_logits = self.gate(hidden_states)
+        routing_weights = torch.nn.functional.softmax(router_logits, dim=-1, dtype=torch.float)
+        routing_weights, router_indices = torch.topk(routing_weights, self.top_k, dim=-1)
+        routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+        routing_weights = routing_weights.to(hidden_states.dtype)
+        hidden_states = hidden_states.reshape(batch_size, -1, self.hidden_size)
+        routed_out = self.experts(hidden_states, routing_weights, router_indices)
+        return routed_out
+
+
+def _setattr_path(root: Any, path: str, value: Any) -> None:
+    current = root
+    parts = path.split('.')
+    for part in parts[:-1]:
+        current = getattr(current, part)
+    setattr(current, parts[-1], value)
+
+
+def _apply_patch_map(root: Any, patch_map: dict[str, Any]) -> None:
+    for path, value in patch_map.items():
+        _setattr_path(root, path, value)
+
+
+_PATCH_TABLE: tuple[tuple[Any, dict[str, Any]], ...] = (
+    (
+        modeling_qwen2,
+        {
+            'Qwen2RMSNorm': NpuRMSNorm,
+            'apply_rotary_pos_emb': npu_apply_rotary_pos_emb,
+            'Qwen2MLP.forward': npu_swiglu_forward,
+        },
+    ),
+    (
+        modeling_qwen3,
+        {
+            'Qwen3RMSNorm': NpuRMSNorm,
+            'apply_rotary_pos_emb': npu_apply_rotary_pos_emb,
+            'Qwen3MLP.forward': npu_swiglu_forward,
+        },
+    ),
+    (
+        modeling_qwen3_moe,
+        {
+            'Qwen3MoeRMSNorm': NpuRMSNorm,
+            'apply_rotary_pos_emb': npu_apply_rotary_pos_emb,
+            'Qwen3MoeSparseMoeBlock.forward': npu_moe_block_forward,
+        },
+    ),
+    (
+        modeling_qwen3_vl_moe,
+        {
+            'Qwen3VLMoeTextExperts.forward': NpuMoeFused.npu_moe_experts_forward,
+            'Qwen3VLMoeTextSparseMoeBlock.forward': NpuMoeFused.npu_moe_sparse_block_forward,
+            'Qwen3VLMoeTextRMSNorm': NpuRMSNorm,
+            'apply_rotary_pos_emb': npu_apply_rotary_pos_emb,
+        },
+    ),
+)
+
+for _module, _patch_map in _PATCH_TABLE:
+    _apply_patch_map(_module, _patch_map)


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR adds NPU fused operators for the qwen3_vl series models, and adjusts the usage method of fused operators to adding a mapping table.

## Experiment results
Experiments were conducted on the layer-reduced Qwen3-VL-30B-A3B-Instruct, with the accuracy comparison as follows:

<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/ae6caa4a-158b-46e5-8f47-df5bbd266943" />

Performance comparison is as follows:
<img width="1033" height="180" alt="image" src="https://github.com/user-attachments/assets/52971440-d6b9-4932-89ca-49a5f765a8df" />
