### PR TITLE
NPU patch FLA

### DIFF
--- a/swift/model/chunk_gated_delta_rule.py
+++ b/swift/model/chunk_gated_delta_rule.py
@@ -1,0 +1,401 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025, HUAWEI CORPORATION.  All rights reserved.
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import warnings
+from typing import Optional
+
+import torch
+import copy
+
+from mindspeed.lite.ops.triton.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
+from mindspeed.lite.ops.triton.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local, chunk_fwd_o
+from mindspeed.lite.ops.triton.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+from mindspeed.lite.ops.triton.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
+from mindspeed.lite.ops.triton.solve_tril import solve_tril
+from mindspeed.lite.ops.triton.cumsum import chunk_local_cumsum
+from mindspeed.lite.ops.triton.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+
+
+def _torch_l2norm_fwd(
+    x: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: Optional[torch.dtype] = None,
+):
+    x_shape_og = x.shape
+    x = x.view(-1, x.shape[-1])
+    x_float = x.float()
+    rstd = torch.rsqrt(torch.sum(x_float * x_float, dim=-1) + eps)
+    y = x_float * rstd.unsqueeze(-1)
+    y = y.to(output_dtype if output_dtype is not None else x.dtype)
+    return y.view(x_shape_og), rstd.view(x_shape_og[:-1])
+
+
+def _torch_l2norm_bwd(
+    y: torch.Tensor,
+    rstd: torch.Tensor,
+    dy: torch.Tensor,
+    eps: float = 1e-6,
+):
+    y_shape_og = y.shape
+    y = y.view(-1, y.shape[-1])
+    dy = dy.view(-1, dy.shape[-1])
+    y_float = y.float()
+    dy_float = dy.float()
+    rstd = rstd.view(-1).float()
+    dx = dy_float * rstd.unsqueeze(-1)
+    dx = dx - torch.sum(dy_float * y_float, dim=-1, keepdim=True) * y_float * rstd.unsqueeze(-1)
+    return dx.to(y.dtype).view(y_shape_og)
+
+
+def chunk_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_size: int = 64,
+):
+    g = chunk_local_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens, head_first=False)
+    # obtain WY representation. u is actually the new v.
+    A = chunk_scaled_dot_kkt_fwd(
+        k=k,
+        g=g,
+        beta=beta,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        output_dtype=torch.float32
+    )
+    A = solve_tril(
+        A=A,
+        cu_seqlens=cu_seqlens,
+        output_dtype=k.dtype
+    )
+    w, u = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        g=g,
+        cu_seqlens=cu_seqlens,
+    )
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        k=k,
+        w=w,
+        u=u,
+        g=g,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+    )
+    o = chunk_fwd_o(
+        q=q,
+        k=k,
+        v=v_new,
+        h=h,
+        g=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+    )
+    return g, o, A, final_state
+
+
+def chunk_gated_delta_rule_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    do: torch.Tensor,
+    dht: torch.Tensor,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_size: int = 64,
+):
+    w, u = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        g=g,
+        cu_seqlens=cu_seqlens,
+    )
+    h, v_new, _ = chunk_gated_delta_rule_fwd_h(
+        k=k,
+        w=w,
+        u=u,
+        g=g,
+        initial_state=initial_state,
+        output_final_state=False,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+    )
+    dv = chunk_bwd_dv_local(
+        q=q,
+        k=k,
+        g=g,
+        do=do,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+    )
+    dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(
+        q=q,
+        k=k,
+        w=w,
+        g=g,
+        h0=initial_state,
+        dht=dht,
+        do=do,
+        dv=dv,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+    )
+    dq, dk, dw, dg = chunk_bwd_dqkwg(
+        q=q,
+        k=k,
+        v=v_new,
+        w=w,
+        g=g,
+        h=h,
+        dv=dv,
+        do=do,
+        dh=dh,
+        chunk_size=chunk_size,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+    )
+    dk2, dv, db, dg2 = prepare_wy_repr_bwd(
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        A=A,
+        dw=dw,
+        du=dv,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size
+    )
+    dk.add_(dk2)
+    dg.add_(dg2)
+    if dg.dtype != torch.float32:
+        raise ValueError(
+            f"dg current type is {dg.dtype} , should be float32"
+        )
+    dg = chunk_local_cumsum(dg, chunk_size=chunk_size, reverse=True, cu_seqlens=cu_seqlens, head_first=False)
+    return dq, dk, dv, db, dg, dh0
+
+
+class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_fwd
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float,
+        initial_state: torch.Tensor,
+        output_final_state: bool,
+        cu_seqlens: Optional[torch.LongTensor] = None,
+        use_qk_l2norm_in_kernel: bool = False,
+        chunk_size: int = 64,
+    ):
+        if use_qk_l2norm_in_kernel:
+            q, q_rstd = _torch_l2norm_fwd(q)
+            k, k_rstd = _torch_l2norm_fwd(k)
+        else:
+            q_rstd, k_rstd = None, None
+
+        g, o, A, final_state = chunk_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size
+        )
+        ctx.save_for_backward(q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens)
+        ctx.scale = scale
+        ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+        ctx.chunk_size = chunk_size
+        return o.to(q.dtype), final_state
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_bwd
+    def backward(
+        ctx,
+        do: torch.Tensor,
+        dht: torch.Tensor
+    ):
+        q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens= ctx.saved_tensors
+        dq, dk, dv, db, dg, dh0 = chunk_gated_delta_rule_bwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            A=A,
+            scale=ctx.scale,
+            initial_state=initial_state,
+            do=do,
+            dht=dht,
+            cu_seqlens=cu_seqlens,
+            chunk_size=ctx.chunk_size,
+        )
+        if ctx.use_qk_l2norm_in_kernel:
+            dq = _torch_l2norm_bwd(q, q_rstd, dq)
+            dk = _torch_l2norm_bwd(k, k_rstd, dk)
+        return dq.to(q), dk.to(k), dv.to(v), dg.to(g), db.to(beta), None, dh0, None, None, None, None
+
+
+@torch.compiler.disable
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_size: int = 64,
+    head_first: bool = False,
+):
+    r"""
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, H, V]`.
+        g (torch.Tensor):
+            (forget) gating tensor (in log space!) of shape `[B, T, H]`.
+        beta (torch.Tensor):
+            betas of shape `[B, T, H]`.
+        scale (Optional[float]):
+            Scale factor for the RetNet attention scores.
+            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape `[N, H, K, V]` for `N` input sequences.
+            For equal-length input sequences, `N` equals the batch size `B`.
+            Default: `None`.
+        output_final_state (Optional[bool]):
+            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+        use_qk_l2norm_in_kernel (bool):
+            Whether to apply L2norm to the q/k tensor internally. Default: `False`.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+        head_first (Optional[bool]):
+            Whether the inputs are in the head-first format. Default: `False`.
+            This argument has been deprecated.
+
+    Returns:
+        o (torch.Tensor):
+            Outputs of shape `[B, T, H, V]`.
+        final_state (torch.Tensor):
+            Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+
+    Examples::
+        >>> import torch
+        >>> import torch.nn.functional as F
+        >>> from einops import rearrange
+        >>> from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+        # inputs with equal lengths
+        >>> B, T, H, K, V = 4, 2048, 4, 512, 512
+        >>> q = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
+        >>> k = F.normalize(torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda'), p=2, dim=-1)
+        >>> v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device='cuda')
+        >>> beta = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda').sigmoid()
+        >>> g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
+        >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
+        >>> o, ht = chunk_gated_delta_rule(
+            q, k, v, g, beta,
+            initial_state=h0,
+            output_final_state=True
+        )
+        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+        >>> q, k, v, beta, g = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, beta, g))
+        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> o, ht = chunk_gated_delta_rule(
+            q, k, v, g, beta,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens
+        )
+    """
+    if q.dtype != k.dtype or k.dtype != v.dtype:
+        raise ValueError(
+            f"q current type is {q.dtype} , k current type is {k.dtype} ,v current type is {v.dtype} , they should are equal"
+        )
+    if q.dtype == torch.float32:
+        raise ValueError(
+            "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
+        )
+    if len(beta.shape) != 3:
+        raise ValueError(
+            f"beta current shape len is {len(beta.shape)}, beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
+        )
+
+    if head_first:
+        warnings.warn(
+            "head_first is deprecated and will be removed in a future version. "
+            "Please use head_first=False for now instead."
+        )
+    if not head_first and q.shape[1] < q.shape[2]:
+        warnings.warn(
+            f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
+            "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
+            "when head_first=False was specified. "
+            "Please verify your input tensor format matches the expected shape [B, T, H, ...]."
+        )
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"Please flatten variable-length inputs before processing."
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}."
+            )
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    o, final_state = ChunkGatedDeltaRuleFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale,
+        initial_state,
+        output_final_state,
+        cu_seqlens,
+        use_qk_l2norm_in_kernel,
+        chunk_size,
+    )
+    return o, final_state

--- a/swift/model/chunk_gated_delta_rule.py
+++ b/swift/model/chunk_gated_delta_rule.py
@@ -349,7 +349,7 @@ def chunk_gated_delta_rule(
     """
     if q.dtype != k.dtype or k.dtype != v.dtype:
         raise ValueError(
-            f"q current type is {q.dtype} , k current type is {k.dtype} ,v current type is {v.dtype} , they should are equal"
+            f"q current type is {q.dtype}, k current type is {k.dtype}, v current type is {v.dtype}, they should be equal"
         )
     if q.dtype == torch.float32:
         raise ValueError(

--- a/swift/model/chunk_gated_delta_rule.py
+++ b/swift/model/chunk_gated_delta_rule.py
@@ -6,7 +6,6 @@ import warnings
 from typing import Optional
 
 import torch
-import copy
 
 from mindspeed.lite.ops.triton.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
 from mindspeed.lite.ops.triton.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local, chunk_fwd_o
@@ -349,7 +348,7 @@ def chunk_gated_delta_rule(
     """
     if q.dtype != k.dtype or k.dtype != v.dtype:
         raise ValueError(
-            f"q current type is {q.dtype}, k current type is {k.dtype}, v current type is {v.dtype}, they should be equal"
+            f"q current type is {q.dtype} , k current type is {k.dtype} ,v current type is {v.dtype} , they should be equal"
         )
     if q.dtype == torch.float32:
         raise ValueError(

--- a/swift/model/chunk_gated_delta_rule.py
+++ b/swift/model/chunk_gated_delta_rule.py
@@ -2,18 +2,16 @@
 # Copyright (c) 2025, HUAWEI CORPORATION.  All rights reserved.
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 
-import warnings
-from typing import Optional
-
 import torch
-
+import warnings
 from mindspeed.lite.ops.triton.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
 from mindspeed.lite.ops.triton.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local, chunk_fwd_o
 from mindspeed.lite.ops.triton.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
-from mindspeed.lite.ops.triton.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
-from mindspeed.lite.ops.triton.solve_tril import solve_tril
 from mindspeed.lite.ops.triton.cumsum import chunk_local_cumsum
+from mindspeed.lite.ops.triton.solve_tril import solve_tril
 from mindspeed.lite.ops.triton.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from mindspeed.lite.ops.triton.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
+from typing import Optional
 
 
 def _torch_l2norm_fwd(
@@ -62,18 +60,8 @@ def chunk_gated_delta_rule_fwd(
     g = chunk_local_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens, head_first=False)
     # obtain WY representation. u is actually the new v.
     A = chunk_scaled_dot_kkt_fwd(
-        k=k,
-        g=g,
-        beta=beta,
-        cu_seqlens=cu_seqlens,
-        chunk_size=chunk_size,
-        output_dtype=torch.float32
-    )
-    A = solve_tril(
-        A=A,
-        cu_seqlens=cu_seqlens,
-        output_dtype=k.dtype
-    )
+        k=k, g=g, beta=beta, cu_seqlens=cu_seqlens, chunk_size=chunk_size, output_dtype=torch.float32)
+    A = solve_tril(A=A, cu_seqlens=cu_seqlens, output_dtype=k.dtype)
     w, u = recompute_w_u_fwd(
         k=k,
         v=v,
@@ -174,22 +162,11 @@ def chunk_gated_delta_rule_bwd(
         cu_seqlens=cu_seqlens,
     )
     dk2, dv, db, dg2 = prepare_wy_repr_bwd(
-        k=k,
-        v=v,
-        beta=beta,
-        g=g,
-        A=A,
-        dw=dw,
-        du=dv,
-        cu_seqlens=cu_seqlens,
-        chunk_size=chunk_size
-    )
+        k=k, v=v, beta=beta, g=g, A=A, dw=dw, du=dv, cu_seqlens=cu_seqlens, chunk_size=chunk_size)
     dk.add_(dk2)
     dg.add_(dg2)
     if dg.dtype != torch.float32:
-        raise ValueError(
-            f"dg current type is {dg.dtype} , should be float32"
-        )
+        raise ValueError(f"dg current type is {dg.dtype} , should be float32")
     dg = chunk_local_cumsum(dg, chunk_size=chunk_size, reverse=True, cu_seqlens=cu_seqlens, head_first=False)
     return dq, dk, dv, db, dg, dh0
 
@@ -229,8 +206,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             initial_state=initial_state,
             output_final_state=output_final_state,
             cu_seqlens=cu_seqlens,
-            chunk_size=chunk_size
-        )
+            chunk_size=chunk_size)
         ctx.save_for_backward(q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens)
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
@@ -240,11 +216,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
     @staticmethod
     @input_guard
     @autocast_custom_bwd
-    def backward(
-        ctx,
-        do: torch.Tensor,
-        dht: torch.Tensor
-    ):
+    def backward(ctx, do: torch.Tensor, dht: torch.Tensor):
         q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens = ctx.saved_tensors
         dq, dk, dv, db, dg, dh0 = chunk_gated_delta_rule_bwd(
             q=q,
@@ -348,44 +320,31 @@ def chunk_gated_delta_rule(
     """
     if q.dtype != k.dtype or k.dtype != v.dtype:
         raise ValueError(
-            f"q current type is {q.dtype}, k current type is {k.dtype},v current type is {v.dtype}, should be equal"
-        )
+            f"q current type is {q.dtype}, k current type is {k.dtype},v current type is {v.dtype}, should be equal")
     if q.dtype == torch.float32:
-        raise ValueError(
-            "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
-        )
+        raise ValueError('ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16.')
     if len(beta.shape) != 3:
-        raise ValueError(
-            f"beta current shape len is {len(beta.shape)}, beta must be of shape "
-            f"[B, T, H] if head_first=False, or [B, H, T] otherwise."
-        )
+        raise ValueError(f"beta current shape len is {len(beta.shape)}, beta must be of shape "
+                         f"[B, T, H] if head_first=False, or [B, H, T] otherwise.")
 
     if head_first:
-        warnings.warn(
-            "head_first is deprecated and will be removed in a future version. "
-            "Please use head_first=False for now instead."
-        )
+        warnings.warn('head_first is deprecated and will be removed in a future version. '
+                      'Please use head_first=False for now instead.')
     if not head_first and q.shape[1] < q.shape[2]:
-        warnings.warn(
-            f"Input tensor shape suggests potential format mismatch: "
-            f"seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
-            "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
-            "when head_first=False was specified. "
-            "Please verify your input tensor format matches the expected shape [B, T, H, ...]."
-        )
+        warnings.warn(f"Input tensor shape suggests potential format mismatch: "
+                      f"seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
+                      'This may indicate the inputs were passed in head-first format [B, H, T, ...] '
+                      'when head_first=False was specified. '
+                      'Please verify your input tensor format matches the expected shape [B, T, H, ...].')
     if cu_seqlens is not None:
         if q.shape[0] != 1:
-            raise ValueError(
-                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
-                f"Please flatten variable-length inputs before processing."
-            )
+            raise ValueError(f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                             f"Please flatten variable-length inputs before processing.")
         if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
-            raise ValueError(
-                f"The number of initial states is expected to be equal to the number of input sequences, "
-                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}."
-            )
+            raise ValueError(f"The number of initial states is expected to be equal to the number of input sequences, "
+                             f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}.")
     if scale is None:
-        scale = k.shape[-1] ** -0.5
+        scale = k.shape[-1]**-0.5
     o, final_state = ChunkGatedDeltaRuleFunction.apply(
         q,
         k,

--- a/swift/model/chunk_gated_delta_rule.py
+++ b/swift/model/chunk_gated_delta_rule.py
@@ -348,7 +348,7 @@ def chunk_gated_delta_rule(
     """
     if q.dtype != k.dtype or k.dtype != v.dtype:
         raise ValueError(
-            f"q current type is {q.dtype} , k current type is {k.dtype} ,v current type is {v.dtype} , they should be equal"
+            f"q current type is {q.dtype}, k current type is {k.dtype},v current type is {v.dtype}, should be equal"
         )
     if q.dtype == torch.float32:
         raise ValueError(
@@ -356,7 +356,8 @@ def chunk_gated_delta_rule(
         )
     if len(beta.shape) != 3:
         raise ValueError(
-            f"beta current shape len is {len(beta.shape)}, beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
+            f"beta current shape len is {len(beta.shape)}, beta must be of shape "
+            f"[B, T, H] if head_first=False, or [B, H, T] otherwise."
         )
 
     if head_first:
@@ -366,7 +367,8 @@ def chunk_gated_delta_rule(
         )
     if not head_first and q.shape[1] < q.shape[2]:
         warnings.warn(
-            f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
+            f"Input tensor shape suggests potential format mismatch: "
+            f"seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
             "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
             "when head_first=False was specified. "
             "Please verify your input tensor format matches the expected shape [B, T, H, ...]."

--- a/swift/model/chunk_gated_delta_rule.py
+++ b/swift/model/chunk_gated_delta_rule.py
@@ -245,7 +245,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         do: torch.Tensor,
         dht: torch.Tensor
     ):
-        q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens= ctx.saved_tensors
+        q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens = ctx.saved_tensors
         dq, dk, dv, db, dg, dh0 = chunk_gated_delta_rule_bwd(
             q=q,
             k=k,

--- a/swift/model/chunk_gated_delta_rule.py
+++ b/swift/model/chunk_gated_delta_rule.py
@@ -320,21 +320,18 @@ def chunk_gated_delta_rule(
     """
     if q.dtype != k.dtype or k.dtype != v.dtype:
         raise ValueError(
-            f'q current type is {q.dtype}, k current type is {k.dtype}, v current type is {v.dtype}, they should be equal'
-        )
+            f'q current type is {q.dtype}, k current type is {k.dtype}, v current type is {v.dtype}, should be equal')
     if q.dtype == torch.float32:
         raise ValueError('ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16.')
     if len(beta.shape) != 3:
-        raise ValueError(
-            f'beta current shape len is {len(beta.shape)}, beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise.'
-        )
-
+        raise ValueError(f'beta current shape len is {len(beta.shape)}, beta must be of shape [B, T, H] '
+                         f'if head_first=False, or [B, H, T] otherwise.')
     if head_first:
         warnings.warn('head_first is deprecated and will be removed in a future version. '
                       'Please use head_first=False for now instead.')
     if not head_first and q.shape[1] < q.shape[2]:
         warnings.warn(
-            f'Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). '
+            f'Input tensor shape suggests format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). '
             'This may indicate the inputs were passed in head-first format [B, H, T, ...] '
             'when head_first=False was specified. '
             'Please verify your input tensor format matches the expected shape [B, T, H, ...].')

--- a/swift/model/chunk_gated_delta_rule.py
+++ b/swift/model/chunk_gated_delta_rule.py
@@ -2,18 +2,16 @@
 # Copyright (c) 2025, HUAWEI CORPORATION.  All rights reserved.
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 
-import warnings
-from typing import Optional
-
 import torch
-
+import warnings
 from mindspeed.lite.ops.triton.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
 from mindspeed.lite.ops.triton.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local, chunk_fwd_o
 from mindspeed.lite.ops.triton.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
-from mindspeed.lite.ops.triton.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
-from mindspeed.lite.ops.triton.solve_tril import solve_tril
 from mindspeed.lite.ops.triton.cumsum import chunk_local_cumsum
+from mindspeed.lite.ops.triton.solve_tril import solve_tril
 from mindspeed.lite.ops.triton.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from mindspeed.lite.ops.triton.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
+from typing import Optional
 
 
 def _torch_l2norm_fwd(
@@ -62,18 +60,8 @@ def chunk_gated_delta_rule_fwd(
     g = chunk_local_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens, head_first=False)
     # obtain WY representation. u is actually the new v.
     A = chunk_scaled_dot_kkt_fwd(
-        k=k,
-        g=g,
-        beta=beta,
-        cu_seqlens=cu_seqlens,
-        chunk_size=chunk_size,
-        output_dtype=torch.float32
-    )
-    A = solve_tril(
-        A=A,
-        cu_seqlens=cu_seqlens,
-        output_dtype=k.dtype
-    )
+        k=k, g=g, beta=beta, cu_seqlens=cu_seqlens, chunk_size=chunk_size, output_dtype=torch.float32)
+    A = solve_tril(A=A, cu_seqlens=cu_seqlens, output_dtype=k.dtype)
     w, u = recompute_w_u_fwd(
         k=k,
         v=v,
@@ -174,22 +162,11 @@ def chunk_gated_delta_rule_bwd(
         cu_seqlens=cu_seqlens,
     )
     dk2, dv, db, dg2 = prepare_wy_repr_bwd(
-        k=k,
-        v=v,
-        beta=beta,
-        g=g,
-        A=A,
-        dw=dw,
-        du=dv,
-        cu_seqlens=cu_seqlens,
-        chunk_size=chunk_size
-    )
+        k=k, v=v, beta=beta, g=g, A=A, dw=dw, du=dv, cu_seqlens=cu_seqlens, chunk_size=chunk_size)
     dk.add_(dk2)
     dg.add_(dg2)
     if dg.dtype != torch.float32:
-        raise ValueError(
-            f"dg current type is {dg.dtype} , should be float32"
-        )
+        raise ValueError(f'dg current type is {dg.dtype} , should be float32')
     dg = chunk_local_cumsum(dg, chunk_size=chunk_size, reverse=True, cu_seqlens=cu_seqlens, head_first=False)
     return dq, dk, dv, db, dg, dh0
 
@@ -229,8 +206,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             initial_state=initial_state,
             output_final_state=output_final_state,
             cu_seqlens=cu_seqlens,
-            chunk_size=chunk_size
-        )
+            chunk_size=chunk_size)
         ctx.save_for_backward(q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens)
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
@@ -240,11 +216,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
     @staticmethod
     @input_guard
     @autocast_custom_bwd
-    def backward(
-        ctx,
-        do: torch.Tensor,
-        dht: torch.Tensor
-    ):
+    def backward(ctx, do: torch.Tensor, dht: torch.Tensor):
         q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens = ctx.saved_tensors
         dq, dk, dv, db, dg, dh0 = chunk_gated_delta_rule_bwd(
             q=q,
@@ -348,42 +320,33 @@ def chunk_gated_delta_rule(
     """
     if q.dtype != k.dtype or k.dtype != v.dtype:
         raise ValueError(
-            f"q current type is {q.dtype} , k current type is {k.dtype} ,v current type is {v.dtype} , they should be equal"
+            f'q current type is {q.dtype}, k current type is {k.dtype}, v current type is {v.dtype}, they should be equal'
         )
     if q.dtype == torch.float32:
-        raise ValueError(
-            "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
-        )
+        raise ValueError('ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16.')
     if len(beta.shape) != 3:
         raise ValueError(
-            f"beta current shape len is {len(beta.shape)}, beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
+            f'beta current shape len is {len(beta.shape)}, beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise.'
         )
 
     if head_first:
-        warnings.warn(
-            "head_first is deprecated and will be removed in a future version. "
-            "Please use head_first=False for now instead."
-        )
+        warnings.warn('head_first is deprecated and will be removed in a future version. '
+                      'Please use head_first=False for now instead.')
     if not head_first and q.shape[1] < q.shape[2]:
         warnings.warn(
-            f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
-            "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
-            "when head_first=False was specified. "
-            "Please verify your input tensor format matches the expected shape [B, T, H, ...]."
-        )
+            f'Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). '
+            'This may indicate the inputs were passed in head-first format [B, H, T, ...] '
+            'when head_first=False was specified. '
+            'Please verify your input tensor format matches the expected shape [B, T, H, ...].')
     if cu_seqlens is not None:
         if q.shape[0] != 1:
-            raise ValueError(
-                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
-                f"Please flatten variable-length inputs before processing."
-            )
+            raise ValueError(f'The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`.'
+                             f'Please flatten variable-length inputs before processing.')
         if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
-            raise ValueError(
-                f"The number of initial states is expected to be equal to the number of input sequences, "
-                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}."
-            )
+            raise ValueError(f'The number of initial states is expected to be equal to the number of input sequences, '
+                             f'i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}.')
     if scale is None:
-        scale = k.shape[-1] ** -0.5
+        scale = k.shape[-1]**-0.5
     o, final_state = ChunkGatedDeltaRuleFunction.apply(
         q,
         k,

--- a/swift/model/npu_patcher.py
+++ b/swift/model/npu_patcher.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 import accelerate.utils.fsdp_utils as fsdp_utils
 import fcntl
-from functools import wraps
 import importlib
 import os
 import torch
 import torch.nn.functional as F
 import torch_npu
 from accelerate.accelerator import Accelerator
+from functools import wraps
 from torch import nn
 from transformers.models.qwen2 import modeling_qwen2
 from transformers.models.qwen3 import modeling_qwen3
@@ -45,6 +45,7 @@ def _import_optional_module(module_name: str) -> Any | None:
 
 
 def _patch_transformers_flash_linear_attention_available() -> None:
+
     def _is_flash_linear_attention_available() -> bool:
         return True
 
@@ -54,8 +55,7 @@ def _patch_transformers_flash_linear_attention_available() -> None:
 
     transformers_import_utils = _import_optional_module('transformers.utils.import_utils')
     if transformers_import_utils is not None:
-        setattr(transformers_import_utils, 'is_flash_linear_attention_available',
-                _is_flash_linear_attention_available)
+        setattr(transformers_import_utils, 'is_flash_linear_attention_available', _is_flash_linear_attention_available)
 
 
 def patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed() -> None:

--- a/swift/model/npu_patcher.py
+++ b/swift/model/npu_patcher.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 import accelerate.utils.fsdp_utils as fsdp_utils
 import fcntl
+from functools import wraps
 import importlib
 import os
 import torch
 import torch.nn.functional as F
 import torch_npu
 from accelerate.accelerator import Accelerator
-from functools import wraps
 from torch import nn
 from transformers.models.qwen2 import modeling_qwen2
 from transformers.models.qwen3 import modeling_qwen3
@@ -22,7 +22,6 @@ from swift.utils.logger import get_logger
 logger = get_logger()
 
 _DEFAULT_NPU_HCCL_CONNECT_TIMEOUT = '600'
-_DEFAULT_TRITON_ASCEND_LAUNCHER_LOCK_PATH = '/tmp/swift_triton_ascend_launcher_compile.lock'
 _ORIGINAL_MINDSPEED_TE_CP_CLASS = None
 
 
@@ -44,34 +43,6 @@ def _import_optional_module(module_name: str) -> Any | None:
         logger.debug('Failed to import optional module %s: %s', module_name, exc)
         return None
 
-def _patch_triton_ascend_launcher_compile_lock() -> None:
-    ascend_driver = _import_optional_module('triton.backends.ascend.driver')
-    if ascend_driver is None:
-        return
-
-    make_launcher_stub = getattr(ascend_driver, 'make_npu_launcher_stub', None)
-    if make_launcher_stub is None or getattr(make_launcher_stub, '_swift_compile_lock', False):
-        return
-
-    @wraps(make_launcher_stub)
-    def _locked_make_npu_launcher_stub(*args, **kwargs):
-        lock_path = os.environ.get('SWIFT_TRITON_ASCEND_LAUNCHER_LOCK',
-                                   _DEFAULT_TRITON_ASCEND_LAUNCHER_LOCK_PATH)
-        with open(lock_path, 'w') as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
-            try:
-                return make_launcher_stub(*args, **kwargs)
-            finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
-
-    _locked_make_npu_launcher_stub._swift_compile_lock = True
-    ascend_driver.make_npu_launcher_stub = _locked_make_npu_launcher_stub
-    logger.info(
-        'Patched Ascend Triton launcher compilation with file lock: %s.',
-        os.environ.get('SWIFT_TRITON_ASCEND_LAUNCHER_LOCK', _DEFAULT_TRITON_ASCEND_LAUNCHER_LOCK_PATH),
-    )
-
-
 def _patch_transformers_flash_linear_attention_available() -> None:
     def _is_flash_linear_attention_available() -> bool:
         return True
@@ -86,60 +57,6 @@ def _patch_transformers_flash_linear_attention_available() -> None:
                 _is_flash_linear_attention_available)
 
 
-def _should_fallback_to_torch_chunk_gated_delta_rule(exc: BaseException) -> bool:
-    if not isinstance(exc, RuntimeError):
-        return False
-
-    message = str(exc)
-    fallback_patterns = (
-        'Failed to compile',
-        'launcher_cxx11abi1.cxx',
-        'internal compiler error',
-        'wide_int_to_tree_1',
-        'ConvertLinalgRToBinary',
-        'hivm.hir',
-    )
-    return any(pattern in message for pattern in fallback_patterns)
-
-
-def _build_qwen3_5_chunk_gated_delta_rule_with_fallback(module_name: str, module: Any,
-                                                        mindspeed_chunk_gated_delta_rule):
-    torch_chunk_gated_delta_rule = getattr(module, 'torch_chunk_gated_delta_rule', None)
-    if torch_chunk_gated_delta_rule is None:
-        return mindspeed_chunk_gated_delta_rule
-
-    warned_runtime_fallback = False
-    warned_forced_fallback = False
-
-    @wraps(mindspeed_chunk_gated_delta_rule)
-    def _wrapped_chunk_gated_delta_rule(*args, **kwargs):
-        nonlocal warned_runtime_fallback, warned_forced_fallback
-
-        if os.environ.get('SWIFT_QWEN3_5_CHUNK_GATED_DELTA_RULE_FORCE_TORCH', '0') == '1':
-            if not warned_forced_fallback:
-                logger.warning('Using torch_chunk_gated_delta_rule for %s because '
-                               'SWIFT_QWEN3_5_CHUNK_GATED_DELTA_RULE_FORCE_TORCH=1.', module_name)
-                warned_forced_fallback = True
-            return torch_chunk_gated_delta_rule(*args, **kwargs)
-
-        if os.environ.get('SWIFT_QWEN3_5_CHUNK_GATED_DELTA_RULE_FORCE_TRITON', '0') == '1':
-            return mindspeed_chunk_gated_delta_rule(*args, **kwargs)
-
-        try:
-            return mindspeed_chunk_gated_delta_rule(*args, **kwargs)
-        except Exception as exc:
-            if not _should_fallback_to_torch_chunk_gated_delta_rule(exc):
-                raise
-            if not warned_runtime_fallback:
-                logger.warning('Falling back to torch_chunk_gated_delta_rule for %s after MindSpeed '
-                               'chunk_gated_delta_rule failed: %s', module_name, exc)
-                warned_runtime_fallback = True
-            return torch_chunk_gated_delta_rule(*args, **kwargs)
-
-    _wrapped_chunk_gated_delta_rule._swift_chunk_gated_delta_rule_fallback = True
-    return _wrapped_chunk_gated_delta_rule
-
-
 def patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed() -> None:
     try:
         from .chunk_gated_delta_rule import chunk_gated_delta_rule
@@ -149,8 +66,7 @@ def patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed() -> None:
 
     patched_modules = []
     for module_name in ('transformers.models.qwen3_5.modeling_qwen3_5',
-                        'transformers.models.qwen3_5_moe.modeling_qwen3_5_moe',
-                        'transformers.models.qwen3_next.modeling_qwen3_next'):
+                        'transformers.models.qwen3_5_moe.modeling_qwen3_5_moe'):
         module = _import_optional_module(module_name)
         if module is None:
             continue
@@ -160,21 +76,12 @@ def patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed() -> None:
         # FLA's fused RMSNormGated initializes with torch.cuda.current_device(),
         # so keep the native Qwen3.5 torch implementation on NPU.
         setattr(module, 'FusedRMSNormGated', None)
-        setattr(
-            module, 'chunk_gated_delta_rule',
-            _build_qwen3_5_chunk_gated_delta_rule_with_fallback(module_name, module, chunk_gated_delta_rule))
+        setattr(module, 'chunk_gated_delta_rule', chunk_gated_delta_rule)
         patched_modules.append(module_name)
 
     if patched_modules:
         logger.info('Patched Qwen3.5 chunk_gated_delta_rule to embedded MindSpeed implementation: %s.',
                     ', '.join(patched_modules))
-
-
-_patch_triton_ascend_launcher_compile_lock()
-_patch_transformers_flash_linear_attention_available()
-patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed()
-modeling_qwen3_5 = _import_optional_module('transformers.models.qwen3_5.modeling_qwen3_5')
-
 
 def patch_mindspeed_te_cp_implementation(megatron_args: dict[str, Any]) -> None:
     """
@@ -525,14 +432,10 @@ def _apply_patch_map(root: Any, patch_map: dict[str, Any]) -> None:
     for path, value in patch_map.items():
         _setattr_path(root, path, value)
 
-
-_QWEN3_5_PATCH_TABLE: tuple[tuple[Any, dict[str, Any]], ...] = ()
+modeling_qwen3_5 = _import_optional_module('transformers.models.qwen3_5.modeling_qwen3_5')
 if modeling_qwen3_5 is not None:
-    _QWEN3_5_PATCH_TABLE = ((modeling_qwen3_5, {
-        'Qwen3_5RMSNorm': NpuQwen3_5RMSNorm,
-        'apply_rotary_pos_emb': npu_apply_rotary_pos_emb_qwen3_5,
-        'Qwen3_5MLP.forward': npu_swiglu_forward,
-    }), )
+    _patch_transformers_flash_linear_attention_available()
+    patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed()
 
 _PATCH_TABLE: tuple[tuple[Any, dict[str, Any]], ...] = (
     (
@@ -551,7 +454,14 @@ _PATCH_TABLE: tuple[tuple[Any, dict[str, Any]], ...] = (
             'Qwen3MLP.forward': npu_swiglu_forward,
         },
     ),
-    *_QWEN3_5_PATCH_TABLE,
+    *(((
+        modeling_qwen3_5,
+        {
+            'Qwen3_5RMSNorm': NpuQwen3_5RMSNorm,
+            'apply_rotary_pos_emb': npu_apply_rotary_pos_emb_qwen3_5,
+            'Qwen3_5MLP.forward': npu_swiglu_forward,
+        },
+    ), ) if modeling_qwen3_5 is not None else ()),
     (
         modeling_qwen3_moe,
         {

--- a/swift/model/npu_patcher.py
+++ b/swift/model/npu_patcher.py
@@ -43,6 +43,7 @@ def _import_optional_module(module_name: str) -> Any | None:
         logger.debug('Failed to import optional module %s: %s', module_name, exc)
         return None
 
+
 def _patch_transformers_flash_linear_attention_available() -> None:
     def _is_flash_linear_attention_available() -> bool:
         return True
@@ -82,6 +83,7 @@ def patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed() -> None:
     if patched_modules:
         logger.info('Patched Qwen3.5 chunk_gated_delta_rule to embedded MindSpeed implementation: %s.',
                     ', '.join(patched_modules))
+
 
 def patch_mindspeed_te_cp_implementation(megatron_args: dict[str, Any]) -> None:
     """
@@ -431,6 +433,7 @@ def _setattr_path(root: Any, path: str, value: Any) -> None:
 def _apply_patch_map(root: Any, patch_map: dict[str, Any]) -> None:
     for path, value in patch_map.items():
         _setattr_path(root, path, value)
+
 
 modeling_qwen3_5 = _import_optional_module('transformers.models.qwen3_5.modeling_qwen3_5')
 if modeling_qwen3_5 is not None:

--- a/swift/model/npu_patcher.py
+++ b/swift/model/npu_patcher.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import accelerate.utils.fsdp_utils as fsdp_utils
+import fcntl
+import importlib
 import os
 import torch
 import torch.nn.functional as F
@@ -20,6 +22,7 @@ from swift.utils.logger import get_logger
 logger = get_logger()
 
 _DEFAULT_NPU_HCCL_CONNECT_TIMEOUT = '600'
+_DEFAULT_TRITON_ASCEND_LAUNCHER_LOCK_PATH = '/tmp/swift_triton_ascend_launcher_compile.lock'
 _ORIGINAL_MINDSPEED_TE_CP_CLASS = None
 
 
@@ -32,6 +35,145 @@ def _set_default_hccl_connect_timeout_for_npu() -> None:
 
 
 _set_default_hccl_connect_timeout_for_npu()
+
+
+def _import_optional_module(module_name: str) -> Any | None:
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as exc:
+        logger.debug('Failed to import optional module %s: %s', module_name, exc)
+        return None
+
+def _patch_triton_ascend_launcher_compile_lock() -> None:
+    ascend_driver = _import_optional_module('triton.backends.ascend.driver')
+    if ascend_driver is None:
+        return
+
+    make_launcher_stub = getattr(ascend_driver, 'make_npu_launcher_stub', None)
+    if make_launcher_stub is None or getattr(make_launcher_stub, '_swift_compile_lock', False):
+        return
+
+    @wraps(make_launcher_stub)
+    def _locked_make_npu_launcher_stub(*args, **kwargs):
+        lock_path = os.environ.get('SWIFT_TRITON_ASCEND_LAUNCHER_LOCK',
+                                   _DEFAULT_TRITON_ASCEND_LAUNCHER_LOCK_PATH)
+        with open(lock_path, 'w') as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                return make_launcher_stub(*args, **kwargs)
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+    _locked_make_npu_launcher_stub._swift_compile_lock = True
+    ascend_driver.make_npu_launcher_stub = _locked_make_npu_launcher_stub
+    logger.info(
+        'Patched Ascend Triton launcher compilation with file lock: %s.',
+        os.environ.get('SWIFT_TRITON_ASCEND_LAUNCHER_LOCK', _DEFAULT_TRITON_ASCEND_LAUNCHER_LOCK_PATH),
+    )
+
+
+def _patch_transformers_flash_linear_attention_available() -> None:
+    def _is_flash_linear_attention_available() -> bool:
+        return True
+
+    transformers_utils = _import_optional_module('transformers.utils')
+    if transformers_utils is not None:
+        setattr(transformers_utils, 'is_flash_linear_attention_available', _is_flash_linear_attention_available)
+
+    transformers_import_utils = _import_optional_module('transformers.utils.import_utils')
+    if transformers_import_utils is not None:
+        setattr(transformers_import_utils, 'is_flash_linear_attention_available',
+                _is_flash_linear_attention_available)
+
+
+def _should_fallback_to_torch_chunk_gated_delta_rule(exc: BaseException) -> bool:
+    if not isinstance(exc, RuntimeError):
+        return False
+
+    message = str(exc)
+    fallback_patterns = (
+        'Failed to compile',
+        'launcher_cxx11abi1.cxx',
+        'internal compiler error',
+        'wide_int_to_tree_1',
+        'ConvertLinalgRToBinary',
+        'hivm.hir',
+    )
+    return any(pattern in message for pattern in fallback_patterns)
+
+
+def _build_qwen3_5_chunk_gated_delta_rule_with_fallback(module_name: str, module: Any,
+                                                        mindspeed_chunk_gated_delta_rule):
+    torch_chunk_gated_delta_rule = getattr(module, 'torch_chunk_gated_delta_rule', None)
+    if torch_chunk_gated_delta_rule is None:
+        return mindspeed_chunk_gated_delta_rule
+
+    warned_runtime_fallback = False
+    warned_forced_fallback = False
+
+    @wraps(mindspeed_chunk_gated_delta_rule)
+    def _wrapped_chunk_gated_delta_rule(*args, **kwargs):
+        nonlocal warned_runtime_fallback, warned_forced_fallback
+
+        if os.environ.get('SWIFT_QWEN3_5_CHUNK_GATED_DELTA_RULE_FORCE_TORCH', '0') == '1':
+            if not warned_forced_fallback:
+                logger.warning('Using torch_chunk_gated_delta_rule for %s because '
+                               'SWIFT_QWEN3_5_CHUNK_GATED_DELTA_RULE_FORCE_TORCH=1.', module_name)
+                warned_forced_fallback = True
+            return torch_chunk_gated_delta_rule(*args, **kwargs)
+
+        if os.environ.get('SWIFT_QWEN3_5_CHUNK_GATED_DELTA_RULE_FORCE_TRITON', '0') == '1':
+            return mindspeed_chunk_gated_delta_rule(*args, **kwargs)
+
+        try:
+            return mindspeed_chunk_gated_delta_rule(*args, **kwargs)
+        except Exception as exc:
+            if not _should_fallback_to_torch_chunk_gated_delta_rule(exc):
+                raise
+            if not warned_runtime_fallback:
+                logger.warning('Falling back to torch_chunk_gated_delta_rule for %s after MindSpeed '
+                               'chunk_gated_delta_rule failed: %s', module_name, exc)
+                warned_runtime_fallback = True
+            return torch_chunk_gated_delta_rule(*args, **kwargs)
+
+    _wrapped_chunk_gated_delta_rule._swift_chunk_gated_delta_rule_fallback = True
+    return _wrapped_chunk_gated_delta_rule
+
+
+def patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed() -> None:
+    try:
+        from .chunk_gated_delta_rule import chunk_gated_delta_rule
+    except ImportError as exc:
+        logger.warning('Failed to import embedded MindSpeed chunk_gated_delta_rule: %s', exc)
+        return
+
+    patched_modules = []
+    for module_name in ('transformers.models.qwen3_5.modeling_qwen3_5',
+                        'transformers.models.qwen3_5_moe.modeling_qwen3_5_moe',
+                        'transformers.models.qwen3_next.modeling_qwen3_next'):
+        module = _import_optional_module(module_name)
+        if module is None:
+            continue
+
+        setattr(module, 'is_flash_linear_attention_available', lambda: True)
+        setattr(module, 'is_fast_path_available', True)
+        # FLA's fused RMSNormGated initializes with torch.cuda.current_device(),
+        # so keep the native Qwen3.5 torch implementation on NPU.
+        setattr(module, 'FusedRMSNormGated', None)
+        setattr(
+            module, 'chunk_gated_delta_rule',
+            _build_qwen3_5_chunk_gated_delta_rule_with_fallback(module_name, module, chunk_gated_delta_rule))
+        patched_modules.append(module_name)
+
+    if patched_modules:
+        logger.info('Patched Qwen3.5 chunk_gated_delta_rule to embedded MindSpeed implementation: %s.',
+                    ', '.join(patched_modules))
+
+
+_patch_triton_ascend_launcher_compile_lock()
+_patch_transformers_flash_linear_attention_available()
+patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed()
+modeling_qwen3_5 = _import_optional_module('transformers.models.qwen3_5.modeling_qwen3_5')
 
 
 def patch_mindspeed_te_cp_implementation(megatron_args: dict[str, Any]) -> None:
@@ -165,12 +307,43 @@ class NpuRMSNorm(nn.Module):
         return f'{tuple(self.weight.shape)}, eps={self.variance_epsilon}'
 
 
+class NpuQwen3_5RMSNorm(nn.Module):
+
+    def __init__(self, dim, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.zeros(dim))
+
+    def forward(self, x):
+        scale = (1.0 + self.weight).to(dtype=x.dtype)
+        return torch_npu.npu_rms_norm(x, scale, epsilon=self.eps)[0]
+
+    def extra_repr(self):
+        return f'{tuple(self.weight.shape)}, eps={self.eps}'
+
+
 def npu_apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """Applies Rotary Position Embedding to the query and key tensors."""
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
     q_embed = torch_npu.npu_rotary_mul(q, cos, sin)
     k_embed = torch_npu.npu_rotary_mul(k, cos, sin)
+    return q_embed, k_embed
+
+
+def npu_apply_rotary_pos_emb_qwen3_5(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+
+    rotary_dim = cos.shape[-1]
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+
+    q_rot = torch_npu.npu_rotary_mul(q_rot, cos, sin)
+    k_rot = torch_npu.npu_rotary_mul(k_rot, cos, sin)
+
+    q_embed = torch.cat([q_rot, q_pass], dim=-1)
+    k_embed = torch.cat([k_rot, k_pass], dim=-1)
     return q_embed, k_embed
 
 
@@ -353,6 +526,14 @@ def _apply_patch_map(root: Any, patch_map: dict[str, Any]) -> None:
         _setattr_path(root, path, value)
 
 
+_QWEN3_5_PATCH_TABLE: tuple[tuple[Any, dict[str, Any]], ...] = ()
+if modeling_qwen3_5 is not None:
+    _QWEN3_5_PATCH_TABLE = ((modeling_qwen3_5, {
+        'Qwen3_5RMSNorm': NpuQwen3_5RMSNorm,
+        'apply_rotary_pos_emb': npu_apply_rotary_pos_emb_qwen3_5,
+        'Qwen3_5MLP.forward': npu_swiglu_forward,
+    }), )
+
 _PATCH_TABLE: tuple[tuple[Any, dict[str, Any]], ...] = (
     (
         modeling_qwen2,
@@ -370,6 +551,7 @@ _PATCH_TABLE: tuple[tuple[Any, dict[str, Any]], ...] = (
             'Qwen3MLP.forward': npu_swiglu_forward,
         },
     ),
+    *_QWEN3_5_PATCH_TABLE,
     (
         modeling_qwen3_moe,
         {


### PR DESCRIPTION
# PR type
New Feature -- Add NPU patch FLA to improve performance.

# PR information
Add npu patcher for Qwen 3.5 dense model. After patching, a throughput of 1.59x was achieved on the NPU, and the single-step time decreased from 7.945s/it to 5.006s/it. Accuracy comparisons with GPUs were implemented on Transformers 5.2.0, and unpatched single-step steady-state time on the GPU is 6.959 s/it.
 
## Experiment results
npu patch and no patch comparison
<img width="598" height="602" alt="截屏2026-04-23 下午4 20 04" src="https://github.com/user-attachments/assets/1173f49c-c07f-479a-ada5-20dafca327dd" />

