### PR TITLE
[bugfix] fix AssertionError vp_stage must be a kwarg in train_valid_t…

### DIFF
--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -32,7 +32,7 @@ mcore_013 = version.parse(megatron.core.__version__) >= version.parse('0.13.0rc0
 
 def get_swift_datasets_provider(train_dataset, val_dataset):
 
-    def swift_datasets_provider(train_val_test_num_samples):
+    def swift_datasets_provider(train_val_test_num_samples, vp_stage=None):
         nonlocal val_dataset
         args = get_args()
         data_parallel_size = mpu.get_data_parallel_world_size()


### PR DESCRIPTION
…est_dataset_provider when using vpp and mcore 0.15

# PR type
- Bug Fix

# PR information
When sft using virtual pipeline parallel or pipeline_model_parallel_layout with mcore r0.15.0, mcore will raise AssertionError at https://github.com/NVIDIA/Megatron-LM/blob/core_r0.15.0/megatron/training/training.py#L683

## Experiment results
Training with pipeline_model_parallel_layout runs perfectly with this pr.
