### PR TITLE
[Megatron] Precision Loss When Qwen3-Next HF -> mcore -> HF

### DIFF
--- a/swift/megatron/model/gpt/qwen3_next.py
+++ b/swift/megatron/model/gpt/qwen3_next.py
@@ -57,6 +57,7 @@ except ImportError:
 
 logger = get_logger()
 
+
 class Qwen3NextRMSNorm(torch.nn.Module):
     """
     Zero-Centered RMSNorm for Qwen3-Next.


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR fixes a precision loss issue ($1e-3$) during the weight conversion process for the Qwen3-Next model between Hugging Face (HF) and Megatron-Core (MCore) formats. During the round-trip conversion (HF -> MCore -> HF), we observed a considerable discrepancy in the LayerNorm weights. This precision drift (up to $10^{-3}$) may be sufficient to cause numerical instability during inference, leading to corrupted outputs (e.g., the model generating repetitive ! in some corner cases).

# Root Cause

The issue stems from a subtle implementation difference between the standard RMSNorm in Megatron-Core and the native implementation used in qwen3-next. 

# Result

When MCore's default RMSNorm is used to load Qwen3 weights, the transformation is not strictly bijective, leading to the observed loss.

# Solution 

I have replaced the generic Megatron RMSNorm with the Qwen3 native RMSNorm implementation within the MCore model definition for Qwen3-Next. This ensures that the weight mapping and the mathematical operations during inference are perfectly aligned with the original Hugging Face implementation.
