### PR TITLE
feat(qwen): add sequence parallel support for Qwen3.5 linear attention

### DIFF
--- a/examples/train/sequence_parallel/sequence_parallel_qwen3_5.sh
+++ b/examples/train/sequence_parallel/sequence_parallel_qwen3_5.sh
@@ -1,0 +1,35 @@
+# Env: 8 * H800
+# Max Length: 65536
+# GPU Memory: 8 * 80GiB, Training Speed 18.97s/it
+NPROC_PER_NODE=8 \
+CELOSS_PARALLEL_SIZE=2048 \
+swift sft \
+    --model Qwen/Qwen3.5-4B \
+    --dataset 'AI-ModelScope/LongAlpaca-12k' \
+    --load_from_cache_file true \
+    --tuner_type lora \
+    --torch_dtype bfloat16 \
+    --per_device_train_batch_size 2 \
+    --target_modules all-linear \
+    --gradient_accumulation_steps 8 \
+    --save_total_limit 2 \
+    --save_only_model true \
+    --save_steps 50 \
+    --max_length 65535 \
+    --warmup_ratio 0.05 \
+    --attn_impl flash_attn \
+    --logging_steps 1 \
+    --use_logits_to_keep false \
+    --sequence_parallel_size 4 \
+    --padding_free true
+# Train:   1%|          | 1/189 [02:41<8:25:06, 161.21s/it]
+
+# {'loss': '1.461', 'grad_norm': '1.705', 'learning_rate': '1e-05', 'token_acc': '0.6399', 'epoch': '0.016', 'global_step/max_steps': '1/189', 'elapsed_time': '2m 41s', 'remaining_time': '8h 25m 20s', 'memory(GiB)': '67.95', 'train_speed(s/it)': '161.3'}
+# {'loss': '1.484', 'grad_norm': '1.666', 'learning_rate': '2e-05', 'token_acc': '0.6324', 'epoch': '0.032', 'global_step/max_steps': '2/189', 'elapsed_time': '3m 55s', 'remaining_time': '6h 6m 35s', 'memory(GiB)': '68.05', 'train_speed(s/it)': '117.6'}
+# {'loss': '1.477', 'grad_norm': '1.767', 'learning_rate': '3e-05', 'token_acc': '0.6311', 'epoch': '0.048', 'global_step/max_steps': '3/189', 'elapsed_time': '4m 48s', 'remaining_time': '4h 57m 21s', 'memory(GiB)': '68.05', 'train_speed(s/it)': '95.92'}
+# {'loss': '1.498', 'grad_norm': '1.683', 'learning_rate': '4e-05', 'token_acc': '0.6355', 'epoch': '0.064', 'global_step/max_steps': '4/189', 'elapsed_time': '5m 36s', 'remaining_time': '4h 18m 56s', 'memory(GiB)': '68.05', 'train_speed(s/it)': '83.98'}
+# {'loss': '1.422', 'grad_norm': '1.528', 'learning_rate': '5e-05', 'token_acc': '0.6329', 'epoch': '0.08', 'global_step/max_steps': '5/189', 'elapsed_time': '6m 17s', 'remaining_time': '3h 51m 17s', 'memory(GiB)': '68.05', 'train_speed(s/it)': '75.42'}
+# {'loss': '1.322', 'grad_norm': '1.203', 'learning_rate': '6e-05', 'token_acc': '0.6457', 'epoch': '0.096', 'global_step/max_steps': '6/189', 'elapsed_time': '6m 53s', 'remaining_time': '3h 30m 1s', 'memory(GiB)': '68.05', 'train_speed(s/it)': '68.86'}
+# ...
+# Train:  24%|██▍       | 46/189 [17:53<45:13, 18.97s/it]
+# {'loss': '1.049', 'grad_norm': '0.6095', 'learning_rate': '9.035e-05', 'token_acc': '0.7018', 'epoch': '0.736', 'global_step/max_steps': '46/189', 'elapsed_time': '17m 54s', 'remaining_time': '55m 38s', 'memory(GiB)': '68.06', 'train_speed(s/it)': '23.34'}

--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1,14 +1,24 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import importlib.metadata
-import inspect
+import math
 import os
 import torch
+import torch.nn.functional as F
 import transformers
 from packaging import version
 from PIL import Image
 from transformers import AutoTokenizer, BitsAndBytesConfig, PretrainedConfig, PreTrainedModel, PreTrainedTokenizerBase
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
 from transformers.models.auto.tokenization_auto import get_tokenizer_config
+
+try:
+    from transformers.utils.import_utils import is_flash_linear_attention_available
+except ImportError:
+
+    def is_flash_linear_attention_available():
+        return False
+
+
 from transformers.utils.versions import require_version
 from types import MethodType
 from typing import Any, Dict, Optional, Tuple, Type, Union
@@ -25,6 +35,20 @@ from ..utils import AttnImpl, use_submodel_func
 
 logger = get_logger()
 dtype_mapping = {torch.float16: 'fp16', torch.bfloat16: 'bf16', torch.float32: 'fp32'}
+
+if is_flash_linear_attention_available():
+    try:
+        from fla.modules.convolution import causal_conv1d as _FLA_CAUSAL_CONV1D_FN
+        from fla.ops.gated_delta_rule import chunk_gated_delta_rule as _FLA_CHUNK_GATED_DELTA_RULE
+    except Exception:
+        _FLA_CAUSAL_CONV1D_FN = None
+        _FLA_CHUNK_GATED_DELTA_RULE = None
+else:
+    _FLA_CAUSAL_CONV1D_FN = None
+    _FLA_CHUNK_GATED_DELTA_RULE = None
+
+_SP_LINEAR_KERNEL_IMPORT_ERROR = ('Qwen3.5 linear attention sequence parallel requires flash-linear-attention. '
+                                  'Install: https://github.com/fla-org/flash-linear-attention#installation')
 
 
 class QwenLoader(ModelLoader):
@@ -1131,11 +1155,272 @@ register_model(
         tags=['vision', 'video']))
 
 
+def _sp_is_enabled(sequence_parallel_context) -> bool:
+    return bool(
+        sequence_parallel_context is not None and int(getattr(sequence_parallel_context, 'sp_world_size', 1) or 1) > 1)
+
+
+def _get_sp_rank(sequence_parallel_context) -> int:
+    return int(getattr(sequence_parallel_context, 'sp_rank', 0) or 0)
+
+
+def seq_to_head_shard(input: torch.Tensor, sequence_parallel_context) -> torch.Tensor:
+    if not _sp_is_enabled(sequence_parallel_context):
+        return input
+    from swift.sequence_parallel.ulysses import _SeqAllToAll
+    return _SeqAllToAll.apply(sequence_parallel_context.sp_group, input, 2, 1)
+
+
+def head_to_seq_shard(input: torch.Tensor, sequence_parallel_context) -> torch.Tensor:
+    if not _sp_is_enabled(sequence_parallel_context):
+        return input
+    from swift.sequence_parallel.ulysses import _SeqAllToAll
+    return _SeqAllToAll.apply(sequence_parallel_context.sp_group, input, 1, 2)
+
+
+def _get_local_padding_mask(attention_mask: torch.Tensor, local_seq_len: int, sequence_parallel_context):
+    if attention_mask.shape[1] == local_seq_len or not _sp_is_enabled(sequence_parallel_context):
+        return attention_mask
+    real_position_ids = getattr(sequence_parallel_context, 'real_position_ids', None)
+    return sequence_parallel_context.split(attention_mask, dim=1, position_ids=real_position_ids)
+
+
+def _ensure_linear_attention_kernels(mod: torch.nn.Module) -> None:
+    mod.causal_conv1d_fn = _FLA_CAUSAL_CONV1D_FN
+    mod.chunk_gated_delta_rule = getattr(mod, 'chunk_gated_delta_rule', None) or _FLA_CHUNK_GATED_DELTA_RULE
+    if mod.chunk_gated_delta_rule is None or mod.causal_conv1d_fn is None:
+        raise ImportError(_SP_LINEAR_KERNEL_IMPORT_ERROR)
+
+
+def _get_local_conv_weights(mod: torch.nn.Module, *, sp_rank: int, local_num_k_heads: int, local_num_v_heads: int):
+    conv_weight = mod.conv1d.weight.squeeze(1)
+    conv_bias = getattr(mod.conv1d, 'bias', None)
+
+    local_key_dim = local_num_k_heads * mod.head_k_dim
+    local_value_dim = local_num_v_heads * mod.head_v_dim
+    q_start = sp_rank * local_key_dim
+    k_start = mod.key_dim + sp_rank * local_key_dim
+    v_start = 2 * mod.key_dim + sp_rank * local_value_dim
+
+    conv_weight = torch.cat([
+        conv_weight[q_start:q_start + local_key_dim],
+        conv_weight[k_start:k_start + local_key_dim],
+        conv_weight[v_start:v_start + local_value_dim],
+    ],
+                            dim=0)
+    if conv_bias is not None:
+        conv_bias = torch.cat([
+            conv_bias[q_start:q_start + local_key_dim],
+            conv_bias[k_start:k_start + local_key_dim],
+            conv_bias[v_start:v_start + local_value_dim],
+        ],
+                              dim=0)
+    return conv_weight, conv_bias
+
+
+def _get_qwen3_5_cu_seqlens_q(sequence_parallel_context):
+    if not bool(getattr(sequence_parallel_context, 'padding_free', False)):
+        return None
+    real_position_ids = getattr(sequence_parallel_context, 'real_position_ids', None)
+    if torch.is_tensor(real_position_ids) and real_position_ids.ndim == 2 and real_position_ids.shape[0] == 1:
+        from swift.utils import get_cu_seqlens_from_position_ids
+        padded_position_ids = sequence_parallel_context.pad(
+            real_position_ids, padding_value=-1, position_ids=real_position_ids)
+        return get_cu_seqlens_from_position_ids(padded_position_ids)
+    return None
+
+
+def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
+    mod: torch.nn.Module,
+    hidden_states: torch.Tensor,
+    *,
+    cache_params=None,
+    cache_position=None,
+    attention_mask: Optional[torch.Tensor] = None,
+    sequence_parallel_context=None,
+) -> torch.Tensor:
+    _ensure_linear_attention_kernels(mod)
+    from transformers.models.qwen3_5.modeling_qwen3_5 import apply_mask_to_padding_states
+
+    local_attention_mask = attention_mask
+    if torch.is_tensor(attention_mask) and attention_mask.dim() == 2:
+        local_attention_mask = _get_local_padding_mask(attention_mask, hidden_states.shape[1],
+                                                       sequence_parallel_context)
+    hidden_states = apply_mask_to_padding_states(hidden_states, local_attention_mask)
+    batch_size, seq_len, _ = hidden_states.shape
+
+    has_previous_state = bool(cache_params is not None and getattr(cache_params, 'has_previous_state', False))
+    use_precomputed_states = has_previous_state and seq_len == 1 and cache_position is not None
+    if use_precomputed_states:
+        raise NotImplementedError(
+            'Qwen3.5 linear attention sequence parallel only supports training/prefill paths; decode with '
+            'cached states is not supported.')
+
+    mixed_qkv = mod.in_proj_qkv(hidden_states)
+    z = mod.in_proj_z(hidden_states).reshape(batch_size, seq_len, mod.num_v_heads, mod.head_v_dim)
+    b = mod.in_proj_b(hidden_states)
+    a = mod.in_proj_a(hidden_states)
+
+    sp_enabled = _sp_is_enabled(sequence_parallel_context)
+    if sp_enabled:
+        sp_world_size = int(sequence_parallel_context.sp_world_size)
+        if mod.num_k_heads % sp_world_size != 0 or mod.num_v_heads % sp_world_size != 0:
+            raise RuntimeError(
+                'Qwen3.5 linear attention sequence parallel requires sp_world_size to divide both '
+                f'linear_num_key_heads ({mod.num_k_heads}) and linear_num_value_heads ({mod.num_v_heads}).')
+        local_num_k_heads = mod.num_k_heads // sp_world_size
+        local_num_v_heads = mod.num_v_heads // sp_world_size
+        q_proj, k_proj, v_proj = torch.split(mixed_qkv, [mod.key_dim, mod.key_dim, mod.value_dim], dim=-1)
+        q_proj = q_proj.reshape(batch_size, seq_len, mod.num_k_heads, mod.head_k_dim)
+        k_proj = k_proj.reshape(batch_size, seq_len, mod.num_k_heads, mod.head_k_dim)
+        v_proj = v_proj.reshape(batch_size, seq_len, mod.num_v_heads, mod.head_v_dim)
+        q_proj = seq_to_head_shard(q_proj, sequence_parallel_context)
+        k_proj = seq_to_head_shard(k_proj, sequence_parallel_context)
+        v_proj = seq_to_head_shard(v_proj, sequence_parallel_context)
+        b = seq_to_head_shard(b.reshape(batch_size, seq_len, mod.num_v_heads, 1), sequence_parallel_context).squeeze(-1)
+        a = seq_to_head_shard(a.reshape(batch_size, seq_len, mod.num_v_heads, 1), sequence_parallel_context).squeeze(-1)
+        seq_after_shard = q_proj.shape[1]
+        mixed_qkv = torch.cat((
+            q_proj.reshape(batch_size, seq_after_shard, local_num_k_heads * mod.head_k_dim),
+            k_proj.reshape(batch_size, seq_after_shard, local_num_k_heads * mod.head_k_dim),
+            v_proj.reshape(batch_size, seq_after_shard, local_num_v_heads * mod.head_v_dim),
+        ),
+                              dim=-1)
+        sp_rank = _get_sp_rank(sequence_parallel_context)
+        conv_weight, conv_bias = _get_local_conv_weights(
+            mod, sp_rank=sp_rank, local_num_k_heads=local_num_k_heads, local_num_v_heads=local_num_v_heads)
+    else:
+        local_num_k_heads = mod.num_k_heads
+        local_num_v_heads = mod.num_v_heads
+        sp_rank = 0
+        b = b.reshape(batch_size, seq_len, mod.num_v_heads)
+        a = a.reshape(batch_size, seq_len, mod.num_v_heads)
+        conv_weight = mod.conv1d.weight.squeeze(1)
+        conv_bias = getattr(mod.conv1d, 'bias', None)
+
+    packed_cu_seqlens = None
+    if sequence_parallel_context is not None:
+        packed_cu_seqlens = _get_qwen3_5_cu_seqlens_q(sequence_parallel_context)
+        if packed_cu_seqlens is not None:
+            packed_cu_seqlens = packed_cu_seqlens.to(dtype=torch.int32, device=mixed_qkv.device)
+
+    if cache_params is not None:
+        cache_params.conv_states[mod.layer_idx] = F.pad(
+            mixed_qkv.transpose(1, 2).contiguous(), (mod.conv_kernel_size - mixed_qkv.shape[1], 0))
+    mixed_qkv, _ = mod.causal_conv1d_fn(
+        x=mixed_qkv,
+        weight=conv_weight,
+        bias=conv_bias,
+        activation=mod.activation,
+        seq_idx=None,
+        backend='triton',
+        cu_seqlens=packed_cu_seqlens,
+    )
+    if mixed_qkv.dim() == 2:
+        mixed_qkv = mixed_qkv.unsqueeze(0)
+    if mixed_qkv.dim() != 3:
+        raise ValueError(f'Unexpected conv output dims: {tuple(mixed_qkv.shape)}')
+
+    local_key_dim = local_num_k_heads * mod.head_k_dim
+    local_value_dim = local_num_v_heads * mod.head_v_dim
+    query, key, value = torch.split(mixed_qkv, [local_key_dim, local_key_dim, local_value_dim], dim=-1)
+    query = query.reshape(batch_size, query.shape[1], local_num_k_heads, mod.head_k_dim)
+    key = key.reshape(batch_size, key.shape[1], local_num_k_heads, mod.head_k_dim)
+    value = value.reshape(batch_size, value.shape[1], local_num_v_heads, mod.head_v_dim)
+
+    beta = b.sigmoid()
+    head_slice = slice(sp_rank * local_num_v_heads, (sp_rank + 1) * local_num_v_heads) if sp_enabled else slice(None)
+    g = -mod.A_log[head_slice].float().exp() * F.softplus(a.float() + mod.dt_bias[head_slice])
+
+    if local_num_v_heads // local_num_k_heads > 1:
+        repeat = local_num_v_heads // local_num_k_heads
+        query = query.repeat_interleave(repeat, dim=2)
+        key = key.repeat_interleave(repeat, dim=2)
+
+    chunk_kwargs = {
+        'g': g,
+        'beta': beta,
+        'initial_state': None,
+        'output_final_state': cache_params is not None,
+        'use_qk_l2norm_in_kernel': True,
+    }
+    if packed_cu_seqlens is not None:
+        chunk_kwargs['cu_seqlens'] = packed_cu_seqlens
+    core_attn_out, last_recurrent_state = mod.chunk_gated_delta_rule(query, key, value, **chunk_kwargs)
+
+    if cache_params is not None:
+        cache_params.recurrent_states[mod.layer_idx] = last_recurrent_state
+
+    if sp_enabled:
+        core_attn_out = head_to_seq_shard(core_attn_out, sequence_parallel_context)
+    core_attn_out = mod.norm(core_attn_out.reshape(-1, mod.head_v_dim), z.reshape(-1, mod.head_v_dim))
+    core_attn_out = core_attn_out.reshape(batch_size, seq_len, local_value_dim if not sp_enabled else mod.value_dim)
+    return mod.out_proj(core_attn_out)
+
+
+def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
+    if os.environ.get('QWEN35_SP_LINEAR_HEAD_PARALLEL', '1') != '1':
+        return
+    try:
+        from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedDeltaNet
+    except Exception:
+        return
+
+    if getattr(Qwen3_5GatedDeltaNet, '_ms_swift_sp_linear_patched', False):
+        return
+
+    origin_forward = Qwen3_5GatedDeltaNet.forward
+
+    def sp_linear_forward(
+        mod,
+        hidden_states: torch.Tensor,
+        cache_params=None,
+        cache_position=None,
+        attention_mask: Optional[torch.Tensor] = None,
+    ):
+        try:
+            from swift.sequence_parallel import sequence_parallel as sequence_parallel_context
+        except Exception:
+            sequence_parallel_context = None
+
+        if int(getattr(sequence_parallel_context, 'rp_world_size', 1) or 1) > 1:
+            requested_sp_size = int(getattr(sequence_parallel_context, 'world_size', 1) or 1)
+            suggested_sp_size = int(getattr(sequence_parallel_context, 'sp_world_size', 1) or 1)
+            raise NotImplementedError(
+                'Qwen3.5 linear attention sequence parallel does not support derived ring attention '
+                f'(sequence_parallel_size={requested_sp_size}, '
+                f'sp_world_size={getattr(sequence_parallel_context, "sp_world_size", None)}, '
+                f'rp_world_size={getattr(sequence_parallel_context, "rp_world_size", None)}). '
+                f'Please reduce --sequence_parallel_size to {suggested_sp_size} so that rp_world_size becomes 1.')
+
+        if not _sp_is_enabled(sequence_parallel_context):
+            return origin_forward(
+                mod,
+                hidden_states,
+                cache_params=cache_params,
+                cache_position=cache_position,
+                attention_mask=attention_mask,
+            )
+
+        return _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
+            mod,
+            hidden_states,
+            cache_params=cache_params,
+            cache_position=cache_position,
+            attention_mask=attention_mask,
+            sequence_parallel_context=sequence_parallel_context,
+        )
+
+    Qwen3_5GatedDeltaNet.forward = sp_linear_forward
+    Qwen3_5GatedDeltaNet._ms_swift_sp_linear_patched = True
+
+
 class Qwen3_5MoeLoader(Qwen3VLLoader):
 
     def get_model(self, model_dir: str, config, processor, model_kwargs) -> PreTrainedModel:
         from transformers import Qwen3_5MoeForConditionalGeneration
         self.auto_model_cls = self.auto_model_cls or Qwen3_5MoeForConditionalGeneration
+        _patch_qwen3_5_linear_attention_sequence_parallel()
         return Qwen2VLLoader.get_model(self, model_dir, config, processor, model_kwargs)
 
 
@@ -1172,6 +1457,7 @@ class Qwen3_5Loader(Qwen3VLLoader):
     def get_model(self, model_dir: str, config, processor, model_kwargs) -> PreTrainedModel:
         from transformers import Qwen3_5ForConditionalGeneration
         self.auto_model_cls = self.auto_model_cls or Qwen3_5ForConditionalGeneration
+        _patch_qwen3_5_linear_attention_sequence_parallel()
         return Qwen2VLLoader.get_model(self, model_dir, config, processor, model_kwargs)
 
 

--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1359,8 +1359,6 @@ def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
 
 
 def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
-    if os.environ.get('QWEN35_SP_LINEAR_HEAD_PARALLEL', '1') != '1':
-        return
     try:
         from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedDeltaNet
     except Exception:

--- a/swift/sequence_parallel/ulysses.py
+++ b/swift/sequence_parallel/ulysses.py
@@ -140,13 +140,8 @@ class DistributedAttention(torch.nn.Module):
             # only ulysses
             position_ids = kwargs.pop('position_ids')
             if position_ids is not None:
-                shape0 = position_ids.shape[0]
-                position_ids_output = torch.empty(
-                    (shape0 * self.sequence_parallel.sp_world_size, position_ids.shape[1]),
-                    dtype=position_ids.dtype,
-                    device=position_ids.device)
-                dist.all_gather_into_tensor(position_ids_output, position_ids, group=self.sequence_parallel.sp_group)
-                position_ids = torch.cat(position_ids_output.split(shape0, dim=0), dim=1)
+                # Reuse the generic gather path so 2D and 3D position_ids share the same SP behavior.
+                position_ids = self.sequence_parallel.gather(position_ids.contiguous(), dim=-1, position_ids=None)
 
         context_layer = self.local_attn(
             query_layer, key_layer, value_layer, attention_mask, *args, position_ids=position_ids, **kwargs)


### PR DESCRIPTION
## Summary

This PR adds sequence parallel support for **Qwen3.5 linear attention** by ulysses.

### Main changes

- Import and validate flash-linear-attention kernels at runtime.
  - `causal_conv1d` from `fla.modules.convolution`
  - `chunk_gated_delta_rule` from `fla.ops.gated_delta_rule`
- Add SP helper utilities for Qwen3.5 linear attention:
  - sequence/head sharding transforms
  - local padding mask handling
  - local convolution weight slicing
  - packed `cu_seqlens` derivation from `real_position_ids` when needed
- Patch  Qwen3.5 linear-attention (gdn)forward .

## PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

## PR information

### Why
Qwen3.5 uses mixed layer types (full + linear attention). Existing SP support is robust for full attention, but lacked model-specific linear-attention SP execution and kernel integration. This PR fix it.

### Scope
- Qwen3.5 linear attention SP path (`sp_world_size > 1`)
- FLA kernel dependency and runtime validation
- Training/prefill path support

### Limitations (explicit)
- `rp_world_size > 1` is not supported for Qwen3.5 linear attention.
- Decode path with cached recurrent states is not supported in this SP patch.

## Experiment results

Paste your experiment result here(if needed).
Train:   1%|          | 1/189 [02:41<8:25:06, 161.21s/it]

{'loss': '1.461', 'grad_norm': '1.705', 'learning_rate': '1e-05', 'token_acc': '0.6399', 'epoch': '0.016', 'global_step/max_steps': '1/189', 'elapsed_time': '2m 41s', 'remaining_time': '8h 25m 20s', 'memory(GiB)': '67.95', 'train_speed(s/it)': '161.3'}
{'loss': '1.484', 'grad_norm': '1.666', 'learning_rate': '2e-05', 'token_acc': '0.6324', 'epoch': '0.032', 'global_step/max_steps': '2/189', 'elapsed_time': '3m 55s', 'remaining_time': '6h 6m 35s', 'memory(GiB)': '68.05', 'train_speed(s/it)': '117.6'}
{'loss': '1.477', 'grad_norm': '1.767', 'learning_rate': '3e-05', 'token_acc': '0.6311', 'epoch': '0.048', 'global_step/max_steps': '3/189', 'elapsed_time': '4m 48s', 'remaining_time': '4h 57m 21s', 'memory(GiB)': '68.05', 'train_speed(s/it)': '95.92'}
{'loss': '1.498', 'grad_norm': '1.683', 'learning_rate': '4e-05', 'token_acc': '0.6355', 'epoch': '0.064', 'global_step/max_steps': '4/189', 'elapsed_time': '5m 36s', 'remaining_time': '4h 18m 56s', 'memory(GiB)': '68.05', 'train_speed(s/it)': '83.98'}
{'loss': '1.422', 'grad_norm': '1.528', 'learning_rate': '5e-05', 'token_acc': '0.6329', 'epoch': '0.08', 'global_step/max_steps': '5/189', 'elapsed_time': '6m 17s', 'remaining_time': '3h 51m 17s', 'memory(GiB)': '68.05', 'train_speed(s/it)': '75.42'}
{'loss': '1.322', 'grad_norm': '1.203', 'learning_rate': '6e-05', 'token_acc': '0.6457', 'epoch': '0.096', 'global_step/max_steps': '6/189', 'elapsed_time': '6m 53s', 'remaining_time': '3h 30m 1s', 'memory(GiB)': '68.05', 'train_speed(s/it)': '68.86'}
...
Train:  24%|██▍       | 46/189 [17:53<45:13, 18.97s/it]
{'loss': '1.049', 'grad_norm': '0.6095', 'learning_rate': '9.035e-05', 'token_acc': '0.7018', 'epoch': '0.736', 'global_step/max_steps': '46/189', 'elapsed_time': '17m 54s', 'remaining_time': '55m 38s', 'memory(GiB)': '68.06', 'train_speed(s/it)': '23.34'}

