### PR TITLE
[bugfix] disable redundant resizing in Qwen template for vLLM mode

### DIFF
--- a/swift/template/templates/qwen.py
+++ b/swift/template/templates/qwen.py
@@ -311,6 +311,9 @@ class Qwen2VLTemplate(Template):
         from qwen_vl_utils import fetch_image, fetch_video
         assert media_type in {'image', 'video'}
         kwargs = {'image_patch_size': self.processor.image_processor.patch_size} if self.version == 'v3' else {}
+        if self.mode == 'vllm':
+            # resized in qwen_vl_utils, no need to resize again in vllm
+            inputs.mm_processor_kwargs['do_resize'] = False
         if media_type == 'image':
             inputs.images[index] = fetch_image({'image': inputs.images[index]}, **kwargs)
             if self.mode == 'lmdeploy':


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

When using the vllm inference backend with QwenVL, a redundant resizing issue was identified.

First Resize: qwen_vl_utils processes the video according to https://github.com/modelscope/ms-swift/blob/main/swift/model/models/qwen.py#L659

Second Resize: vLLM's internal InputProcessor attempts to resize the input again by default (do_resize=True).

## Experiment results

We test some cases around ~150s, logging at swift side and vllm side

"spatial_merge_size": 2, -> 2*2=4 token into 1
"temporal_patch_size": 2 -> 2 frames into 1

### do_resize=True in vllm side: 32k max_model_len (300frames, ~91 tokens/frame)

<details>
<summary>
We found vllm resized again, from ~91 tokens/frame into ~72 tokens/frame.
</summary>

DISABLE_VERSION_CHECK=1 \
VIDEO_MIN_TOKEN_NUM=64 \
VIDEO_MAX_TOKEN_NUM=768 \
MODEL_SEQ_LEN=16000 \
FPS_MAX_FRAMES=768 \
FPS=2.0 \
OMP_NUM_THREADS=4 \
NPROC_PER_NODE=4 \
swift infer \
        --model Qwen/Qwen3.5-2B \
        --use_hf True \
        --infer_backend vllm \
        --val_dataset xx.json \
        --val_dataset_shuffle True \
        --temperature 1.0 \
        --top_p 0.95 \
        --top_k 20 \
        --vllm_gpu_memory_utilization 0.85 \
        --vllm_tensor_parallel_size 1 \
        --vllm_max_model_len 32768 \
        --write_batch_size 8


qwen-vl-utils using decord to read video.
Fetched video with shape torch.Size([300, 3, 224, 416]), video kwargs 1.999779579850754
WARNING 03-26 07:00:55 [input_processor.py:227] Passing raw prompts to InputProcessor is deprecated and will be removed in v0.18. You should instead pass the outputs of Renderer.render_cmpl() or Renderer.render_chat().
[WARNING:swift] [DEBUG_VIDEO_CONTEXT] request_id=1 prompt_token_ids_len=69 max_model_len=32768 media_counts={'images': 0, 'audios': 0, 'videos': 1} mm_processor_kwargs_keys=['do_sample_frames']
WARNING 03-26 07:01:04 [qwen3_vl.py:1060] [DEBUG_VIDEO_CONTEXT] vllm_qwen3vl_video raw_frames=300 video_grid_thw=[[150, 12, 24]] tokens_per_frame_base=72 tokens_per_frame_sum=10800 replacement_token_len=12190 timestamps=150 do_sample_frames=False
WARNING 03-26 07:01:04 [qwen3_vl.py:1090] [DEBUG_VIDEO_CONTEXT] vllm_qwen3vl_hf_video_placeholder hf_input_ids_len=12190 hf_video_token_count=10800 replacement_token_len=12190 raw_frames=300

</details>

### [!!!!!!] do_resize=True in vllm side: 32k max_model_len (768frames, ~768 tokens/frame)

<details>
<summary>
We consider a more corner case, the length is more than 32k and should raise error.
At this time, vllm resized again, as qwen-vl-utils resize into ~768tokens/frame, vllm resize into ~28tokens/frame.
</summary>

DISABLE_VERSION_CHECK=1 \
VIDEO_MIN_TOKEN_NUM=64 \
VIDEO_MAX_TOKEN_NUM=768 \
MODEL_SEQ_LEN=16000000 \
FPS_MAX_FRAMES=768 \
FPS=24 \
OMP_NUM_THREADS=4 \
NPROC_PER_NODE=4 \
swift infer \
        --model Qwen/Qwen3.5-2B \
        --use_hf True \
        --infer_backend vllm \
        --val_dataset xx.json \
        --val_dataset_shuffle True \
        --temperature 1.0 \
        --top_p 0.95 \
        --top_k 20 \
        --vllm_gpu_memory_utilization 0.85 \
        --vllm_tensor_parallel_size 1 \
        --vllm_max_model_len 32768 \
        --write_batch_size 8

Fetched video with shape torch.Size([768, 3, 288, 544]), video kwargs 5.12
[WARNING:swift] [DEBUG_VIDEO_CONTEXT] request_id=4 prompt_token_ids_len=63 max_model_len=32768 media_counts={'images': 0, 'audios': 0, 'videos': 1} mm_processor_kwargs_keys=['do_sample_frames']
WARNING 03-26 07:36:20 [qwen3_vl.py:1060] [DEBUG_VIDEO_CONTEXT] vllm_qwen3vl_video raw_frames=768 video_grid_thw=[[384, 8, 14]] tokens_per_frame_base=28 tokens_per_frame_sum=10752 replacement_token_len=14264 timestamps=384 do_sample_frames=False
WARNING 03-26 07:36:20 [qwen3_vl.py:1090] [DEBUG_VIDEO_CONTEXT] vllm_qwen3vl_hf_video_placeholder hf_input_ids_len=14264 hf_video_token_count=10752 replacement_token_len=14264 raw_frames=768

</details>

### do_resize=False in vllm side: 32k max_model_len (768frames, ~768 tokens/frame)

<details>
<summary>
Expected Behavior 
</summary>

DISABLE_VERSION_CHECK=1 \
VIDEO_MIN_TOKEN_NUM=64 \
VIDEO_MAX_TOKEN_NUM=768 \
MODEL_SEQ_LEN=16000000 \
FPS_MAX_FRAMES=768 \
FPS=24 \
OMP_NUM_THREADS=4 \
NPROC_PER_NODE=4 \
swift infer \
        --model Qwen/Qwen3.5-2B \
        --use_hf True \
        --infer_backend vllm \
        --val_dataset xx.json \
        --val_dataset_shuffle True \
        --temperature 1.0 \
        --top_p 0.95 \
        --top_k 20 \
        --vllm_gpu_memory_utilization 0.85 \
        --vllm_tensor_parallel_size 1 \
        --vllm_max_model_len 32768 \
        --write_batch_size 8


Fetched video with shape torch.Size([768, 3, 288, 544]), video kwargs 5.119435724417931
WARNING 03-26 07:16:30 [input_processor.py:227] Passing raw prompts to InputProcessor is deprecated and will be removed in v0.18. You should instead pass the outputs of Renderer.render_cmpl() or Renderer.render_chat().
WARNING 03-26 07:16:43 [qwen3_vl.py:1060] [DEBUG_VIDEO_CONTEXT] vllm_qwen3vl_video raw_frames=768 video_grid_thw=[[384, 18, 34]] tokens_per_frame_base=153 tokens_per_frame_sum=58752 replacement_token_len=62310 timestamps=384 do_sample_frames=False
WARNING 03-26 07:16:43 [qwen3_vl.py:1090] [DEBUG_VIDEO_CONTEXT] vllm_qwen3vl_hf_video_placeholder hf_input_ids_len=62310 hf_video_token_count=58752 replacement_token_len=62310 raw_frames=768
[rank0]: Traceback (most recent call last):
...
[rank0]: ValueError: The decoder prompt (length 62349) is longer than the maximum model length of 32768. Make sure that `max_model_len` is no smaller than the number of text tokens plus multimodal tokens. For image inputs, the number of image tokens depends on the number of images, and possibly their aspect ratios as well.

</details>
