### PR TITLE
Fix for load_dataset function to restore ability to use custom loader

### DIFF
--- a/swift/dataset/loader.py
+++ b/swift/dataset/loader.py
@@ -297,16 +297,6 @@ def load_dataset(
         num_proc = None
     train_datasets = []
     val_datasets = []
-    loader = DatasetLoader(
-        num_proc=num_proc,
-        load_from_cache_file=load_from_cache_file,
-        streaming=streaming,
-        hub_token=hub_token,
-        strict=strict,
-        download_mode=download_mode,
-        columns=columns,  # columns_mapping
-        remove_unused_columns=remove_unused_columns,
-    )
 
     use_hf_default = use_hf
     if use_hf_default is None:
@@ -324,6 +314,16 @@ def load_dataset(
                 dataset_syntax.dataset = dataset_meta.hf_dataset_id if use_hf else dataset_meta.ms_dataset_id
         else:
             dataset_meta = dataset_syntax.get_dataset_meta(use_hf)
+        loader = dataset_meta.loader(
+            num_proc=num_proc,
+            load_from_cache_file=load_from_cache_file,
+            streaming=streaming,
+            hub_token=hub_token,
+            strict=strict,
+            download_mode=download_mode,
+            columns=columns,  # columns_mapping
+            remove_unused_columns=remove_unused_columns,
+        )
         train_dataset = loader.load(dataset_syntax, dataset_meta, use_hf=use_hf)
         train_dataset, val_dataset = loader.post_process(
             train_dataset,


### PR DESCRIPTION
With update 4.0.0 function load_dataset function creates base DataLoader and don't respect loader field of DatasetMeta. In 3.x.x version it was honored via load_function, so this small change restore ability to use custom load of dataset


DatasetMeta creates base DatasetLoader in post_init if None were given, so with this change, behavior for registered datasets will remain the same

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
