### PR TITLE
Improve vLLM examples regarding vllm_engine_kwargs use 

### DIFF
--- a/examples/infer/vllm/mllm_ddp.sh
+++ b/examples/infer/vllm/mllm_ddp.sh
@@ -7,5 +7,6 @@ swift infer \
     --val_dataset speech_asr/speech_asr_aishell1_trainsets:validation#1000 \
     --vllm_gpu_memory_utilization 0.9 \
     --vllm_max_model_len 8192 \
+    --vllm_engine_kwargs '{"attention_config": {"backend": "FLASH_ATTN"}}' \
     --max_new_tokens 2048 \
     --vllm_limit_mm_per_prompt '{"audio": 5}'


### PR DESCRIPTION
# PR type 
- [x] Document Updates 

# PR information
Add an example of an advanced usecase of `--vllm_engine_kwargs ` use since there was no similar example in the past.  It applies to `vllm >= 0.13.0`.
List of input vLLM args can be found here https://github.com/vllm-project/vllm/pull/26315 . It relates to https://github.com/modelscope/ms-swift/issues/7132 .
