### PR TITLE
Make the default value of fsdp compatible with transformers less than 4.57

### DIFF
--- a/swift/llm/argument/train_args.py
+++ b/swift/llm/argument/train_args.py
@@ -290,6 +290,7 @@ class TrainArguments(SwanlabArguments, TunerArguments, BaseArguments, Seq2SeqTra
 
     def _init_fsdp(self):
         if not self.fsdp:
+            self.fsdp = []
             return
 
         if is_mp() and not self.use_ray:


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

Make the default value of fsdp compatible with transformers less than 4.57

## Experiment results

Paste your experiment result here(if needed).
