### PR TITLE
npu  qwen3.5 megatron padding_free fix

### DIFF
--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -969,6 +969,8 @@ class BaseMegatronTrainer(ABC):
             if 'attention_mask_2d' not in batch and batch.get('attention_mask') is not None:
                 batch['attention_mask_2d'] = (~batch['attention_mask']).sum(dim=(1, 2)) > 0
             batch['attention_mask'] = None
+        else:
+            batch['attention_mask'] = None
         if args.padding_free and text_position_ids is not None:
             batch['packed_seq_params'] = get_packed_seq_params(text_position_ids)
             batch['packed_seq_params'].num_samples = num_samples

--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -23,6 +23,7 @@ from modelscope import check_local_model_is_latest
 from packaging import version
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
+from transformers.utils import is_torch_npu_available
 
 from swift.dataset import RowPreprocessor
 from swift.megatron.callbacks import megatron_callbacks_map
@@ -53,6 +54,17 @@ except ImportError:
 mcore_016 = version.parse(megatron.core.__version__) >= version.parse('0.16.0rc0')
 
 logger = get_logger()
+
+
+def _should_use_npu_generated_attention_mask(args) -> bool:
+    return (
+        is_torch_npu_available()
+        and
+        args.task_type == 'causal_lm'
+        and not args.padding_free
+        and getattr(args, 'attention_backend', None) != 'local'
+        and getattr(args, 'use_flash_attn', False)
+    )
 
 
 class BaseMegatronTrainer(ABC):
@@ -952,9 +964,12 @@ class BaseMegatronTrainer(ABC):
             num_samples = batch.pop('num_samples')
         args = self.args
         text_position_ids = batch.pop('text_position_ids', None)
-        batch.pop('attention_mask_2d', None)
         if text_position_ids is None:
             text_position_ids = batch.get('position_ids')
+        if _should_use_npu_generated_attention_mask(args):
+            if 'attention_mask_2d' not in batch and batch.get('attention_mask') is not None:
+                batch['attention_mask_2d'] = (~batch['attention_mask']).sum(dim=(1, 2)) > 0
+            batch['attention_mask'] = None
         if args.padding_free and text_position_ids is not None:
             batch['packed_seq_params'] = get_packed_seq_params(text_position_ids)
             batch['packed_seq_params'].num_samples = num_samples

--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -56,9 +56,6 @@ mcore_016 = version.parse(megatron.core.__version__) >= version.parse('0.16.0rc0
 logger = get_logger()
 
 
-
-
-
 class BaseMegatronTrainer(ABC):
 
     def __init__(self, args, template: Template):

--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -56,15 +56,7 @@ mcore_016 = version.parse(megatron.core.__version__) >= version.parse('0.16.0rc0
 logger = get_logger()
 
 
-def _should_use_npu_generated_attention_mask(args) -> bool:
-    return (
-        is_torch_npu_available()
-        and
-        args.task_type == 'causal_lm'
-        and not args.padding_free
-        and getattr(args, 'attention_backend', None) != 'local'
-        and getattr(args, 'use_flash_attn', False)
-    )
+
 
 
 class BaseMegatronTrainer(ABC):
@@ -958,6 +950,16 @@ class BaseMegatronTrainer(ABC):
     def forward_step(self, data_iterator, model):
         pass
 
+    def _should_use_npu_generated_attention_mask(self, args) -> bool:
+        return (
+            is_torch_npu_available()
+            and
+            args.task_type == 'causal_lm'
+            and not args.padding_free
+            and getattr(args, 'attention_backend', None) != 'local'
+            and getattr(args, 'use_flash_attn', False)
+        )
+
     def _prepare_batch(self, data, vp_stage=None, num_samples=None):
         batch = get_batch_on_this_pp_rank(self.args, data, vp_stage=vp_stage)
         if num_samples is None:
@@ -966,7 +968,7 @@ class BaseMegatronTrainer(ABC):
         text_position_ids = batch.pop('text_position_ids', None)
         if text_position_ids is None:
             text_position_ids = batch.get('position_ids')
-        if _should_use_npu_generated_attention_mask(args):
+        if self._should_use_npu_generated_attention_mask(args):
             if 'attention_mask_2d' not in batch and batch.get('attention_mask') is not None:
                 batch['attention_mask_2d'] = (~batch['attention_mask']).sum(dim=(1, 2)) > 0
             batch['attention_mask'] = None

--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -964,7 +964,7 @@ class BaseMegatronTrainer(ABC):
                 batch['attention_mask_2d'] = (~batch['attention_mask']).sum(dim=(1, 2)) > 0
             batch['attention_mask'] = None
         else:
-            batch['attention_mask'] = None
+            batch.pop('attention_mask_2d', None)
         if args.padding_free and text_position_ids is not None:
             batch['packed_seq_params'] = get_packed_seq_params(text_position_ids)
             batch['packed_seq_params'].num_samples = num_samples

--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -22,8 +22,8 @@ from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelpe
 from modelscope import check_local_model_is_latest
 from packaging import version
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
 from transformers.utils import is_torch_npu_available
+from typing import Callable, Dict, List, Optional
 
 from swift.dataset import RowPreprocessor
 from swift.megatron.callbacks import megatron_callbacks_map
@@ -948,14 +948,8 @@ class BaseMegatronTrainer(ABC):
         pass
 
     def _should_use_npu_generated_attention_mask(self, args) -> bool:
-        return (
-            is_torch_npu_available()
-            and
-            args.task_type == 'causal_lm'
-            and not args.padding_free
-            and getattr(args, 'attention_backend', None) != 'local'
-            and getattr(args, 'use_flash_attn', False)
-        )
+        return (is_torch_npu_available() and args.task_type == 'causal_lm' and not args.padding_free
+                and getattr(args, 'attention_backend', None) != 'local' and getattr(args, 'use_flash_attn', False))
 
     def _prepare_batch(self, data, vp_stage=None, num_samples=None):
         batch = get_batch_on_this_pp_rank(self.args, data, vp_stage=vp_stage)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

fix(megatron): preserve `attention_mask_2d` for NPU GDN models when `padding_free=False`

## Problem

On NPU, Qwen3.5 / Qwen3-Next can run with `padding_free=True` but fail with `padding_free=False`.
 The failure usually surfaces around `masked_select`, while the actual async error comes from `**aclnnFlashAttentionScore**`. 

## Cause

For GDN models:

- `padding_free=True` goes through the thd path and derives mask from `cu_seqlens_q`
- `padding_free=False` goes through the non-thd path and reads external mask from kwargs

The trainer side did not preserve the NPU-compatible `attention_mask_2d` end-to-end, so the non-thd branch consumed an incompatible mask. This is why `padding_free=True` only bypassed the issue instead of fixing it. 

## Fix

This PR preserves `attention_mask_2d` in the Megatron trainer batch path for the NPU flash-attn case, so downstream model wrappers can still access the correct 2D mask when `padding_free=False`.

The complete fix also includes a companion `mcore-bridge` update where GDN non-thd prefers `attention_mask_2d` on NPU.

## Impact

The issue is limited to models with HF-style GDN components such as Qwen3.5 / Qwen3-Next.
 Pure Megatron attention paths are not affected.
