### PR TITLE
fix(grpo): Fix NCCL timeout/hang in ZeRO-3 with dynamic batch sizes

### DIFF
--- a/swift/rlhf_trainers/grpo_trainer.py
+++ b/swift/rlhf_trainers/grpo_trainer.py
@@ -1367,7 +1367,7 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
         max_chunks = max(chunks_per_device)
 
         # Re-compute chunk size so that max_chunks * new_chunk_size covers entire batch
-        new_chunk_size = (batch_size + max_chunks - 1) // max_chunks if max_chunks > 0 else 1
+        new_chunk_size = (batch_size + max_chunks - 1) // max_chunks
 
         losses, weights = [], []
         all_metrics_data = []
@@ -1392,8 +1392,7 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
                 weights.append(chunk_weight)
                 all_metrics_data.append((chunk_metrics_data, chunk_weight))
             else:
-                # append loss * 0 to the losses list after doing dummy forward
-                # Otherwise,the result of dummy forward won't be added to computation graph,so backward won't trigger ReduceScatter hook of ZeRO-3 ,leading to NCCL freezes
+                # # Add dummy loss to computation graph to trigger ZeRO-3 backward hooks
                 losses.append(chunk_loss * 0.0)
 
         # Compute weighted average loss


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

### What does this PR do?
Fixes a critical bug where DeepSpeed ZeRO-3 hangs (NCCL timeout) during GRPO / Multi-turn RLHF training. It happens when each rollout sample didn't generate same number of turns,which triggers dynamic sample mechanism and makes the each ranks get different batchsize.(For more information,look `_compute_loss` and `_compute_loss_chunked`)

### Root Cause
In `_compute_loss_chunked`, the framework correctly performs dummy forward passes to align the number of steps across different ranks. However, for these dummy padding steps, the resulting `chunk_loss` is **not appended** to the `losses` list. 

As a result, these dummy computational graphs are detached from `final_loss`. During `final_loss.backward()`, the autograd engine skips the backward pass for these dummy chunks. This causes ranks with fewer valid samples to trigger fewer DeepSpeed backward hooks (Pre-Backward `All-Gather` and Post-Backward `Reduce-Scatter`), causing the other ranks to wait indefinitely and eventually crash with an NCCL Timeout watchdog error.


## Experiment results

my running script:
```bash
export NCCL_TIMEOUT=14400
export TORCH_DIST_TIMEOUT=14400
CUDA_VISIBLE_DEVICES=2,3,4,5,6,7 
NPROC_PER_NODE=6 
swift rlhf 
--rlhf_type grpo 
--model my_model(Qwen3)
--model_type qwen3 
--external_plugins my_plugin(for using a custom reward function)
--reward_funcs my_reward 
--train_type full 
--torch_dtype bfloat16 
--loss_scale last_round 
--use_vllm true 
--check_model false 
--vllm_mode server 
--vllm_server_host 127.0.0.1 
--vllm_server_port 8011 
--vllm_server_group_port 51210 
--dataset  ./merged_qa_reformat.json 
--load_from_cache_file true 
--max_completion_length 32000 
--num_train_epochs 8 
--per_device_train_batch_size 1 
--learning_rate 1e-5 
--gradient_accumulation_steps 1 
--save_steps 20 
--save_total_limit 4 
--logging_steps 1 
--output_dir ./260221_rl_full 
--dataloader_num_workers 8 
--dataset_num_proc 3 
--num_generations 16 
--gradient_accumulation_steps 32 
--temperature 0.9 
--log_completions true 
--deepspeed zero3_offload 
--gradient_checkpointing true 
--beta 0 
--num_iterations 1
```
my rollout script:
```bash
CUDA_VISIBLE_DEVICES=1 
swift rollout 
--model  my_model(Qwen3)
--model_type qwen3 
--vllm_use_async_engine true 
--multi_turn_scheduler my_multi_turn_scheduler # similar to ThinkingModelTipsScheduler
--vllm_max_model_len 32000 
--vllm_gpu_memory_utilization 0.8 
--port 8011 
--max_turns 6 
--response_prefix '<think>\n\n</think>\n\n'
```

Paste your experiment result here(if needed).
bug log:
```
[Rank 1] batch_size=3, expected_bs=1, dynamic=True
[Rank 4] batch_size=3, expected_bs=1, dynamic=True
[Rank 2] batch_size=3, expected_bs=1, dynamic=True
[Rank 0] batch_size=3, expected_bs=1, dynamic=True
[Rank 5] batch_size=2, expected_bs=1, dynamic=True[Rank 3] batch_size=3, expected_bs=1, dynamic=True

[rank5]:[E224 22:16:11.568524565 ProcessGroupNCCL.cpp:685] [Rank 5] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=1488, OpType=_REDUCE_SCATTER_BASE, NumelIn=777912324, NumelOut=129652054, Timeout(ms)=600000) ran for 600004 milliseconds before timing out.
[rank5]:[E224 22:16:11.568605579 ProcessGroupNCCL.cpp:2252][PG ID 1 PG GUID 1 Rank 5]  failure detected by watchdog at work sequence id: 1488 PG status: last enqueued work: 1488, last completed work: 1487
[rank3]:[E224 22:16:11.951175818 ProcessGroupNCCL.cpp:1870][PG ID 0 PG GUID 0(default_pg) Rank 3] Received a dump signal due to a collective timeout from  rank 5 and we will try our best to dump the debug info. Last enqueued NCCL work: 82361, last completed NCCL work: 82357.This is most likely caused by incorrect usages of collectives, e.g., wrong sizes used across ranks...
```

## Solution
Multiply the dummy `chunk_loss` by `0.0` and append it to `losses`. 
This keeps the computational graph connected, forcing PyTorch to traverse it during the backward pass. It triggers all necessary collective communication hooks to keep ZeRO-3 in sync without affecting the actual gradient values. Since the rank would otherwise be idle waiting for other ranks, the `0.0 * loss` dummy backward pass does not introduce overall wall-clock training overhead.