### PR TITLE
Update npu mindspeed doc and fix new version mindspeed's cp error

### DIFF
--- a/docs/source/BestPractices/NPU-support.md
+++ b/docs/source/BestPractices/NPU-support.md
@@ -25,7 +25,7 @@
 ### 环境安装
 ```shell
 # 创建新的 conda 虚拟环境（可选）
-conda create -n swift-npu python=3.10 -y
+conda create -n swift-npu python=3.11 -y
 conda activate swift-npu
 
 # 注意进行后续操作前要先 source 激活 CANN 环境
@@ -41,7 +41,7 @@ cd ms-swift
 pip install -e .
 
 # 安装 torch-npu
-pip install torch-npu decorator
+pip install torch_npu decorator
 # 如果你想要使用 deepspeed（控制显存占用，训练速度会有一定下降）
 pip install deepspeed
 
@@ -65,20 +65,26 @@ print(torch.randn(10, device='npu:0'))
 
 **如果需要使用 MindSpeed(Megatron-LM)，请按照下面引导安装必要依赖**
 ```shell
-# 1. 获取并切换 Megatron-LM 至 core_v0.12.1 版本
+# 1. 获取并切换 Megatron-LM 至 v0.15.3 版本
 git clone https://github.com/NVIDIA/Megatron-LM.git
 cd Megatron-LM
-git checkout core_v0.12.1
+git checkout v0.15.3
 cd ..
 
 # 2. 获取并安装 MindSpeed
 git clone https://gitcode.com/Ascend/MindSpeed.git
 cd MindSpeed
-git checkout 2.3.0_core_r0.12.1
+git checkout core_r0.15.3
 pip install -e .
 cd ..
 
-# 3. 设置环境变量
+# 3. 获取并安装 mcore-bridge
+git clone https://github.com/modelscope/mcore-bridge.git
+cd mcore-bridge
+pip install -e .
+cd ..
+
+# 4. 设置环境变量
 export PYTHONPATH=$PYTHONPATH:<your_local_megatron_lm_path>
 export MEGATRON_LM_PATH=<your_local_megatron_lm_path>
 ```
@@ -303,10 +309,10 @@ ASCEND_RT_VISIBLE_DEVICES=0 swift deploy --model xxx/checkpoint-xxx-merged --max
 使用pypi进行安装：
 ```shell
 # Install vllm-project/vllm. The newest supported version is v0.11.0.
-pip install vllm==0.11.0
+pip install vllm==0.14.0
 
 # Install vllm-project/vllm-ascend from pypi.
-pip install vllm-ascend==0.11.0rc3
+pip install vllm-ascend==0.14.0rc1
 ```
 原始模型：
 ```shell

--- a/swift/megatron/pipelines/train/sft.py
+++ b/swift/megatron/pipelines/train/sft.py
@@ -14,6 +14,7 @@ from swift.utils import append_to_jsonl, get_logger, is_last_rank, plot_images
 if is_torch_npu_available():
     # Enable Megatron on Ascend NPU
     from mindspeed.megatron_adaptor import repatch
+
     from swift.model.npu_patcher import patch_mindspeed_te_cp_implementation
 else:
     repatch = None

--- a/swift/megatron/pipelines/train/sft.py
+++ b/swift/megatron/pipelines/train/sft.py
@@ -14,8 +14,10 @@ from swift.utils import append_to_jsonl, get_logger, is_last_rank, plot_images
 if is_torch_npu_available():
     # Enable Megatron on Ascend NPU
     from mindspeed.megatron_adaptor import repatch
+    from swift.model.npu_patcher import patch_mindspeed_te_cp_implementation
 else:
     repatch = None
+    patch_mindspeed_te_cp_implementation = None
 
 logger = get_logger()
 
@@ -47,6 +49,7 @@ class MegatronSft(SwiftSft):
                 # to enable flash attention on Ascend NPU.
                 args.use_flash_attn = True
                 megatron_args['use_flash_attn'] = True
+            patch_mindspeed_te_cp_implementation(megatron_args)
             repatch(megatron_args)
         template_cls = args.template_meta.template_cls
         if args.model_meta.is_multimodal and template_cls and template_cls.use_model:

--- a/swift/model/npu_patcher.py
+++ b/swift/model/npu_patcher.py
@@ -40,8 +40,8 @@ def patch_mindspeed_te_cp_implementation(megatron_args: dict[str, Any]) -> None:
     only supports kvallgather.
     """
     try:
-        from mindspeed.core.context_parallel.adaptor import MindSpeedCPDotProductAttention
         import mindspeed.te.pytorch.attention.dot_product_attention.dot_product_attention as ms_te_dpa
+        from mindspeed.core.context_parallel.adaptor import MindSpeedCPDotProductAttention
     except ImportError as e:
         logger.warning(f'Failed to import MindSpeed CP modules before repatch: {e}')
         return

--- a/swift/model/npu_patcher.py
+++ b/swift/model/npu_patcher.py
@@ -20,6 +20,7 @@ from swift.utils.logger import get_logger
 logger = get_logger()
 
 _DEFAULT_NPU_HCCL_CONNECT_TIMEOUT = '600'
+_ORIGINAL_MINDSPEED_TE_CP_CLASS = None
 
 
 def _set_default_hccl_connect_timeout_for_npu() -> None:
@@ -31,6 +32,42 @@ def _set_default_hccl_connect_timeout_for_npu() -> None:
 
 
 _set_default_hccl_connect_timeout_for_npu()
+
+
+def patch_mindspeed_te_cp_implementation(megatron_args: dict[str, Any]) -> None:
+    """
+    Route NPU CP to the legacy MindSpeed TE adaptor when the new strategy factory
+    only supports kvallgather.
+    """
+    try:
+        from mindspeed.core.context_parallel.adaptor import MindSpeedCPDotProductAttention
+        import mindspeed.te.pytorch.attention.dot_product_attention.dot_product_attention as ms_te_dpa
+    except ImportError as e:
+        logger.warning(f'Failed to import MindSpeed CP modules before repatch: {e}')
+        return
+
+    global _ORIGINAL_MINDSPEED_TE_CP_CLASS
+    if _ORIGINAL_MINDSPEED_TE_CP_CLASS is None:
+        _ORIGINAL_MINDSPEED_TE_CP_CLASS = getattr(ms_te_dpa, 'MindSpeedTEDotProductAttention', None)
+
+    if _ORIGINAL_MINDSPEED_TE_CP_CLASS is None:
+        logger.warning('MindSpeedTEDotProductAttention is unavailable before repatch; skip CP workaround.')
+        return
+
+    cp_algo = megatron_args.get('context_parallel_algo', 'megatron_cp_algo')
+    use_legacy_cp_te = int(megatron_args.get('context_parallel_size', 1)) > 1 and cp_algo != 'kvallgather_cp_algo'
+    target_cls = MindSpeedCPDotProductAttention if use_legacy_cp_te else _ORIGINAL_MINDSPEED_TE_CP_CLASS
+
+    if getattr(ms_te_dpa, 'MindSpeedTEDotProductAttention', None) is target_cls:
+        return
+
+    ms_te_dpa.MindSpeedTEDotProductAttention = target_cls
+    logger.info(
+        'Patched MindSpeedTEDotProductAttention to %s for context_parallel_size=%s, context_parallel_algo=%s.',
+        target_cls.__name__,
+        megatron_args.get('context_parallel_size', 1),
+        cp_algo,
+    )
 
 
 class NPUCastError(RuntimeError):


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information

Update the NPU documentation to support mindspeed/megatron 0.15.3, and fix the CP error issues that may be caused by the new version of mindspeed.