### PR TITLE
fix(megatron): mask out padding positions (labels==-100) in MTP loss

### DIFF
--- a/swift/megatron/model/gpt_model.py
+++ b/swift/megatron/model/gpt_model.py
@@ -371,11 +371,11 @@ class GPTModel(McoreGPTModel):
             if labels is not None:
                 mtp_labels = labels.clone()
                 if loss_mask is None:
-                    # if loss_mask is not provided, use all ones as loss_mask
-                    if packed_seq_params is None:
-                        loss_mask = torch.ones_like(mtp_labels)
-                    else:
-                        loss_mask = mtp_labels.new_ones((1, packed_seq_params.cu_seqlens_q[-1]))
+                    # Derive loss_mask from labels: mask out padding positions (labels == -100)
+                    # so that system prompt, user query, and vision tokens don't contribute to MTP loss.
+                    loss_mask = (mtp_labels != -100).to(mtp_labels.dtype)
+                    if packed_seq_params is not None:
+                        loss_mask = loss_mask.view(1, -1)
                 cu_seqlens = packed_seq_params.cu_seqlens_q if packed_seq_params is not None else None
                 for mtp_layer_number in range(self.config.mtp_num_layers):
                     # output


### PR DESCRIPTION
## Problem

When `loss_mask` is not provided by the trainer (which is the default path in `forward_step`), the MTP loss computation in `GPTModel._postprocess` creates an **all-ones** `loss_mask`:

```python
loss_mask = torch.ones_like(mtp_labels)
```

This means positions where `labels == -100` (system prompt, user query, vision tokens in multimodal SFT data) all contribute to the MTP loss. These positions produce inflated loss values (~`log(vocab_size)` ≈ 12.0), and since they typically account for 50-80% of tokens in SFT data, they **dominate the gradient signal**.

The main language model loss correctly masks these positions in `trainer.py`'s `loss_func`:
```python
loss_mask = labels != -100
```

But MTP loss is computed inside the model's `_postprocess` (before `loss_func` runs), so it never benefits from this masking.

### Symptoms

- MTP loss starts at ~8.8 and **plateaus at ~4.0** regardless of training duration (tested: 3195 steps / 1 full epoch)
- The plateau value is dominated by the cross-entropy loss on masked positions
- Resulting MTP head has only ~4-6% acceptance rate in speculative decoding (essentially useless)

## Fix

Derive `loss_mask` from labels by masking out `-100` positions, consistent with how the main LM loss handles it:

```python
loss_mask = (mtp_labels != -100).to(mtp_labels.dtype)
```

## Verification

Tested on Qwen3.5-35B-A3B multimodal SFT (Plan B: freeze LLM, train only MTP head):

| Step | MTP Loss (before fix) | MTP Loss (after fix) |
|------|----------------------|---------------------|
| 1    | 8.83                 | 12.87               |
| 20   | 4.00 ← **plateau**   | 8.94                |
| 40   | 4.05                 | 2.22                |
| 50   | 4.02                 | 0.91                |
| 60   | 4.01                 | **0.50**            |

The higher starting loss after the fix is expected — we're now only measuring loss on actual response tokens (harder to predict) instead of averaging in masked positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)