### PR TITLE
[bugfix] fix reward model adapters 

### DIFF
--- a/swift/llm/infer/utils.py
+++ b/swift/llm/infer/utils.py
@@ -137,7 +137,7 @@ def prepare_adapter(args, model, adapters=None):
     else:
         tuner = Swift
     # compat deploy
-    adapters = adapters or args.adapters
+    adapters = adapters if adapters is not None else args.adapters
     for adapter in adapters:
         model = tuner.from_pretrained(model, adapter)
     if args.train_type == 'bone':


### PR DESCRIPTION
Fix a bug where, when adapters / ref_adapters (i.e., the adapter weight path specified via --model) and reward_model are both set, incorrectly attempts to merge the adapters into the reward model.