### PR TITLE
feat(swanlab): support email notification with dedicated arguments

### DIFF
--- a/swift/arguments/sft_args.py
+++ b/swift/arguments/sft_args.py
@@ -93,10 +93,9 @@ class SwanlabArguments:
             if self.swanlab_notification_method == 'email':
                 if not (self.swanlab_sender_email and self.swanlab_receiver_email and self.swanlab_smtp_server
                         and self.swanlab_smtp_port):
-                    raise ValueError(
-                        "When 'swanlab_notification_method' is 'email', both 'swanlab_sender_email' "
-                        "and 'swanlab_receiver_email' and 'swanlab_smtp_server' and 'swanlab_smtp_port' must be provided."
-                    )
+                    raise ValueError("When 'swanlab_notification_method' is 'email', both 'swanlab_sender_email' "
+                                     "and 'swanlab_receiver_email' and 'swanlab_smtp_server' and 'swanlab_smtp_port' "
+                                     'must be provided.')
                 callback = EmailCallback(
                     sender_email=self.swanlab_sender_email,
                     receiver_email=self.swanlab_receiver_email,


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information
主要修复了 swanlab的email插件通知
swanlab官方email通知: https://docs.swanlab.cn/plugin/notification-email.html
原来的实现存在问题: 参数对不上

Write the detail information belongs to this PR.
主要将swanlab的官方文档的参数补上就没了，做了一个if判断，很简单的实现
## Experiment results
<img width="2287" height="427" alt="image" src="https://github.com/user-attachments/assets/1165916e-f852-4a40-8541-7960a38037ef" />

<img width="2021" height="733" alt="image" src="https://github.com/user-attachments/assets/d856e3f2-b8d7-4c98-839c-8d0b7cdcd440" />


# 测试脚本 
```
bash examples/train/seq_cls/bert/sft.sh
```

增加    
--swanlab_notification_method email \
  --swanlab_sender_email 1391913301@qq.com \
  --swanlab_smtp_server smtp.qq.com \
  --swanlab_receiver_email 1391913301@qq.com \
  --swanlab_smtp_port 587 \
  --swanlab_secret "xxxx" \
  --report_to swanlab \