### PR TITLE
[grpo] set default load_format auto

### DIFF
--- a/swift/megatron/trainers/rollout_mixin.py
+++ b/swift/megatron/trainers/rollout_mixin.py
@@ -244,7 +244,7 @@ class MegatronRolloutMixin:
         logprobs_mode = 'processed_logprobs' if self.vllm_version_ge_0_10_2 else None
 
         vllm_engine_kwargs = args.vllm_engine_kwargs or {}
-        load_format = vllm_engine_kwargs.pop('load_format', 'dummy')
+        load_format = vllm_engine_kwargs.pop('load_format', 'auto')
 
         if self.args.router_replay_mode == 'R3':
             assert check_vllm_version_ge('0.14.0'), \

--- a/swift/pipelines/infer/rollout.py
+++ b/swift/pipelines/infer/rollout.py
@@ -449,9 +449,6 @@ class SwiftRolloutDeploy(SwiftPipeline):
         # for RL rollout model weight sync
         engine_kwargs.update({'worker_extension_cls': 'swift.pipelines.infer.rollout.WeightSyncWorkerExtension'})
 
-        # For RL rollout, we use 'dummy' load_format to prevent vLLM from loading weights from disk,
-        # as they will be synced from the trainer process.
-        # This will accelerate the rollout speed.
         load_format = engine_kwargs.pop('load_format', 'auto')
         kwargs['load_format'] = load_format
 

--- a/swift/pipelines/infer/rollout.py
+++ b/swift/pipelines/infer/rollout.py
@@ -452,7 +452,7 @@ class SwiftRolloutDeploy(SwiftPipeline):
         # For RL rollout, we use 'dummy' load_format to prevent vLLM from loading weights from disk,
         # as they will be synced from the trainer process.
         # This will accelerate the rollout speed.
-        load_format = engine_kwargs.pop('load_format', 'dummy')
+        load_format = engine_kwargs.pop('load_format', 'auto')
         kwargs['load_format'] = load_format
 
         if args.vllm_use_async_engine and args.vllm_data_parallel_size > 1:

--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -235,7 +235,7 @@ class RolloutTrainerMixin(RLHFTrainerMixin):
             set_expandable_segments(False)
             # Use load_format from vllm_engine_kwargs if provided, otherwise default to 'dummy'
             vllm_engine_kwargs = self.args.vllm_engine_kwargs or {}
-            load_format = vllm_engine_kwargs.pop('load_format', 'dummy')
+            load_format = vllm_engine_kwargs.pop('load_format', 'auto')
             engine = GRPOVllmEngine(
                 model.model_dir,
                 torch_dtype=model.model_info.torch_dtype,

--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -233,7 +233,7 @@ class RolloutTrainerMixin(RLHFTrainerMixin):
 
         with Swift.grpo_context(model, self.template.processor):
             set_expandable_segments(False)
-            # Use load_format from vllm_engine_kwargs if provided, otherwise default to 'dummy'
+            # Use load_format from vllm_engine_kwargs if provided, otherwise default to 'auto'
             vllm_engine_kwargs = self.args.vllm_engine_kwargs or {}
             load_format = vllm_engine_kwargs.pop('load_format', 'auto')
             engine = GRPOVllmEngine(


### PR DESCRIPTION
https://github.com/modelscope/ms-swift/issues/9096

Some models, such as Gemma4, have buffer weights that are not covered by the current weight synchronization logic. Previously, the default load_format was set to dummy, which caused these buffer weights to be incorrectly initialized. Set load_format to auto to work around this issue.