### PR TITLE
Fix/environment variable in multinode train

### DIFF
--- a/examples/train/multi-node/swift/train_node1.sh
+++ b/examples/train/multi-node/swift/train_node1.sh
@@ -1,12 +1,12 @@
 nnodes=2
 nproc_per_node=4
 
-export CUDA_VISIBLE_DEVICES=0,1,2,3 
-export NNODES=$nnodes 
-export NODE_RANK=0 
-export MASTER_ADDR=127.0.0.1 
-export MASTER_PORT=29500 
-export NPROC_PER_NODE=$nproc_per_node 
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+export NNODES=$nnodes
+export NODE_RANK=0
+export MASTER_ADDR=127.0.0.1
+export MASTER_PORT=29500
+export NPROC_PER_NODE=$nproc_per_node
 swift sft \
     --model Qwen/Qwen2.5-7B-Instruct \
     --tuner_type full \

--- a/examples/train/multi-node/swift/train_node1.sh
+++ b/examples/train/multi-node/swift/train_node1.sh
@@ -1,12 +1,12 @@
 nnodes=2
 nproc_per_node=4
 
-export CUDA_VISIBLE_DEVICES=0,1,2,3 \
-export NNODES=$nnodes \
-export NODE_RANK=0 \
-export MASTER_ADDR=127.0.0.1 \
-export MASTER_PORT=29500 \
-export NPROC_PER_NODE=$nproc_per_node \
+export CUDA_VISIBLE_DEVICES=0,1,2,3 
+export NNODES=$nnodes 
+export NODE_RANK=0 
+export MASTER_ADDR=127.0.0.1 
+export MASTER_PORT=29500 
+export NPROC_PER_NODE=$nproc_per_node 
 swift sft \
     --model Qwen/Qwen2.5-7B-Instruct \
     --tuner_type full \

--- a/examples/train/multi-node/swift/train_node1.sh
+++ b/examples/train/multi-node/swift/train_node1.sh
@@ -1,12 +1,12 @@
 nnodes=2
 nproc_per_node=4
 
-CUDA_VISIBLE_DEVICES=0,1,2,3 \
-NNODES=$nnodes \
-NODE_RANK=0 \
-MASTER_ADDR=127.0.0.1 \
-MASTER_PORT=29500 \
-NPROC_PER_NODE=$nproc_per_node \
+export CUDA_VISIBLE_DEVICES=0,1,2,3 \
+export NNODES=$nnodes \
+export NODE_RANK=0 \
+export MASTER_ADDR=127.0.0.1 \
+export MASTER_PORT=29500 \
+export NPROC_PER_NODE=$nproc_per_node \
 swift sft \
     --model Qwen/Qwen2.5-7B-Instruct \
     --tuner_type full \

--- a/examples/train/multi-node/swift/train_node2.sh
+++ b/examples/train/multi-node/swift/train_node2.sh
@@ -1,12 +1,12 @@
 nnodes=2
 nproc_per_node=4
 
-export CUDA_VISIBLE_DEVICES=0,1,2,3 \
-export NNODES=$nnodes \
-export NODE_RANK=1 \
-export MASTER_ADDR=xxx.xxx.xxx.xxx \
-export MASTER_PORT=29500 \
-export NPROC_PER_NODE=$nproc_per_node \
+export CUDA_VISIBLE_DEVICES=0,1,2,3 
+export NNODES=$nnodes 
+export NODE_RANK=1 
+export MASTER_ADDR=xxx.xxx.xxx.xxx 
+export MASTER_PORT=29500 
+export NPROC_PER_NODE=$nproc_per_node
 swift sft \
     --model Qwen/Qwen2.5-7B-Instruct \
     --tuner_type full \

--- a/examples/train/multi-node/swift/train_node2.sh
+++ b/examples/train/multi-node/swift/train_node2.sh
@@ -4,7 +4,7 @@ nproc_per_node=4
 export CUDA_VISIBLE_DEVICES=0,1,2,3 
 export NNODES=$nnodes 
 export NODE_RANK=1 
-export MASTER_ADDR=xxx.xxx.xxx.xxx 
+export MASTER_ADDR=xxx.xxx.xxx.xxx # FIXME: Replace with the IP address of the master node (node 1)
 export MASTER_PORT=29500 
 export NPROC_PER_NODE=$nproc_per_node
 swift sft \

--- a/examples/train/multi-node/swift/train_node2.sh
+++ b/examples/train/multi-node/swift/train_node2.sh
@@ -1,12 +1,12 @@
 nnodes=2
 nproc_per_node=4
 
-CUDA_VISIBLE_DEVICES=0,1,2,3 \
-NNODES=$nnodes \
-NODE_RANK=1 \
-MASTER_ADDR=xxx.xxx.xxx.xxx \
-MASTER_PORT=29500 \
-NPROC_PER_NODE=$nproc_per_node \
+export CUDA_VISIBLE_DEVICES=0,1,2,3 \
+export NNODES=$nnodes \
+export NODE_RANK=1 \
+export MASTER_ADDR=xxx.xxx.xxx.xxx \
+export MASTER_PORT=29500 \
+export NPROC_PER_NODE=$nproc_per_node \
 swift sft \
     --model Qwen/Qwen2.5-7B-Instruct \
     --tuner_type full \

--- a/examples/train/multi-node/swift/train_node2.sh
+++ b/examples/train/multi-node/swift/train_node2.sh
@@ -1,11 +1,11 @@
 nnodes=2
 nproc_per_node=4
 
-export CUDA_VISIBLE_DEVICES=0,1,2,3 
-export NNODES=$nnodes 
-export NODE_RANK=1 
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+export NNODES=$nnodes
+export NODE_RANK=1
 export MASTER_ADDR=xxx.xxx.xxx.xxx # FIXME: Replace with the IP address of the master node (node 1)
-export MASTER_PORT=29500 
+export MASTER_PORT=29500
 export NPROC_PER_NODE=$nproc_per_node
 swift sft \
     --model Qwen/Qwen2.5-7B-Instruct \


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [√] Document Updates
- [ ] More Models or Datasets Support

# PR information

In cloud servers, the environment variable names may differ from those used here (for example, in Tencent Cloud's DDP environment, NNODES is actually named WORLD_SIZE). This can cause torch.distributed.run to fail to recognize nnodes, preventing the master node and worker nodes from discovering each other.

The multi-node training examples in the examples directory may fail due to subtle differences in environment variable names, which can disrupt the normal training process. Additionally, the existing examples can mislead users into thinking that the training script reads values directly from the shell script rather than retrieving environment variables with the same names. This lacks sufficient guidance for beginners.