### PR TITLE
fix(megatron): destroy NCCL process groups on training exit

### DIFF
--- a/swift/megatron/pipelines/train/sft.py
+++ b/swift/megatron/pipelines/train/sft.py
@@ -1,6 +1,7 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import os
 import torch
+import torch.distributed as dist
 from dataclasses import asdict
 from transformers.utils import is_torch_npu_available
 from typing import List, Optional, Union
@@ -81,6 +82,8 @@ class MegatronSft(SwiftSft):
 
                 jsonl_path = os.path.join(args.output_dir, 'logging.jsonl')
                 append_to_jsonl(jsonl_path, self.train_msg, strict=False, write_on_rank='last')
+            if dist.is_initialized():
+                dist.destroy_process_group()
         return self.train_msg
 
 


### PR DESCRIPTION
## Summary
- Add explicit `dist.destroy_process_group()` call at the end of `MegatronSft.run()` to cleanly tear down all NCCL process groups after training completes or fails.
- MoE models (e.g. GLM-4.5-Air, DeepSeek-MoE) create many expert-parallel NCCL groups that cause watchdog timeouts and process hangs during Python's uncoordinated GC teardown on exit.
- Since `MegatronPretrain` and `MegatronRLHF` inherit `run()` from `MegatronSft`, this fix covers all Megatron training pipelines.

## Motivation
When training MoE models with Megatron, the process hangs indefinitely after training completes. This is because NCCL's internal watchdog thread detects that peers have stopped responding during uncoordinated Python GC cleanup of the many expert-parallel process groups. The fix ensures all ranks coordinately destroy their process groups before exiting.

Fixes #7992
Related to #4643

## Test plan
- [x] Pre-commit checks pass (flake8, isort, yapf)
- [x] Verified fix resolves exit hang with MoE model training on multi-node setup