### PR TITLE
[bugfix] fix lora in vllm >= v0.12

### DIFF
--- a/swift/trainers/rlhf_trainer/utils.py
+++ b/swift/trainers/rlhf_trainer/utils.py
@@ -858,37 +858,42 @@ def patch_vllm_load_adapter():
             # to ensure correct loading of lora weights.
             model = self._adapter_manager.model
             hf_to_vllm_mapper = getattr(model, 'hf_to_vllm_mapper', None)
-            if isinstance(lora_request, TensorLoRARequest):  # this is the patch
+
+            lora_request_kwargs = {
+                'peft_helper': peft_helper,
+                'lora_model_id': lora_request.lora_int_id,
+                'device': 'cpu',
+                'dtype': self.lora_config.lora_dtype,
+                'weights_mapper': hf_to_vllm_mapper,
+            }
+            if hasattr(self, 'embedding_padding_modules'):
+                lora_request_kwargs['embedding_modules'] = self.embedding_modules
+                lora_request_kwargs['embedding_padding_modules'] = self.embedding_padding_modules
+            else:
+                lora_request_kwargs['model_vocab_size'] = self.vocab_size
+            if hasattr(self.lora_config, 'lora_extra_vocab_size'):
+                # lora_extra_vocab_size is removed in vllm >= 0.12
+                # https://github.com/vllm-project/vllm/issues/23474
+                lora_request_kwargs['target_embedding_padding'] = (
+                    self.vocab_size + self.lora_config.lora_extra_vocab_size)
+
+            if isinstance(lora_request, TensorLoRARequest):
                 lora = self._lora_model_cls.from_lora_tensors(
-                    lora_model_id=lora_request.lora_int_id,
                     tensors=lora_tensors,
-                    peft_helper=peft_helper,
-                    device='cpu',
-                    dtype=self.lora_config.lora_dtype,
-                    embeddings=None,
-                    target_embedding_padding=self.vocab_size + self.lora_config.lora_extra_vocab_size,
-                    embedding_modules=self.embedding_modules,
-                    embedding_padding_modules=self.embedding_padding_modules,
-                    weights_mapper=hf_to_vllm_mapper,
+                    **lora_request_kwargs,
                 )
             else:
                 lora = self._lora_model_cls.from_local_checkpoint(
                     lora_path,
                     expected_lora_modules,
-                    peft_helper=peft_helper,
-                    lora_model_id=lora_request.lora_int_id,
-                    device='cpu',
-                    dtype=self.lora_config.lora_dtype,
-                    target_embedding_padding=self.vocab_size + self.lora_config.lora_extra_vocab_size,
-                    embedding_modules=self.embedding_modules,
-                    embedding_padding_modules=self.embedding_padding_modules,
-                    weights_mapper=hf_to_vllm_mapper,
+                    **lora_request_kwargs,
                 )
         except Exception as e:
             raise e
-        if lora.extra_vocab_size > self.lora_config.lora_extra_vocab_size:
-            raise ValueError(f'LoRA added vocab size {lora.extra_vocab_size} is greater than '
-                             f'lora_extra_vocab_size {self.lora_config.lora_extra_vocab_size}.')
+        if hasattr(self.lora_config, 'lora_extra_vocab_size'):
+            if lora.extra_vocab_size > self.lora_config.lora_extra_vocab_size:
+                raise ValueError(f'LoRA added vocab size {lora.extra_vocab_size} is greater than '
+                                 f'lora_extra_vocab_size {self.lora_config.lora_extra_vocab_size}.')
         return lora
 
     def patched_get_lora_tokenizer(self: TokenizerGroup, lora_request: LoRARequest):


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Since vllm has remove extra vocab for LoRA, `lora_extra_vocab_size` access led to error in training, use get_attr to support newer version. Tested on vllm v0.13.0

## Experiment results

Paste your experiment result here(if needed).
