### PR TITLE
[bugfix] initialize step3 image inputs for text-only requests

### DIFF
--- a/swift/template/templates/stepfun.py
+++ b/swift/template/templates/stepfun.py
@@ -316,6 +316,7 @@ class Step3VLTemplate(Template):
         input_ids = encoded['input_ids']
         labels = encoded['labels']
         loss_scale = encoded.get('loss_scale', None)
+        image_inputs = {}
 
         images = inputs.images
         if images:


### PR DESCRIPTION
## Summary
- initialize `image_inputs` in `Step3VLTemplate._encode()` before the image branch runs
- avoid text-only Step3 requests failing when the template later updates the encoded payload

## Verification
- reproduced the text-only Step3 template failure locally before the change
- verified text-only Step3 requests proceed through the template path after the fix
