### PR TITLE
[fix bugs] Megatron GKD Training

### DIFF
--- a/swift/megatron/trainers/gkd_trainer.py
+++ b/swift/megatron/trainers/gkd_trainer.py
@@ -471,6 +471,8 @@ class MegatronGKDTrainer(MegatronRolloutMixin, MegatronRLHFTrainer):
         args = self.args
         if labels is not None:
             mask = labels != -100
+            mask = mask[:, 1:]
+            mask = torch.cat([mask, torch.zeros_like(mask[:, -1:])], dim=-1)
             local_num_valid = mask.sum()
         else:
             mask = None
@@ -694,17 +696,7 @@ class MegatronGKDTrainer(MegatronRolloutMixin, MegatronRLHFTrainer):
                 s_logits = student_logits[student_mask][None]
                 teacher_api_logprobs = teacher_api_logprobs[teacher_mask][None]
                 teacher_api_indices = teacher_api_indices[teacher_mask][None]
-                # DEBUG
-                first_sample_top1_ids = teacher_api_indices[0, :, 0]
-                first_sample_top1_logprobs = teacher_api_logprobs[0, :, 0]
-                valid_pos = torch.isfinite(first_sample_top1_logprobs)
-                first_sample_top1_ids = first_sample_top1_ids[valid_pos].detach().cpu().tolist()
-                first_sample_top1_tokens = [
-                    self.template.safe_decode([token_id], skip_special_tokens=False)
-                    for token_id in first_sample_top1_ids
-                ]
-                logger.info(f"DEBUG: teacher_top1_first_sample_tokens={first_sample_top1_tokens}")
-                # DEBUG END
+
                 jsd_loss = self.generalized_jsd_loss(
                     student_logits=s_logits,
                     teacher_logits=None,


### PR DESCRIPTION
# PR type
- [ x ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

在使用Megatron版本进行GKD on-policy蒸馏时，共计遇到两个问题：
1. 当topk_logits启用时，teacher_prompt会被忽略。即原先的669行，会在teacher_logits为None时忽略掉teacher_prompt。但topk_logits启用时，local_teacher会在331行将teacher_logits置为None，api_teacher则会在373行将teacher_logits置为None。此时，teacher_topk_logits会根据student_label进行mask，这在teacher_prompt与student_prompt不同时，会引起匹配位置错误的bug。
2. logits与label均没shift，导致匹配错误。logits代表[P(t1|), P(t2|), ...P(tn+1|)；而label标记的则是[t0, t1, ... tn]。似乎应该类似于SFT那样，将logits右移一位，或者将label左移一位。考虑到当前代码组织，为方便考虑，左移label可能是更简单的选项。
  - 当我们同时使用teacher_prompt以及api_teacher时，此bug还会导致jsd_loss为nan。这是因为api_teacher的logits会被忽略掉时序步第0项(即None)，并在时序步的最右边填充pad(值为-inf)。本来最右边这个token对应student计算的P(tn+1|query+answer+EOS)，是一个应该被掩码忽略的项，但因为logits和label均没被正确的shift，使得该项(值为-inf)也参与了计算，进一步使得jsd_loss得到nan。

以上的bug或许在rlhf版本中同样存在
 
## Experiment results

仅在个人的场景下确定能得到修复
