### PR TITLE
[bugfix] Web UI: load from checkpoint path by type instead of dirty exception check

### DIFF
--- a/swift/ui/base.py
+++ b/swift/ui/base.py
@@ -342,13 +342,11 @@ class BaseUI:
         if os.path.exists(local_args_path):
             try:
                 if hasattr(arg_cls, 'resume_from_checkpoint'):
-                    try:
+                    # Use adapter vs full-model constructor by path type (avoids fragile exception message check).
+                    if BaseArguments._check_is_adapter(model):
                         args = arg_cls(resume_from_checkpoint=model, load_data_args=True)
-                    except Exception as e:
-                        if 'using `--model`' in str(e):  # TODO a dirty fix
-                            args = arg_cls(model=model, load_data_args=True)
-                        else:
-                            raise e
+                    else:
+                        args = arg_cls(model=model, load_data_args=True)
                 else:
                     if os.path.exists(os.path.join(model, 'adapter_config.json')):
                         args = arg_cls(adapters=model, load_data_args=True)


### PR DESCRIPTION
**Summary:** Replaces the "TODO a dirty fix" in Web UI when loading a local checkpoint: instead of catching the error message and retrying with `--model`, we now decide the constructor up front using `BaseArguments._check_is_adapter(model)`.

- **Before:** `arg_cls(resume_from_checkpoint=model, ...)` was called; on exception containing `"using \`--model\`"`, we called `arg_cls(model=model, ...)`. This was fragile and commented as a dirty fix.
- **After:** If `_check_is_adapter(model)` is true (adapter/peft dir with `adapter_config.json` etc.), we use `resume_from_checkpoint=model`; otherwise we use `model=model` for full checkpoint paths. No reliance on exception text.

**Changes:**
- In `swift/ui/base.py`, when `local_args_path` exists and `arg_cls` has `resume_from_checkpoint`, use `BaseArguments._check_is_adapter(model)` to choose between `resume_from_checkpoint=model` and `model=model`.
- Removed the try/except that checked for `'using \`--model\`' in str(e)` and the "TODO a dirty fix" comment.

Please take a look when you have time. cc @Jintao-Huang @hjh0119
