### PR TITLE
[bugfix] Fix Qwen3.5 LoRA merge export producing wrong state_dict keys

### DIFF
--- a/swift/model/utils.py
+++ b/swift/model/utils.py
@@ -296,7 +296,15 @@ def save_checkpoint(model: Optional[PreTrainedModel],
                     additional_saved_files: Optional[List[str]] = None) -> None:
     if model is not None:
         if model.__class__.__name__ != 'SentenceTransformer':
-            model.save_pretrained(output_dir, safe_serialization=safe_serialization, max_shard_size=max_shard_size)
+            # Pass save_original_format=False to avoid transformers>=5.5 revert_weight_conversion bug
+            # that corrupts state_dict keys for composite models (e.g. Qwen3.5).
+            # See: https://github.com/modelscope/ms-swift/issues/9046
+            save_kwargs = {}
+            import inspect
+            if 'save_original_format' in inspect.signature(model.save_pretrained).parameters:
+                save_kwargs['save_original_format'] = False
+            model.save_pretrained(
+                output_dir, safe_serialization=safe_serialization, max_shard_size=max_shard_size, **save_kwargs)
         else:
             model.save_pretrained(output_dir, safe_serialization=safe_serialization)
             # copy sentencetransformers files


### PR DESCRIPTION
## Issue

Fixes https://github.com/modelscope/ms-swift/issues/9046

## Root Cause

When using , the  method applies  which uses the model's conversion mapping (e.g. ) in reverse during saving. For composite models like Qwen3.5 (which has a  submodule), this causes state_dict keys to be incorrectly prefixed.

For example:
-  becomes 
-  becomes 

This makes the exported model unusable.

## Fix

Pass  to  to skip the buggy  step. The fix uses  to check parameter availability for backward compatibility with older transformers versions.

## Testing

Verified with Qwen3.5-0.8B + LoRA merge export:
- Before fix: All 473 keys had wrong prefixes
- After fix: All 473 keys are correct and model loads successfully
