### PR TITLE
fix npu hccl timeout

### DIFF
--- a/swift/model/npu_patcher.py
+++ b/swift/model/npu_patcher.py
@@ -27,7 +27,7 @@ def _set_default_hccl_connect_timeout_for_npu() -> None:
         return
 
     os.environ['HCCL_CONNECT_TIMEOUT'] = _DEFAULT_NPU_HCCL_CONNECT_TIMEOUT
-    logger.info('Set HCCL_CONNECT_TIMEOUT=600 by default for NPU.')
+    logger.info(f'Set HCCL_CONNECT_TIMEOUT={_DEFAULT_NPU_HCCL_CONNECT_TIMEOUT} by default for NPU.')
 
 
 _set_default_hccl_connect_timeout_for_npu()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Problem

Under the Ascend NPU + FSDP setup, after upgrading `transformers` from `4.57.x` to `5.x`, startup becomes more likely to exhibit rank skew, which can then surface as HCCL timeouts around the first synchronization / coordination point.
<img width="1505" height="141" alt="hccl_error" src="https://github.com/user-attachments/assets/1139ff39-00ce-45b9-8520-92125724654e" />

This tends to show up earlier on Ascend because the official default `HCCL_CONNECT_TIMEOUT` is only **120 seconds**. According to the Ascend documentation, `HCCL_CONNECT_TIMEOUT` controls the timeout for **socket link establishment / synchronization before collective communication initialization**, with a valid range of `[120, 7200]` and a default value of `120s` (plus an additional 20 seconds used for failure notification). Meanwhile, PyTorch documents that `torch.distributed.init_process_group(timeout=...)` defaults to **10 minutes for NCCL**.

* Ascend doc: [https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/850alpha002/maintenref/envvar/envref_07_0077.html](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/850alpha002/maintenref/envvar/envref_07_0077.html)
* PyTorch distributed doc: [https://docs.pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group](https://docs.pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group)

## Cause

The practical regression after upgrading from `transformers 4.57.x` to `5.x` is that **non-zero ranks now perform more local work before the first collective communication**.

`transformers v5` is officially a major refactor, and the loading path was reworked accordingly. Compared with `4.57.x`, the `5.x` loading flow introduces a more explicit and heavier post-load / finalize stage before the model reaches the first FSDP synchronization point. As a result, non-zero ranks spend longer in local preparation, while rank 0 is more likely to reach the first synchronization point earlier. This increases startup-time rank skew and makes timeout failures easier to surface on Ascend.

## Change
This PR raises the default `HCCL_CONNECT_TIMEOUT` from **120 seconds** to **600 seconds** for Ascend / NPU runs, as a runtime safeguard to reduce premature HCCL timeouts caused by startup-time rank skew.

This is a **runtime mitigation**, not a root-cause fix for the upstream `transformers 5.x` loading / startup behavior.
