### PR TITLE
Fixing issue with video loading for Gemma 4 with relative paths

### DIFF
--- a/swift/template/base.py
+++ b/swift/template/base.py
@@ -308,6 +308,22 @@ class Template(ProcessorMixin):
                     images[i] = self._save_pil_image(image)
         inputs.images = images
 
+        # Resolve video/audio paths with ROOT_IMAGE_DIR.
+        # Image paths are resolved by _load_image above, but video/audio paths are
+        # passed as raw strings to model-specific templates. Templates that delegate
+        # media loading to HF processors (e.g. Gemma4) need resolved absolute paths.
+        if self.root_image_dir:
+            for i, video in enumerate(inputs.videos):
+                if isinstance(video, str) and not os.path.isfile(video) and not video.startswith('http'):
+                    resolved = os.path.join(self.root_image_dir, video)
+                    if os.path.isfile(resolved):
+                        inputs.videos[i] = resolved
+            for i, audio in enumerate(inputs.audios):
+                if isinstance(audio, str) and not os.path.isfile(audio) and not audio.startswith('http'):
+                    resolved = os.path.join(self.root_image_dir, audio)
+                    if os.path.isfile(resolved):
+                        inputs.audios[i] = resolved
+
         if self.mode == 'vllm' and inputs.audios:
             sampling_rate = get_env_args('sampling_rate', int, None)
             inputs.audios = load_batch(


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

When using datasets with relative media paths and `--root_image_dir`, video and audio file paths are not resolved to absolute paths before being passed to model-specific templates. Image paths are correctly resolved via `_load_image`, but video and audio paths are passed as raw strings.

This causes a `FileNotFoundError` for models like Gemma 4 whose templates delegate media loading to the HuggingFace processor, since the processor receives the unresolved relative path.

This fix adds path resolution for `inputs.videos` and `inputs.audios` in `Template._preprocess_media` (`swift/template/base.py`), matching the existing behavior for images. A relative path is resolved against `root_image_dir` only when:
- `root_image_dir` is set
- The path is a string (not already loaded)
- The file does not exist at the original path
- The path is not a URL
- The resolved path points to an existing file

## Experiment results

Verified that Gemma 4 video fine-tuning with relative video paths in the dataset and `--root_image_dir` correctly loads videos after this fix, where previously it raised `FileNotFoundError`.
