### PR TITLE
[template] Support HunyuanMT1.5-1.8B and HunyuanMT1.5-7B templates

### DIFF
--- a/swift/llm/template/constant.py
+++ b/swift/llm/template/constant.py
@@ -102,6 +102,8 @@ class LLMTemplateType:
     dots1 = 'dots1'
     hunyuan_moe = 'hunyuan_moe'
     hunyuan = 'hunyuan'
+    hunyuan_mt1_5_1_8b = 'hunyuan_mt1_5_1_8b'
+    hunyuan_mt1_5_7b = 'hunyuan_mt1_5_7b'
     ernie = 'ernie'
     ernie_thinking = 'ernie_thinking'
     longchat = 'longchat'

--- a/swift/llm/template/template/llm.py
+++ b/swift/llm/template/template/llm.py
@@ -302,39 +302,6 @@ register_template(
         default_system='You are a helpful assistant.',
     ))
 
-register_template(
-    TemplateMeta(
-        LLMTemplateType.hunyuan_moe,
-        prefix=['<|startoftext|>'],
-        system_prefix=['<|startoftext|>{{SYSTEM}}<|extra_4|>'],
-        prompt=['{{QUERY}}<|extra_0|>'],
-        chat_sep=['<|eos|><|startoftext|>'],
-        suffix=['<|eos|>'],
-    ))
-
-
-class HunyuanTemplate(Template):
-
-    def _remove_thinking_content(self, content: str) -> str:
-        content = content.split('<answer>')[-1].rstrip()
-        if content.endswith('</answer>'):
-            content = content[:-len('</answer>')]
-        return self.template_meta.history_thinking_prefix + content.strip()
-
-
-register_template(
-    TemplateMeta(
-        LLMTemplateType.hunyuan,
-        prefix=['<｜hy_begin▁of▁sentence｜>'],
-        system_prefix=['<｜hy_begin▁of▁sentence｜>{{SYSTEM}}<｜hy_place▁holder▁no▁3｜>'],
-        prompt=['<｜hy_User｜>{{QUERY}}<｜hy_Assistant｜>'],
-        chat_sep=['<｜hy_place▁holder▁no▁2｜>'],
-        suffix=['<｜hy_place▁holder▁no▁2｜>'],
-        template_cls=HunyuanTemplate,
-        is_thinking=True,
-        non_thinking_prefix='<think>\n\n</think>\n',
-        agent_template='hunyuan_hermes'))
-
 
 class GptTemplate(Template):
     support_padding_free = False


### PR DESCRIPTION
- Add hunyuan_mt1_5_1_8b and hunyuan_mt1_5_7b template types to LLMTemplateType
- Move hunyuan_moe and hunyuan template definitions from llm.py to tencent.py

参考对应模型的chat template编写：
https://huggingface.co/tencent/HY-MT1.5-1.8B/blob/main/chat_template.jinja
https://huggingface.co/tencent/HY-MT1.5-7B/blob/main/chat_template.jinja

如果HY-MT1.5-7B使用默认的hunyuan的模板，会生成不正常的结束符/重复片段，训练时需指定 `--template hunyuan_mt1_5_7b`，HY-MT1.5-1.8B需指定 `--template hunyuan_mt1_5_1_8`。