### PR TITLE
add npu qwen3-next example and warning of ep size

### DIFF
--- a/examples/ascend/train/qwen3_next/qwen3_next_megatron.sh
+++ b/examples/ascend/train/qwen3_next/qwen3_next_megatron.sh
@@ -1,0 +1,40 @@
+export TASK_QUEUE_ENABLE=2
+NPROC_PER_NODE=8 \
+ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+megatron sft \
+    --model Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --load_safetensors true \
+    --save_safetensors true \
+    --dataset 'AI-ModelScope/alpaca-gpt4-data-zh#500' \
+    --train_type lora \
+    --lora_rank 8 \
+    --lora_alpha 32 \
+    --target_modules all-linear \
+    --tensor_model_parallel_size 2 \
+    --pipeline_model_parallel_size 2 \
+    --export_model_parallel_size 4 \
+    --model_type qwen3_next \
+    --sequence_parallel true \
+    --micro_batch_size 1 \
+    --global_batch_size 4 \
+    --recompute_granularity full \
+    --recompute_method uniform \
+    --recompute_num_layers 4 \
+    --finetune true \
+    --cross_entropy_loss_fusion true \
+    --lr 1e-4 \
+    --lr_warmup_fraction 0.05 \
+    --min_lr 1e-5 \
+    --max_epochs 1 \
+    --save megatron_output/Qwen3-Next-Instruct \
+    --save_interval 100 \
+    --max_length 1024 \
+    --system 'You are a helpful assistant.' \
+    --num_workers 4 \
+    --no_save_optim true \
+    --no_save_rng true \
+    --dataset_num_proc 4 \
+    --no_gradient_accumulation_fusion true \
+    --no_masked_softmax_fusion true \
+    --model_author swift \
+    --model_name swift-robot

--- a/swift/megatron/arguments/megatron_args.py
+++ b/swift/megatron/arguments/megatron_args.py
@@ -8,6 +8,7 @@ import json
 import megatron.core
 import torch
 from packaging import version
+from transformers.utils import is_torch_npu_available
 from transformers.utils.versions import require_version
 
 from swift.arguments import ModelArguments
@@ -16,6 +17,7 @@ from swift.utils import get_dist_setting, get_logger, json_parse_to_dict
 
 mcore_015 = version.parse(megatron.core.__version__) >= version.parse('0.15.0rc0')
 logger = get_logger()
+MAX_NPU_EXPERTS_PER_EP = 128
 
 
 @dataclass
@@ -696,6 +698,15 @@ class MegatronArguments(ExtraMegatronArguments):
         if self.num_experts is not None:
             if self.moe_ffn_hidden_size is None:
                 self.moe_ffn_hidden_size = self.ffn_hidden_size
+            if is_torch_npu_available() and self.num_experts > MAX_NPU_EXPERTS_PER_EP:
+                required_ep = (self.num_experts + MAX_NPU_EXPERTS_PER_EP - 1) // MAX_NPU_EXPERTS_PER_EP
+                if self.expert_model_parallel_size < required_ep:
+                    logger.warning(f'{">"*20} WARNING {"<"*20}\n'
+                                   f'MindSpeed on NPU supports up to {MAX_NPU_EXPERTS_PER_EP} experts per EP group. '
+                                   f'num_experts={self.num_experts}, '
+                                   f'expert_model_parallel_size={self.expert_model_parallel_size}. '
+                                   f'Please set expert_model_parallel_size (EP) to {required_ep} '
+                                   f'(num_experts / {MAX_NPU_EXPERTS_PER_EP}) or higher.')
 
     def __post_init__(self):
         require_version('numpy<2.0', 'Please install numpy<2.0 by running: `pip install "numpy<2.0"`.')


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
1. Add NPU-based training example for Qwen3_Next
    - add a NPU megatron training example for Qwen3_Next
2. Add warning information about Expert Parallel (EP) size limitation
    - Warning: The number of experts in Qwen3_Next is larger than 128, which is the maximum limit supported by fused ops in MindSpeed. If the number of experts allocated to each rank exceeds 128, the fused ops module will report error information.

## Experiment results

Paste your experiment result here(if needed).
