### PR TITLE
Fix device mismatch in _forward_qwen3_vl_or_qwen3_omni when computing visual_pos_masks

### DIFF
--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -888,14 +888,14 @@ def _forward_qwen3_vl_or_qwen3_omni(
 
         image_mask = (input_ids == self.config.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
         video_mask = (input_ids == self.config.video_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+        image_mask = image_mask.to(inputs_embeds.device)
+        video_mask = video_mask.to(inputs_embeds.device)
         if image_embeds is not None:
             image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
-            image_mask = image_mask.to(inputs_embeds.device)
             inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
 
         if video_embeds is not None:
             video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
-            video_mask = video_mask.to(inputs_embeds.device)
             inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
         image_mask, video_mask = image_mask[..., 0], video_mask[..., 0]
         visual_pos_masks = image_mask | video_mask


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
When the model receives only image inputs (without video inputs), the image_masktensor and video_masktensor may be on different CUDA devices, causing a RuntimeError when performing the bitwise OR operation: visual_pos_masks = image_mask | video_mask.


## Experiment results

<img width="1823" height="658" alt="企业微信截图_17683020462767" src="https://github.com/user-attachments/assets/81598c00-abd4-4024-bb9a-10e9957ffcc3" />
