### PR TITLE
fix: handle None padding_to in get_padding_to() for fused attention

### DIFF
--- a/swift/megatron/utils/utils.py
+++ b/swift/megatron/utils/utils.py
@@ -347,7 +347,7 @@ def get_padding_to(args):
     elif fp8_format is not None:
         padding_to = max((padding_to or 1) * 8, 16)
     if args.attention_backend == 'fused':
-        padding_to = max(padding_to, ((origin_padding_to) or 1) * 64)
+        padding_to = max(padding_to or 1, ((origin_padding_to) or 1) * 64)
     return padding_to
 
 


### PR DESCRIPTION
## Summary

Fixed `TypeError: '>' not supported between instances of 'int' and 'NoneType'` in `get_padding_to()` when using fused attention with `tp=1`.

## Problem

When using megatron training with fused attention (`attention_backend='fused'`) and `tensor_model_parallel_size=1`, the function `get_padding_to()` raises a TypeError:

```python
padding_to = max(padding_to, ((origin_padding_to) or 1) * 64)
# TypeError: '>' not supported between instances of 'int' and 'NoneType'
```

This occurs because `padding_to` can remain `None` when:
- `tensor_model_parallel_size == 1` or `sequence_parallel` is False
- `context_parallel_size <= 1`  
- `fp8_recipe != 'blockwise'` and `fp8_format is None`

## Solution

Applied the same `or 1` pattern used elsewhere in the function:

```python
# Before
padding_to = max(padding_to, ((origin_padding_to) or 1) * 64)

# After
padding_to = max(padding_to or 1, ((origin_padding_to) or 1) * 64)
```

Fixes #8000