### PR TITLE
fix: add missing import re in utils.py

### DIFF
--- a/swift/megatron/utils/utils.py
+++ b/swift/megatron/utils/utils.py
@@ -1,4 +1,5 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
+import re
 import megatron.core
 import torch
 import torch.distributed as dist


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
Added import re to the standard library import section in swift/megatron/utils/utils.py.

