### PR TITLE
[bugfix] fix qwen3 omni template

### DIFF
--- a/swift/template/templates/qwen.py
+++ b/swift/template/templates/qwen.py
@@ -888,7 +888,6 @@ class Qwen2_5OmniTemplate(Qwen2_5VLTemplate):
             position_ids = position_ids.to(torch.int64)
         return {'position_ids': self._concat_text_position_ids(position_ids)}
 
-
     def _data_collator_mm_data(self, batch: List[Dict[str, Any]]) -> Dict[str, Any]:
         res = super()._data_collator_mm_data(batch)
         video_second_per_grid = self.gather_list(batch, 'video_second_per_grid')

--- a/swift/template/templates/qwen.py
+++ b/swift/template/templates/qwen.py
@@ -886,7 +886,8 @@ class Qwen2_5OmniTemplate(Qwen2_5VLTemplate):
         )
         if torch.is_floating_point(position_ids):
             position_ids = position_ids.to(torch.int64)
-        return self._concat_text_position_ids(position_ids)
+        return {'position_ids': self._concat_text_position_ids(position_ids)}
+
 
     def _data_collator_mm_data(self, batch: List[Dict[str, Any]]) -> Dict[str, Any]:
         res = super()._data_collator_mm_data(batch)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Summary

Fix the Qwen3 Omni template contract so `position_ids` is returned as a mapping instead of a raw tensor in the padding-free / packing path.

## Background

`Qwen3 Omni` goes through `packing_row()` during `padding_free` training. That path expects `_get_position_ids()` to return a dictionary, because the result is consumed via `dict.update(...)`.

Before this change, `Qwen2_5OmniTemplate._get_position_ids()` returned a bare tensor:

```python
return self._concat_text_position_ids(position_ids)
```

This caused `dict.update()` to fail with:

```text
ValueError: dictionary update sequence element #0 has length 1; 2 is required
```

## What Changed

- Changed `Qwen2_5OmniTemplate._get_position_ids()` to return:
  ```python
  {'position_ids': self._concat_text_position_ids(position_ids)}
  ```
- Kept the `packing_row()` and `_data_collator()` call sites unchanged.
- Restored the expected template contract without adding extra compatibility branches.

## Validation

- Added a regression test that directly verifies:
  ```python
  res.update(template._get_position_ids(inputs))
  ```
  no longer raises.