### PR TITLE
[bugfix] fix multi-node server mode weight sync race condition

### DIFF
--- a/swift/megatron/trainers/rollout_mixin.py
+++ b/swift/megatron/trainers/rollout_mixin.py
@@ -21,7 +21,8 @@ from swift.infer_engine.protocol import RequestConfig, RolloutInferRequest, Roll
 from swift.rlhf_trainers.utils import (FlattenedTensorBucket, aggressive_empty_cache, check_vllm_version_ge,
                                        patch_vllm_moe_model_weight_loader, profiling_context, profiling_decorator,
                                        set_expandable_segments)
-from swift.utils import get_current_device, get_logger, is_last_rank, is_vllm_available, remove_response, synchronize, to_device
+from swift.utils import (get_current_device, get_logger, is_last_rank, is_vllm_available, remove_response, synchronize,
+                         to_device)
 from .utils import (gather_object, load_megatron_model_to_gpu, load_megatron_optimizer, offload_megatron_model_to_cpu,
                     offload_megatron_optimizer)
 

--- a/swift/megatron/trainers/rollout_mixin.py
+++ b/swift/megatron/trainers/rollout_mixin.py
@@ -21,7 +21,7 @@ from swift.infer_engine.protocol import RequestConfig, RolloutInferRequest, Roll
 from swift.rlhf_trainers.utils import (FlattenedTensorBucket, aggressive_empty_cache, check_vllm_version_ge,
                                        patch_vllm_moe_model_weight_loader, profiling_context, profiling_decorator,
                                        set_expandable_segments)
-from swift.utils import get_current_device, get_logger, is_last_rank, is_vllm_available, remove_response, to_device
+from swift.utils import get_current_device, get_logger, is_last_rank, is_vllm_available, remove_response, synchronize, to_device
 from .utils import (gather_object, load_megatron_model_to_gpu, load_megatron_optimizer, offload_megatron_model_to_cpu,
                     offload_megatron_optimizer)
 
@@ -338,6 +338,10 @@ class MegatronRolloutMixin:
         """Synchronize a bucket of parameters to vLLM server."""
         if not bucket_params or not self.is_main_process:
             return
+
+        # Ensure all async GPU ops (e.g. TP all-gather on NCCL stream from bridge.export_weights)
+        # are complete before .copy_() reads param data on the default stream.
+        synchronize()
 
         bucket = FlattenedTensorBucket(named_tensors=bucket_params)
         metadatas = bucket.get_metadata()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

## Problem
In multi-node Megatron GRPO training with server-mode vLLM rollout, the model rapidly collapses when lr > 0. Even with lr = 0 and the same data repeated, rollout performance degrades over generations (e.g., action format reward drops from 0.95 to 0.44). Single-node training is not affected.

## Root Cause
`bridge.export_weights()` reconstructs full-rank tensors from TP shards via all-gather operations that execute on the NCCL TP communication stream. These tensors are then collected into buckets and copied into a flattened buffer by `FlattenedTensorBucket.__init__()`, which uses `.copy_()` on the default CUDA stream.

Since CUDA does not enforce execution ordering across different streams, the `.copy_()` kernels on the default stream can read from tensors whose underlying all-gather operations on the NCCL stream have not yet completed, resulting in stale data being copied into the flattened buffer. The `synchronize()` call inside `vllm_client.update_flattened_params` occurs after the flattened tensor is already constructed, so it cannot prevent this.

In single-node setups, TP all-gathers over NVLink are fast enough that the race window is negligible. In multi-node setups, all-gathers over the network have significantly higher latency, making it far more likely for `.copy_()` to execute before the all-gather completes.

## Fix
Add a `synchronize()` call in `_sync_bucket_to_server()` before `FlattenedTensorBucket` construction. This waits for all CUDA streams (including the NCCL TP stream) to complete, ensuring that every parameter tensor holds its final data before `.copy_()` reads it.
