### PR TITLE
[WIP] Moe kernel for qwen3 omni in ascend 

### DIFF
--- a/swift/model/npu_patcher.py
+++ b/swift/model/npu_patcher.py
@@ -11,6 +11,7 @@ from torch import nn
 from transformers.models.qwen2 import modeling_qwen2
 from transformers.models.qwen3 import modeling_qwen3
 from transformers.models.qwen3_moe import modeling_qwen3_moe
+from transformers.models.qwen3_omni_moe import modeling_qwen3_omni_moe
 from transformers.models.qwen3_vl_moe import modeling_qwen3_vl_moe
 from typing import Any
 
@@ -330,6 +331,15 @@ _PATCH_TABLE: tuple[tuple[Any, dict[str, Any]], ...] = (
             'Qwen3VLMoeTextSparseMoeBlock.forward': NpuMoeFused.npu_moe_sparse_block_forward,
             'Qwen3VLMoeTextRMSNorm': NpuRMSNorm,
             'apply_rotary_pos_emb': npu_apply_rotary_pos_emb,
+        },
+    ),
+    (
+        modeling_qwen3_omni_moe,
+        {
+            'Qwen3OmniMoeTextRMSNorm': NpuRMSNorm,
+            'Qwen3OmniMoeRMSNorm': NpuRMSNorm,
+            'apply_rotary_pos_emb': npu_apply_rotary_pos_emb,
+            'Qwen3OmniMoeThinkerTextSparseMoeBlock.forward': npu_moe_block_forward,
         },
     ),
 )


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR mainly adds accelerated operator patches for the Qwen3-Omni model.

This PR is currently marked as WIP, as the AI Core utilization still needs to be verified.

The current NPU patch implementation does not yet account for structural differences across different Transformers versions. After this PR is merged, follow-up work will address compatibility with different Transformers versions.

## Experiment results

Paste your experiment result here(if needed).
