### PR TITLE
Fix message access in infer_requests

### DIFF
--- a/swift/pipelines/sampling/distill_sampler.py
+++ b/swift/pipelines/sampling/distill_sampler.py
@@ -32,7 +32,7 @@ class OpenAIEngine:
         for infer_request in infer_requests:
             completion = self.client.chat.completions.create(
                 model=self.model,
-                messages=infer_request['messages'],
+                messages=infer_request.messages,
                 temperature=request_config.temperature,
                 top_p=request_config.top_p,
                 max_tokens=request_config.max_tokens,


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Due to the definition of swift.infer_engine.protocol.InferRequest, the swift.pipelines.sampling.distill_sampler.OpenAIEngine may have to use a different way to access the infer_requests.