### PR TITLE
fix: correct KL metrics in rollout importance sampling

### DIFF
--- a/docs/source/Instruction/GRPO/AdvancedResearch/training_inference_mismatch.md
+++ b/docs/source/Instruction/GRPO/AdvancedResearch/training_inference_mismatch.md
@@ -124,18 +124,19 @@ $$
 
 ### 1. KL 散度（KL Divergence）
 
-KL 散度衡量训练策略偏离 rollout 策略的程度。两个指标都估计 $\text{KL}(\pi_\theta \| \pi_{\text{vLLM}})$，这与重要性采样权重 $\rho = \frac{\pi_\theta}{\pi_{\text{vLLM}}}$ 直接相关。
+KL 散度衡量 rollout 策略与训练策略之间的偏离程度。两个指标都估计 $\text{KL}(\pi_{\text{vLLM}} \| \pi_\theta)$
+
 
 **直接估计器 `kl`**：
 
 $$
-\text{KL}(\pi_\theta \| \pi_{\text{vLLM}}) = \mathbb{E}_{\pi_{\text{vLLM}}}\left[ \log \frac{\pi_\theta}{\pi_{\text{vLLM}}} \right]
+\text{KL}(\pi_{\text{vLLM}} \| \pi_\theta) = \mathbb{E}_{\pi_{\text{vLLM}}}\left[ \log \frac{\pi_{\text{vLLM}}}{\pi_\theta} \right]
 $$
 
 **K3 估计器 `k3_kl`**：
 
 $$
-\text{KL}(\pi_\theta \| \pi_{\text{vLLM}}) \approx \mathbb{E}_{\pi_{\text{vLLM}}}\left[ \rho - \log \rho - 1 \right], \quad \rho = \frac{\pi_\theta}{\pi_{\text{vLLM}}}
+\text{KL}(\pi_{\text{vLLM}} \| \pi_\theta) \approx \mathbb{E}_{\pi_{\text{vLLM}}}\left[ \rho - \log \rho - 1 \right], \quad \rho = \frac{\pi_\theta}{\pi_{\text{vLLM}}}
 $$
 
 K3 估计器在 KL 值较小时数值更稳定，且始终非负。

--- a/docs/source_en/Instruction/GRPO/AdvancedResearch/training_inference_mismatch.md
+++ b/docs/source_en/Instruction/GRPO/AdvancedResearch/training_inference_mismatch.md
@@ -124,18 +124,18 @@ To monitor the degree of training-inference mismatch during training, we add the
 
 ### 1. KL Divergence
 
-KL divergence measures how much the training policy deviates from the rollout policy. Both metrics estimate $\text{KL}(\pi_\theta \| \pi_{\text{vLLM}})$, which is directly related to the importance sampling ratio $\rho = \frac{\pi_\theta}{\pi_{\text{vLLM}}}$.
+KL divergence measures the deviation between the rollout policy and the training policy. Both metrics estimate $\text{KL}(\pi_{\text{vLLM}} \| \pi_\theta)$
 
 **Direct estimator `kl`**:
 
 $$
-\text{KL}(\pi_\theta \| \pi_{\text{vLLM}}) = \mathbb{E}_{\pi_{\text{vLLM}}}\left[ \log \frac{\pi_\theta}{\pi_{\text{vLLM}}} \right]
+\text{KL}(\pi_{\text{vLLM}} \| \pi_\theta) = \mathbb{E}_{\pi_{\text{vLLM}}}\left[ \log \frac{\pi_{\text{vLLM}}}{\pi_\theta} \right]
 $$
 
 **K3 estimator `k3_kl`**:
 
 $$
-\text{KL}(\pi_\theta \| \pi_{\text{vLLM}}) \approx \mathbb{E}_{\pi_{\text{vLLM}}}\left[ \rho - \log \rho - 1 \right], \quad \rho = \frac{\pi_\theta}{\pi_{\text{vLLM}}}
+\text{KL}(\pi_{\text{vLLM}} \| \pi_\theta) \approx \mathbb{E}_{\pi_{\text{vLLM}}}\left[ \rho - \log \rho - 1 \right], \quad \rho = \frac{\pi_\theta}{\pi_{\text{vLLM}}}
 $$
 
 The K3 estimator is more numerically stable when KL values are small and is always non-negative.

--- a/swift/megatron/trainers/grpo_trainer.py
+++ b/swift/megatron/trainers/grpo_trainer.py
@@ -1926,8 +1926,8 @@ class MegatronGRPOTrainer(MegatronRLHFTrainer):
         log_ratio = per_token_logps - rollout_per_token_logps
         log_ratio = log_ratio * completion_mask
 
-        # 2a. kl: Direct estimator for KL(π_training || π_rollout)
-        kl = masked_mean(log_ratio, completion_mask)
+        # 2a. kl: Direct estimator for KL(π_rollout || π_training)
+        kl = masked_mean(-log_ratio, completion_mask)
         metrics['kl'] = gather(kl.unsqueeze(0), group=dp_group).nanmean()
 
         # 2b. k3_kl: K3 estimator for KL

--- a/swift/trainers/rlhf_trainer/grpo_trainer.py
+++ b/swift/trainers/rlhf_trainer/grpo_trainer.py
@@ -2358,25 +2358,22 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
             (-mean_log_prob_training).mean()).nanmean().item()
 
         # 2. Compute rollout off-policy metrics
-        # All KL metrics estimate KL(π_training || π_rollout), which measures how much
+        # All KL metrics estimate KL(π_rollout || π_training), which measures how much
         # the training policy deviates from the rollout policy. This is directly related
         # to the importance sampling ratio ρ = π_training / π_rollout.
 
-        # log_ratio = log(π_training / π_rollout), used for both KL estimators
+        # log_ratio = log(π_training / π_rollout), used for IS weights and KL estimators
         log_ratio = per_token_logps - rollout_per_token_logps
         log_ratio *= completion_mask
 
-        # 2a. kl: Direct estimator for KL(π_training || π_rollout)
-        # Formula: KL(P||Q) = E_Q[log(P/Q)] when sampled from Q (rollout)
-        # However, we use the identity: E_Q[log(P/Q)] = E_Q[log P] - E_Q[log Q]
-        # Since data is from rollout, E_Q[log Q] ≈ E[rollout_logps], E_Q[log P] ≈ E[training_logps]
-        # Positive value means training policy assigns higher probability than rollout
-        kl = masked_mean(log_ratio, completion_mask)
+        # 2a. kl: Direct estimator for KL(π_rollout || π_training)
+        # Formula: KL(P||Q) = E_P[log(P/Q)] where P=π_rollout, Q=π_training
+        # = E_rollout[log(π_rollout) - log(π_training)] = E[-log_ratio]
+        kl = masked_mean(-log_ratio, completion_mask)
         metrics['kl'] = self.accelerator.gather_for_metrics(kl).nanmean().item()
 
-        # 2b. k3_kl: K3 estimator for KL(π_training || π_rollout)
+        # 2b. k3_kl: K3 estimator for KL(π_rollout || π_training)
         # More stable for small KL values
-        # Formula: KL(P||Q) ≈ E_Q[P/Q - log(P/Q) - 1] where P=π_training, Q=π_rollout
         k3_kl_matrix = torch.exp(log_ratio) - log_ratio - 1
         k3_kl = masked_mean(k3_kl_matrix, completion_mask)
         metrics['k3_kl'] = self.accelerator.gather_for_metrics(k3_kl).nanmean().item()


### PR DESCRIPTION
align KL metrics with https://github.com/volcengine/verl/blob/main/verl/trainer/ppo/rollout_corr_helper.py