### PR TITLE
Patch ms-swift logger bug and point towards ms-swift fork

### DIFF
--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -99,7 +99,7 @@ class BaseMegatronTrainer(ABC):
             getattr(callback, event)(**kwargs)
 
     def on_log(self, logs, prefix=''):
-        n_steps = logs.get('n_steps', 1)
+        n_steps = logs.pop('n_steps', 1)
         self._log_callback(logs, n_steps)
         if prefix:
             logs = {f'{prefix}{k}': v for k, v in logs.items()}


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information

## Bug
When running ms-swift with PP>1 for GLM4.7, we end up encountering the following KeyError:
```
"""
[rank19]: Traceback (most recent call last):
[rank19]:   File "/usr/local/lib/python3.11/site-packages/swift/cli/_megatron/sft.py", line 7, in <module>
[rank19]:     megatron_sft_main()
[rank19]:   File "/usr/local/lib/python3.11/site-packages/swift/megatron/pipelines/train/sft.py", line 77, in megatron_sft_main
[rank19]:     return MegatronSft(args).main()
[rank19]:            ^^^^^^^^^^^^^^^^^^^^^^^^
[rank19]:   File "/usr/local/lib/python3.11/site-packages/swift/pipelines/base.py", line 52, in main
[rank19]:     result = self.run()
[rank19]:              ^^^^^^^^^^
[rank19]:   File "/usr/local/lib/python3.11/site-packages/swift/megatron/pipelines/train/sft.py", line 67, in run
[rank19]:     trainer.train(train_dataset, val_dataset)
[rank19]:   File "/usr/local/lib/python3.11/site-packages/swift/megatron/trainers/base.py", line 518, in train
[rank19]:     self.on_log(logs=train_metrics)
[rank19]:   File "/usr/local/lib/python3.11/site-packages/swift/megatron/trainers/base.py", line 101, in on_log
[rank19]:     n_steps = logs.pop('n_steps')
[rank19]:               ^^^^^^^^^^^^^^^^^^^
[rank19]: KeyError: 'n_steps'
```
## Cause
Relevant Code Snippet: https://github.com/modelscope/ms-swift/blob/main/swift/megatron/trainers/base.py#L505-L530

1. `on_log` tries to fetch `n_steps` from an empty dict, which causes this KeyError.

2. The function [`_aggregated_metrics`](https://github.com/modelscope/ms-swift/blob/main/swift/megatron/trainers/base.py#L655) is responsible to populating this dict. However, it is [gated behind `is_pipeline_last_stage`](https://github.com/modelscope/ms-swift/blob/main/swift/megatron/trainers/base.py#L511-L512).  [See relevant Megatron code](https://github.com/epfLLM/Megatron-LLM/blob/806a83302cbf4f7d6e147fe34bad5885cf745709/megatron/core/parallel_state.py#L331).
3. When that evaluates to false, we do not populate the logs dict. But we *still* call `on_log` because that is just based on `state.should_log`.
4. ‼️ This creates an edge case where we are incorrectly fetching an empty dict, and this only happens *once* on the first step.

There are two ways to fix this:
1. Do not call `on_log` if  `is_pipeline_last_stage` evaluates to false.
2. Make `on_log` resilient to if `n_steps` is not populated.

Method 1 actually doesn't fix the problem, and causes the training run to indefinitely hang because it is waiting on an all reduce call from the pp_groups.
- `track_moe_metrics` ([GitHub](https://github.com/NVIDIA/Megatron-LM/blob/9f611b7953aa49ff87d708cd8ba7d8a08caf1470/megatron/core/transformer/moe/moe_utils.py#L1003)) calls reduce_aux_losses_tracker_across_ranks ([GitHub](https://github.com/NVIDIA/Megatron-LM/blob/9f611b7953aa49ff87d708cd8ba7d8a08caf1470/megatron/core/transformer/moe/moe_utils.py#L958)), which [makes all reduce calls](https://github.com/NVIDIA/Megatron-LM/blob/9f611b7953aa49ff87d708cd8ba7d8a08caf1470/megatron/core/transformer/moe/moe_utils.py#L987-L1000)
- Because we skipped `on_log`  if  `is_pipeline_last_stage` evaluates to false, this makes the all-reduce hang because it never got the result back from some.

Thus, we do method 2, which we've validated to work with an example code we ran.

## Experiment results

To test this code, we have a running version of GLM 4.7 with LoRA that previously fails on the main branch of ms-swift, but succeeds to completion on the patched version of the code.