### PR TITLE
feat(megatron): add on_save callback to MegatronCallback

### DIFF
--- a/swift/megatron/callbacks/base.py
+++ b/swift/megatron/callbacks/base.py
@@ -35,3 +35,12 @@ class MegatronCallback:
 
     def on_eval_step(self):
         pass
+
+    def on_save(self, output_dir):
+        """Called after save_checkpoint() returns.
+
+        Note: When async_save is enabled, the checkpoint may not be fully
+        written to disk yet. Use only for non-I/O-dependent logic, or
+        ensure async_save is disabled if you need to read the checkpoint.
+        """
+        pass

--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -601,6 +601,7 @@ class BaseMegatronTrainer(ABC):
                     disable_forward_pre_hook(self.wrapped_models)
                 state.should_save = False
                 self.save_checkpoint()
+                self.call_event('on_save', output_dir=self.state.last_model_checkpoint)
                 if should_disable_forward_pre_hook(args):
                     enable_forward_pre_hook(self.wrapped_models)
 


### PR DESCRIPTION
Add on_save hook to MegatronCallback base class, fired after save_checkpoint() completes in the training loop. This brings the Megatron trainer closer to parity with the HuggingFace-based FSDP trainer, which already supports on_save via TrainerCallback.

The callback receives the output_dir of the saved checkpoint, enabling custom post-save logic such as uploading, validation, or notification.

Note: When async_save is enabled, the callback fires after save_checkpoint() returns but before async I/O completes, matching HuggingFace trainer behavior with async checkpointing.

# PR type
- [ ] Bug Fix
- [ X ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support


