### PR TITLE
[bugfix] fix deepspeed distributed weight offload code

### DIFF
--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -33,7 +33,7 @@ from swift.plugins import MultiTurnScheduler, multi_turns
 from swift.sequence_parallel import sequence_parallel
 from swift.template import Template
 from swift.tuners import Swift
-from swift.utils import get_current_device, get_logger, is_vllm_available, remove_response, is_deepspeed_enabled
+from swift.utils import get_current_device, get_logger, is_deepspeed_enabled, is_vllm_available, remove_response
 from .arguments import RolloutTrainerArgumentsMixin
 from .rlhf_mixin import RLHFTrainerMixin
 from .utils import (FlattenedTensorBucket, TensorLoRARequest, _create_parameter_buckets,
@@ -1180,7 +1180,7 @@ class RolloutTrainerMixin(RLHFTrainerMixin):
             # After DeepSpeed distributed loading: param.data is empty and weights cannot be off-loaded.
             # The real weights are stored in ds_tensor.
             if is_deepspeed_enabled() and hasattr(param, 'ds_tensor'):
-                param.ds_tensor.data = param.ds_tensor.data.to("cpu", non_blocking=True)
+                param.ds_tensor.data = param.ds_tensor.data.to('cpu', non_blocking=True)
             else:
                 param.data = param.data.to(torch.device('cpu'), non_blocking=True)
         torch.cuda.empty_cache()
@@ -1201,6 +1201,7 @@ class RolloutTrainerMixin(RLHFTrainerMixin):
                 param.ds_tensor.data = param.ds_tensor.data.to(device, non_blocking=True)
             else:
                 param.data = param.data.to(device, non_blocking=True)
+
     @torch.no_grad()
     def offload_optimizer(self):
         if not self.optimizer.state:


### PR DESCRIPTION
## PR type

* [x] Bug Fix
* [ ] New Feature
* [ ] Document Updates
* [ ] More Models or Datasets Support

---

## PR information

This PR fixes an issue where **model offloading is ineffective when using DeepSpeed ZeRO-3**, which causes GPU/NPU memory to remain occupied even after calling `offload_model`.

### Background

In Swift GRPO training, both **actor model** and **reference model** are initialized with **DeepSpeed ZeRO-3**.
For co-located training + inference workflows, models must be offloaded before initializing **vLLM**, otherwise vLLM may fail due to insufficient available device memory.

However, the current `offload_model` implementation only moves `param.data` to CPU, which does **not** release actual parameter storage under ZeRO-3.

### Root Cause

Under **DeepSpeed ZeRO-3**:

* Model parameters are partitioned and stored in `param.ds_tensor`
* `param.data` is often a placeholder tensor
* Moving `param.data` does not affect the real parameter shard

As a result, calling `offload_model` has **no effect on device memory usage**.

### What this PR does

* Makes `offload_model` **DeepSpeed ZeRO-3 aware**
* Explicitly handles parameters backed by `ds_tensor`
* Ensures model parameter shards are correctly offloaded from device memory
* Does **not** touch optimizer states (handled separately)

### Scope

* ✅ Actor model offload
* ✅ Reference model offload


## Experiment results

### Environment

* Training backend: DeepSpeed ZeRO-3
* Inference backend: vLLM
* Model size: ~34B
* Hardware: GPU / NPU

---

### Memory behavior comparison

#### Before this PR

Calling `offload_model` has **no effect** on device memory usage under ZeRO-3.

```
before vllm init,
memory allocated (GB): 5.59,
memory reserved (GB): 6.64,
device memory used/total (GB): 8.49 / 61.27

after model offload,
memory allocated (GB): 5.59,
memory reserved (GB): 6.64,
device memory used/total (GB): 8.49 / 61.27

after ref offload,
memory allocated (GB): 5.59,
memory reserved (GB): 6.64,
device memory used/total (GB): 8.49 / 61.27
```

**Observation**:
Model parameters remain resident on device memory even after offloading both actor and reference models.

---

#### After this PR

Model parameter shards are correctly released from device memory.

```
before vllm init,
memory allocated (GB): 5.59,
memory reserved (GB): 6.67,
device memory used/total (GB): 8.53 / 61.27

after model offload,
memory allocated (GB): 2.79,
memory reserved (GB): 6.67,
device memory used/total (GB): 8.53 / 61.27

after ref offload,
memory allocated (GB): 0.00,
memory reserved (GB): 3.10,
device memory used/total (GB): 5.00 / 61.27
```

**Observation**:

* Actor model offload releases ~2.8 GB allocated memory
* Reference model offload fully clears model parameter allocation
* Reserved memory also drops significantly after both models are offloaded
* vLLM can be initialized successfully without OOM

---

### Conclusion

This PR makes model offloading **effective and reliable under DeepSpeed ZeRO-3**, which is required for co-located training + inference workflows.

* ✅ Correctly handles parameters stored in `ds_tensor`
* ✅ Releases actual device memory instead of placeholder tensors
* ✅ Unblocks vLLM initialization in large-model training setups


