### PR TITLE
[bugfix] fix load audio from local video path when USE_AUDIO_IN_VIDEO (fix #8332)

### DIFF
--- a/swift/template/templates/qwen.py
+++ b/swift/template/templates/qwen.py
@@ -660,9 +660,15 @@ class Qwen2_5OmniTemplate(Qwen2_5VLTemplate):
             inputs.videos[index] = _video
             if self.use_audio_in_video:
                 import librosa
+                # Librosa/soundfile do not support video containers (e.g. .mp4). Decode via ffmpeg (gh#8332).
                 if video.startswith('http://') or video.startswith('https://'):
                     import audioread
                     video = audioread.ffdec.FFmpegAudioFile(video)
+                elif isinstance(video, str):
+                    path_lower = video.lower()
+                    if any(path_lower.endswith(ext) for ext in ('.mp4', '.webm', '.avi', '.mov', '.mkv')):
+                        import audioread
+                        video = audioread.ffdec.FFmpegAudioFile(video)
                 video = librosa.load(video, sr=self.sampling_rate)[0]
                 if self.mode != 'vllm':
                     inputs.audios.insert(inputs.audio_idx, (video, 'video'))


### PR DESCRIPTION
# [bugfix] fix load audio from local video path when USE_AUDIO_IN_VIDEO (fix #8332)

https://github.com/modelscope/ms-swift/issues/8332

With `USE_AUDIO_IN_VIDEO=True`, loading audio from a **local** video path (e.g. `.mp4`) passed the path directly to `librosa.load()`. Librosa/soundfile do not support video containers, which caused:

```
soundfile.LibsndfileError: Error opening 'xxx.mp4': Format not recognised.
```

URLs were already handled via `audioread.ffdec.FFmpegAudioFile`. This PR applies the same ffmpeg-based decoding for local paths when the file extension is a video format (`.mp4`, `.webm`, `.avi`, `.mov`, `.mkv`), so that `librosa.load` receives a decoded audio stream instead of the raw path.

**Changes:**
- `swift/template/templates/qwen.py`: In the `use_audio_in_video` branch, if `video` is a local path with a video extension, open it with `audioread.ffdec.FFmpegAudioFile(video)` before calling `librosa.load()`. No new dependencies (audioread/ffmpeg already used for URLs).
