### PR TITLE
Fix Qwen3-VL compatibility: Visual attribute nesting and Processor length issues

### DIFF
--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -719,7 +719,13 @@ class Qwen2VLLoader(ModelLoader):
         self.auto_model_cls = self.auto_model_cls or Qwen2VLForConditionalGeneration
         model = super().get_model(model_dir, config, processor, model_kwargs)
         base_model = model.model if 'AWQ' in model.__class__.__name__ else model
-        patch_get_input_embeddings(base_model.visual, 'patch_embed')
+        visual_module = None
+        if hasattr(base_model, 'model') and hasattr(base_model.model, 'visual'):
+            visual_module = base_model.model.visual
+        elif hasattr(base_model, 'visual'):
+            visual_module = base_model.visual    
+        if visual_module:
+            patch_get_input_embeddings(visual_module, 'patch_embed')
         return model
 
     def _check_qwen_vl_utils(self):

--- a/swift/model/register.py
+++ b/swift/model/register.py
@@ -346,8 +346,12 @@ class ModelLoader(BaseModelLoader):
             if model is not None and not self.return_dummy_model:
                 llm_model = get_lm_head_model(model, self.model_meta)
                 origin_vocab_size = HfConfigFactory.get_config_attr(llm_model.config, 'vocab_size')
-                if origin_vocab_size < len(tokenizer):
-                    vocab_size = math.ceil(len(tokenizer) / 128) * 128
+                if hasattr(tokenizer, 'tokenizer'):
+                    _tokenizer = tokenizer.tokenizer
+                else:
+                    _tokenizer = tokenizer
+                if origin_vocab_size < len(_tokenizer):
+                    vocab_size = math.ceil(len(_tokenizer) / 128) * 128
                     llm_model.resize_token_embeddings(vocab_size)
                     # fix transformers==4.52.4 qwen2.5-vl
                     HfConfigFactory.set_config_attr(llm_model.config, 'vocab_size', vocab_size)


### PR DESCRIPTION
# PR type
- Bug Fix


# PR information

1. Fix AttributeError in swift/model/models/qwen.py

Issue: In Qwen3-VL (and some customized versions of Qwen2.5-VL), the visual encoder is no longer a direct attribute of the top-level model class. Instead, it is nested under base_model.model.visual.

Fix: Added a safe-access logic to check both base_model.model.visual and the legacy base_model.visual. This ensures patch_get_input_embeddings correctly identifies the vision component for embedding patching.

2. Fix TypeError in swift/model/register.py

Issue: The model registration process occasionally receives a Processor object (e.g., Qwen3VLProcessor) instead of a raw Tokenizer. Since Processor objects do not implement __len__, the code crashes when calculating vocabulary size.

Fix: Added a check to see if the object has a .tokenizer attribute. If it does, the length is retrieved from the internal tokenizer; otherwise, it falls back to the original behavior.

## Error Logs Resolved (Reference)

AttributeError: 'Qwen3VLForConditionalGeneration' object has no attribute 'visual'

TypeError: object of type 'Qwen3VLProcessor' has no len()
