### PR TITLE
[bugfix] fix EarlyStopCallback init missing trainer argument

### DIFF
--- a/swift/callbacks/early_stop.py
+++ b/swift/callbacks/early_stop.py
@@ -1,7 +1,7 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import numpy as np
 from transformers import TrainerControl, TrainerState
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from swift.utils import get_logger
 from .base import TrainerCallback
@@ -13,9 +13,16 @@ logger = get_logger()
 
 
 class EarlyStopCallback(TrainerCallback):
-    """An early stop implementation"""
+    """Early stopping: stop when best_metric does not improve for early_stop_interval evals."""
 
-    def __init__(self, args: 'TrainingArguments', trainer: 'Trainer'):
+    def __init__(self, args: 'TrainingArguments', trainer: Optional['Trainer'] = None):
+        # Support both (args, trainer) and (trainer,) for backward compatibility (gh#8330).
+        if trainer is None:
+            trainer = args
+            args = getattr(trainer, 'args', None)
+            if args is None:
+                raise TypeError(
+                    'EarlyStopCallback requires (args, trainer) or a single Trainer instance with .args set.')
         super().__init__(args, trainer)
         self.best_metric = None
         self.interval = 0

--- a/tests/callbacks/test_early_stop.py
+++ b/tests/callbacks/test_early_stop.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Tests for EarlyStopCallback (gh#8330)."""
+import unittest
+from unittest.mock import MagicMock
+
+from swift.callbacks.early_stop import EarlyStopCallback
+
+
+class TestEarlyStopCallback(unittest.TestCase):
+    """Test both (args, trainer) and (trainer,) init signatures."""
+
+    def test_init_args_and_trainer(self):
+        """Standard call: EarlyStopCallback(args, trainer)."""
+        args = MagicMock()
+        args.early_stop_interval = 3
+        trainer = MagicMock()
+        trainer.args = args
+        cb = EarlyStopCallback(args, trainer)
+        self.assertIs(cb.args, args)
+        self.assertIs(cb.trainer, trainer)
+        self.assertEqual(cb.total_interval, 3)
+
+    def test_init_trainer_only(self):
+        """Backward compat: EarlyStopCallback(trainer) when trainer.args is set (gh#8330)."""
+        args = MagicMock()
+        args.early_stop_interval = 5
+        trainer = MagicMock()
+        trainer.args = args
+        cb = EarlyStopCallback(trainer)
+        self.assertIs(cb.args, args)
+        self.assertIs(cb.trainer, trainer)
+        self.assertEqual(cb.total_interval, 5)
+
+    def test_init_trainer_only_no_args_raises(self):
+        """Single-arg call with no trainer.args must raise."""
+        trainer = MagicMock(spec=[])  # no .args
+        with self.assertRaises(TypeError) as ctx:
+            EarlyStopCallback(trainer)
+        self.assertIn('EarlyStopCallback requires', str(ctx.exception))


### PR DESCRIPTION
# [bugfix] fix EarlyStopCallback init missing trainer argument

https://github.com/modelscope/ms-swift/issues/8330

With `--early_stop_interval` set, some code paths instantiate `EarlyStopCallback` with a single argument (the Trainer), leading to:

```
TypeError: EarlyStopCallback.__init__() missing 1 required positional argument: 'trainer'
```

**Changes:**
- `swift/callbacks/early_stop.py`: `EarlyStopCallback.__init__(args, trainer=None)`. When `trainer is None`, treat the first argument as the Trainer and set `args = getattr(trainer, 'args', None)`; raise clear `TypeError` if `trainer.args` is missing. Keeps existing `(args, trainer)` call sites unchanged.
- `tests/callbacks/test_early_stop.py`: Add tests for `(args, trainer)`, single-arg `(trainer)` with `.args`, and single-arg without `.args` (expect raise).
