### PR TITLE
[bugfix] fallback to eager attention for MPS VL loaders

### DIFF
--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1055,6 +1055,13 @@ class Qwen3VLLoader(Qwen2VLLoader):
         require_version('qwen_vl_utils>=0.0.14')
         compat_qwen_vl_utils(image_patch_size=16)
 
+    def get_config(self, model_dir: str):
+        # torch SDPA on MPS currently mis-handles Qwen3-VL GQA during generation.
+        if self.attn_impl is None and self.model_kwargs.get('device_map') == 'mps':
+            self.attn_impl = 'eager'
+            logger.info('Setting attn_impl=eager for Qwen3-VL on MPS.')
+        return super().get_config(model_dir)
+
     def get_model(self, model_dir: str, config, processor, model_kwargs) -> PreTrainedModel:
         from transformers import Qwen3VLForConditionalGeneration
         self.auto_model_cls = self.auto_model_cls or Qwen3VLForConditionalGeneration

--- a/swift/model/models/stepfun.py
+++ b/swift/model/models/stepfun.py
@@ -133,6 +133,8 @@ register_model(
 class Step3VLLoader(ModelLoader):
 
     def get_config(self, model_dir: str) -> PretrainedConfig:
+        if self.attn_impl is None and self.model_kwargs.get('device_map') == 'mps':
+            self.attn_impl = 'eager'
         config = super().get_config(model_dir)
         config.vocab_size = config.text_config.vocab_size
         return config


### PR DESCRIPTION
## Summary
- force `attn_impl=eager` for `Qwen3VLLoader` on MPS when the user does not specify one
- apply the same MPS fallback to `Step3VLLoader` to avoid generation crashes

## Verification
- reproduced MPS generation failures locally before the change
- verified `swift deploy` on MPS no longer crashes immediately for Qwen3-VL and Step3-VL text generation
