### PR TITLE
Fix wandb logging step and metrics reporting

### DIFF
--- a/swift/rlhf_trainers/utils.py
+++ b/swift/rlhf_trainers/utils.py
@@ -584,7 +584,10 @@ def profiling_context(trainer, name: str):
     end_time = time.perf_counter()
     duration = end_time - start_time
 
-    profiling_metrics = {f'profiling/Time taken: {trainer.__class__.__name__}.{name}': duration}
+    profiling_metrics = {
+        f'profiling/Time taken: {trainer.__class__.__name__}.{name}': duration,
+        "step": trainer.state.global_step
+    }
 
     is_main_process = False
     if hasattr(trainer, 'accelerator'):


### PR DESCRIPTION
# PR type
- [ x ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

使用GKD trainer训练时，如设置report_to wandb，则会向wandb上报多次profiling，包括
- profiling/Time taken: MegatronGKDTrainer.export_weights
- profiling/Time taken: MegatronGKDTrainer._move_model_to_vllm
- profiling/Time taken: MegatronGKDTrainer._generate_completions

而每一次上报时没有指定step，导致每次上报都会让wandb的step自增，进而使得正确的日志(包含正确的step)进行上报时，会出现错误，从而被忽略，例如：wandb: WARNING Tried to lLog to step 1 that is less than the current step 3. Steps must be monotonically increasing, so this data 


## Experiment results

原先：
<img width="2462" height="560" alt="image" src="https://github.com/user-attachments/assets/f2ca85d1-c9fb-4b47-b284-c5711675693a" />
更新后：
<img width="2434" height="486" alt="image" src="https://github.com/user-attachments/assets/b2167b2b-a514-4e5e-9d64-6a2cec402132" />

