### PR TITLE
[bugfix] fix npu cast error after apply fsdp2

### DIFF
--- a/swift/model/npu_patcher.py
+++ b/swift/model/npu_patcher.py
@@ -1,14 +1,99 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
+from __future__ import annotations
+from functools import wraps
 from typing import Any
 
+import accelerate.utils.fsdp_utils as fsdp_utils
 import torch
 import torch.nn.functional as F
 import torch_npu
+from accelerate.accelerator import Accelerator
 from torch import nn
 from transformers.models.qwen2 import modeling_qwen2
 from transformers.models.qwen3 import modeling_qwen3
 from transformers.models.qwen3_moe import modeling_qwen3_moe
 from transformers.models.qwen3_vl_moe import modeling_qwen3_vl_moe
+
+
+class NPUCastError(RuntimeError):
+    """Raised when fp32 casting fails during NPU FSDP2 preparation."""
+
+
+def _get_first_parameter(module: torch.nn.Module) -> torch.nn.Parameter | None:
+    for param in module.parameters(recurse=True):
+        return param
+    return None
+
+
+def _needs_fp32_cast_for_npu(
+    module: torch.nn.Module,
+    accelerator: Accelerator,
+) -> bool:
+    if accelerator.device.type != 'npu':
+        return False
+
+    param = _get_first_parameter(module)
+    if param is None:
+        return False
+
+    return param.is_floating_point() and param.dtype != torch.float32
+
+
+def _cast_to_fp32(module: torch.nn.Module) -> torch.nn.Module:
+    """
+    Cast module parameters to fp32.
+
+    Assumes parameters are already on CPU or meta device.
+    Only dtype is changed; device is preserved.
+    """
+    try:
+        return module.to(torch.float32)
+    except Exception as exc:
+        raise NPUCastError(f'Failed to cast {module.__class__.__name__} to fp32.') from exc
+
+
+# ----------------------------------------------------------------------
+# Patch accelerate.utils.fsdp_utils.fsdp2_prepare_model
+# ----------------------------------------------------------------------
+
+_original_fsdp2_prepare_model = fsdp_utils.fsdp2_prepare_model
+
+
+@wraps(_original_fsdp2_prepare_model)
+def wrapped_fsdp2_prepare_model(
+    accelerator: Accelerator,
+    model: torch.nn.Module,
+):
+    if _needs_fp32_cast_for_npu(model, accelerator):
+        model = _cast_to_fp32(model)
+
+    return _original_fsdp2_prepare_model(accelerator, model)
+
+
+fsdp_utils.fsdp2_prepare_model = wrapped_fsdp2_prepare_model
+
+# ----------------------------------------------------------------------
+# Patch Accelerator._prepare_fsdp2
+# ----------------------------------------------------------------------
+
+_original_prepare_fsdp2 = Accelerator._prepare_fsdp2
+
+
+@wraps(_original_prepare_fsdp2)
+def wrapped_prepare_fsdp2(
+    self: Accelerator,
+    *args,
+    **kwargs,
+):
+    patched_args = [
+        _cast_to_fp32(obj) if isinstance(obj, torch.nn.Module) and _needs_fp32_cast_for_npu(obj, self) else obj
+        for obj in args
+    ]
+
+    return _original_prepare_fsdp2(self, *patched_args, **kwargs)
+
+
+Accelerator._prepare_fsdp2 = wrapped_prepare_fsdp2
 
 
 class NpuRMSNorm(nn.Module):


### PR DESCRIPTION
## PR type

* [x] Bug Fix
* [ ] New Feature
* [ ] Document Updates
* [ ] More Models or Datasets Support

---

## PR information

### Background

When using **Accelerate FSDP2 on NPU backends**, model preparation may fail
during the FSDP2 initialization phase if the model parameters are not already
in `torch.float32`.

This issue is commonly observed in RLHF / GRPO training pipelines, where:

* `actor` and `ref` models are initialized in `bf16` / `fp16`
* `accelerator.prepare()` triggers `fsdp2_prepare_model`
* Accelerate internally performs a dtype cast to `fp32`

---

### Problem Description

On NPU backends, `accelerate.utils.fsdp_utils.fsdp2_prepare_model`
internally executes:

```python
model = model.to(torch.float32)
```

At this point, the model (or its parameters) may already be wrapped by **FSDP2**
and represented as **DTensor**.

This triggers the NPU operator:

```
npu._npu_dtype_cast
```

However, this operator **does not have a sharding strategy registered** in the
DTensor sharding propagation system, resulting in the following runtime error:

```text
NotImplementedError: Operator npu._npu_dtype_cast.default does not have a sharding strategy registered.
```

Full stack trace confirms the failure occurs during sharding propagation after
FSDP2 wrapping.

---

### Root Cause

* FSDP2 expects dtype casting to be completed **before sharding**
* On NPU, dtype cast operators do **not support DTensor sharding propagation**
* Performing `model.to(torch.float32)` **after** FSDP2 wrapping is therefore unsafe
* CUDA backends do not hit this issue due to different operator support

---

### Solution

This PR ensures that floating-point parameters are cast to `torch.float32`
**before entering the FSDP2 preparation stage** on NPU backends.

Specifically:

* Detect NPU backend via `Accelerator.device`
* Check whether model parameters are floating-point and not already `fp32`
* Perform an early dtype cast **before** FSDP2 sharding
* Avoid triggering any sharded dtype cast operators on NPU

Two internal entry points are patched:

1. `accelerate.utils.fsdp_utils.fsdp2_prepare_model`
2. `Accelerator._prepare_fsdp2`

The logic is guarded and **only active on NPU**, with no impact on CUDA or CPU
backends.

---

### Why this Fix Works

* The dtype cast happens on unsharded parameters
* No DTensor objects are involved during casting
* No NPU dtype-cast operators are executed on sharded tensors
* FSDP2 receives a model in a valid and expected state

This preserves the original Accelerate and FSDP2 behavior while avoiding an
unsupported execution path on NPU.

---

### Scope and Impact

* **Fixes**: NPU + Accelerate FSDP2 dtype cast crash
* **Affected workflows**: RLHF / GRPO / multi-model training (actor + ref)
* **Backends impacted**: NPU only
* **Behavior change on CUDA / CPU**: None
* **API changes**: None

---

## Experiment results

Verified on NPU backend:

* RLHF training with FSDP2 enabled
* `actor` and `ref` models initialized in `bf16`
* Training proceeds successfully without dtype cast errors


### Related Issue

Fixes #7871