### PR TITLE
[optimizer] Set loss mask to compute the loss for multi-turn reasoning

### DIFF
--- a/examples/train/grpo/plugin/treepo/tree_rollout_plugin.py
+++ b/examples/train/grpo/plugin/treepo/tree_rollout_plugin.py
@@ -147,8 +147,8 @@ class TreeRolloutScheduler(MultiTurnScheduler):
                             # If we use intermediate reasoning results when computing the reward,
                             # but loss_mask is not explicitly set,
                             # only the loss of the final round of reasoning will be computed.
-                            response_loss_mask=[[1] * len(response_ids) for response_ids in
-                                                child_sample.all_response_ids],
+                            response_loss_mask=[[1] * len(response_ids)
+                                                for response_ids in child_sample.all_response_ids],
                             rollout_infos={'num_turns': next_infer_step},
                         ))
                 else:
@@ -224,8 +224,8 @@ class TreeRolloutScheduler(MultiTurnScheduler):
         return sample.status == SampleStatus.FINISHED
 
     def roll_back_to_divergence(
-            self,
-            finished_samples: Dict[int, List[DataSampleTree]],
+        self,
+        finished_samples: Dict[int, List[DataSampleTree]],
     ) -> List[DataSampleTree]:
         """
         All nodes have completed inference, but there is still budget available, rollback.


### PR DESCRIPTION


# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

TreePO’s step() uses {role: user, content: prompt} for multi-turn interactions. When the reward function evaluates the results of multi-turn outputs, in theory the tokens from multiple assistant outputs should all be included in the loss computation. If loss_mask is not explicitly set, by default only the output from the final turn is selected for loss calculation.
