### PR TITLE
[bugfix] fix PeftModel save_pretrained selected_adapters when using custom adapter_name

### DIFF
--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -57,6 +57,21 @@ from .utils import (can_return_loss, dynamic_gradient_checkpointing, find_labels
 logger = get_logger()
 
 
+def _get_peft_selected_adapters(model: PeftModel) -> List[str]:
+    """Resolve active adapter name(s) for PeftModel.save_pretrained(selected_adapters=...).
+
+    When users pass a custom adapter_name (e.g. 'vision_only_lora') to Swift.prepare_model,
+    we must pass the same name(s) to save_pretrained; otherwise PEFT raises because
+    supported adapter names do not include 'default'. See: gh#8336.
+    """
+    active = getattr(model, 'active_adapter', None) or getattr(model, 'active_adapters', None)
+    if active is None:
+        return ['default']
+    if isinstance(active, str):
+        return [active]
+    return list(active)
+
+
 class SwiftMixin:
     FLASH_CKPT_WAIT_TIMEOUT = 1800
 
@@ -284,7 +299,7 @@ class SwiftMixin:
             if isinstance(_unwrap_model, supported_classes):
                 save_kwargs = {'state_dict': state_dict, 'max_shard_size': self.args.max_shard_size}
                 if isinstance(_unwrap_model, PeftModel):
-                    save_kwargs['selected_adapters'] = ['default']
+                    save_kwargs['selected_adapters'] = _get_peft_selected_adapters(_unwrap_model)
                 if use_flash_ckpt:
                     _unwrap_model.save_pretrained(
                         output_dir,
@@ -321,7 +336,7 @@ class SwiftMixin:
             if self.model.__class__.__name__ != 'SentenceTransformer':
                 save_kwargs = {'state_dict': state_dict, 'max_shard_size': self.args.max_shard_size}
                 if isinstance(self.model, PeftModel):
-                    save_kwargs['selected_adapters'] = ['default']
+                    save_kwargs['selected_adapters'] = _get_peft_selected_adapters(self.model)
                 if use_flash_ckpt:
                     self.model.save_pretrained(
                         output_dir,

--- a/tests/tuners/test_peft.py
+++ b/tests/tuners/test_peft.py
@@ -13,6 +13,7 @@ from peft.tuners.lora import Linear
 from peft.utils import WEIGHTS_NAME
 from torch import nn
 
+from swift.trainers.mixin import _get_peft_selected_adapters
 from swift.tuners import AdaLoraConfig, LoraConfig, LoRAConfig, Swift, get_peft_model
 
 
@@ -157,3 +158,37 @@ class TestPeft(unittest.TestCase):
         self.assertTrue(model3.base_model.model.bert.encoder.layer[0].attention.self.key.lora_A.default.weight.dtype ==
                         torch.float32)
         self.assertTrue(isinstance(model3.peft_config['default'], peft.LoraConfig))
+
+    def test_get_peft_selected_adapters_custom_name(self):
+        """Check selected_adapters respects custom adapter_name (gh#8336)."""
+        model = SbertForSequenceClassification(SbertConfig())
+        lora_config = LoraConfig(target_modules=['query', 'key', 'value'])
+        model = Swift.prepare_model(model, lora_config, adapter_name='vision_only_lora')
+        # SwiftModel wraps base_model; trainer unwraps to PeftModel for save.
+        inner = getattr(model, 'base_model', model)
+        self.assertEqual(_get_peft_selected_adapters(inner), ['vision_only_lora'])
+
+    def test_get_peft_selected_adapters_default(self):
+        """Check selected_adapters falls back to default when no custom name."""
+        model = SbertForSequenceClassification(SbertConfig())
+        lora_config = LoraConfig(target_modules=['query', 'key', 'value'])
+        model = Swift.prepare_model(model, lora_config)
+        inner = getattr(model, 'base_model', model)
+        self.assertEqual(_get_peft_selected_adapters(inner), ['default'])
+
+    def test_get_peft_selected_adapters_mock(self):
+        """Check _get_peft_selected_adapters with active_adapter/active_adapters (gh#8336)."""
+        class MockPeft:
+            pass
+        # None -> default
+        m = MockPeft()
+        m.active_adapter = None
+        m.active_adapters = None
+        self.assertEqual(_get_peft_selected_adapters(m), ['default'])
+        # str
+        m.active_adapter = 'my_lora'
+        self.assertEqual(_get_peft_selected_adapters(m), ['my_lora'])
+        # list (active_adapters takes precedence when active_adapter is None)
+        m.active_adapter = None
+        m.active_adapters = ['a', 'b']
+        self.assertEqual(_get_peft_selected_adapters(m), ['a', 'b'])


### PR DESCRIPTION
# [bugfix] fix PeftModel save_pretrained selected_adapters when using custom adapter_name

https://github.com/modelscope/ms-swift/issues/8336

When users pass a custom `adapter_name` (e.g. `vision_only_lora`) to `Swift.prepare_model()`, checkpoint save was still passing `selected_adapters=['default']` to `PeftModel.save_pretrained()`, causing:

```
ValueError: You passed an invalid `selected_adapters` arguments, current supported adapter names are ['vision_only_lora'] - got ['default'].
```

**Changes:**
- `swift/trainers/mixin.py`: Add `_get_peft_selected_adapters(model)` to resolve `active_adapter` / `active_adapters` from the PeftModel; use it in `_save_model()` for both PeftModel save paths instead of hardcoded `['default']`.
- `tests/tuners/test_peft.py`: Add tests for default adapter, custom adapter_name, and mock (None/str/list).
