### PR TITLE
[megatron]delete cpu sync

### DIFF
--- a/swift/megatron/init.py
+++ b/swift/megatron/init.py
@@ -745,12 +745,7 @@ def _patch_mrope():
         Returns:
             Tensor: Shape [t, h, d]. The input tensor after applying RoPE.
         """
-        if cp_group is not None:
-            cp_size = cp_group.size()
-        else:
-            cp_size = mpu.get_context_parallel_world_size()
-        cu_seqlens_for_batched = cu_seqlens // cp_size
-        use_batched_rope = (freqs.dim() >= 1 and freqs.shape[0] == cu_seqlens_for_batched[-1]).item()
+        use_batched_rope = freqs.dim() >= 1 and freqs.shape[0] == t.shape[0]
         if not use_batched_rope:
             logger.warning_once('Using non-batched RoPE, which may affect performance.')
             kwargs = {'cp_group': cp_group} if mcore_013 else {}


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

1. Delete the CPU sync when rope, which speeds up 1.5%.


before:
<img width="962" height="125" alt="image" src="https://github.com/user-attachments/assets/d6e7f81b-afc4-4449-b5b6-cd094691c814" />

after:
<img width="708" height="175" alt="image" src="https://github.com/user-attachments/assets/52060e28-f58c-451b-8907-08f2c1eeeb81" />



## Experiment results

Paste your experiment result here(if needed).
