### PR TITLE
Document FLA/MindSpeed replacement for Qwen3.5 on NPU

### DIFF
--- a/docs/source/BestPractices/NPU-support.md
+++ b/docs/source/BestPractices/NPU-support.md
@@ -94,6 +94,37 @@ export MEGATRON_LM_PATH=<your_local_megatron_lm_path>
 python -c "import mindspeed.megatron_adaptor; from swift.megatron.init import init_megatron_env; init_megatron_env(); print('✓ NPU环境下的Megatron-SWIFT配置验证成功！')"
 ```
 
+### Qwen3.5 FLA补丁说明
+
+当前仓库已经内置了面向昇腾 NPU 的 Qwen3.5 linear attention patch，无需用户再额外修改 `transformers` 或 `fla` 源码。该 patch 的目标不是直接替换整个 `flash-linear-attention` 包，而是在 `Qwen3.5` 实际调用的 `chunk_gated_delta_rule` 路径上，将底层 GPU Triton 算子重定向到 MindSpeed 的 NPU 实现。
+
+补丁生效时，ms-swift 会执行以下替换：
+
+1. 将 `transformers.utils.is_flash_linear_attention_available` 与 `transformers.utils.import_utils.is_flash_linear_attention_available` 置为 `True`，使 `transformers.models.qwen3_5.modeling_qwen3_5` 可以按 FLA fast path 完成初始化。
+2. 将 `transformers.models.qwen3_5.modeling_qwen3_5.chunk_gated_delta_rule` 以及 `transformers.models.qwen3_5_moe.modeling_qwen3_5_moe.chunk_gated_delta_rule` 重定向到 ms-swift 内置实现 `swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule`。
+3. `swift.model.chunk_gated_delta_rule` 内部继续调用 MindSpeed 提供的原生 Triton 算子，包括：
+   - `mindspeed.lite.ops.triton.chunk_delta_h`
+   - `mindspeed.lite.ops.triton.chunk_o`
+   - `mindspeed.lite.ops.triton.chunk_scaled_dot_kkt`
+   - `mindspeed.lite.ops.triton.wy_fast`
+4. 保留了 torch 原生 l2norm 小算子实现，减轻每层每步的 launch 开销以及冷启动中的 compile/autotune 开销，提升模型在 NPU 上的性能表现。
+5. 对于 FLA 中依赖 `torch.cuda.current_device()` 初始化的 `FusedRMSNormGated`，NPU 上会保留 Qwen3.5 的原生 torch 路径，避免 CUDA-only 初始化逻辑带来的兼容性问题。
+
+可以将这条调用链理解为：
+
+```text
+Qwen3.5 modeling.chunk_gated_delta_rule
+    -> swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule
+    -> MindSpeed Triton kernels
+```
+
+因此：
+
+- 该 patch 主要覆盖的是 **Qwen3.5 linear attention 的 gated-delta-rule 路径**；
+- 它并不等价于“将整个 fla 包完整替换为 MindSpeed”；
+- 若需要这条路径生效，请确保当前环境中可以正确导入 MindSpeed。
+- 精度对齐验证版本：torch 2.7.1 + MindSpeed 0.12.1 + flash-linear-attention 4.1.0 + triton-ascend 3.2.0 + transformers 5.2.0
+
 ### 环境查看
 
 查看NPU的P2P连接，这里看到每个NPU都通过7条HCCS与其他NPU互联

--- a/docs/source/BestPractices/Qwen3_5-Best-Practice.md
+++ b/docs/source/BestPractices/Qwen3_5-Best-Practice.md
@@ -33,6 +33,35 @@ pip install -U "transformers==5.2.*"
 - Qwen3.5 视频数据训练卡住：使用decord后端读取视频可能导致卡住问题，参考[这个issue](https://github.com/dmlc/decord/issues/269)。你可以使用torchcodec后端，具体参考[qwen_vl_utils](https://github.com/QwenLM/Qwen3-VL/blob/50068df2334f309979ff05d75f1078c8309c63ed/qwen-vl-utils/src/qwen_vl_utils/vision_process.py#L390-L400)库。
 
 
+### NPU上的 FLA / MindSpeed 替换关系
+
+在昇腾 NPU 环境下，Qwen3.5 的 linear attention 训练链路与常规 CUDA 环境不同。当前 ms-swift 已内置针对 Qwen3.5 的 patch，用于将 `transformers` 中实际执行的 `chunk_gated_delta_rule` 替换为 ms-swift 封装的 NPU 版本，再由后者调用 MindSpeed 的原生 Triton 算子。
+
+简化后的关系如下：
+
+```text
+transformers.models.qwen3_5.modeling_qwen3_5.chunk_gated_delta_rule
+    -> swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule
+    -> mindspeed.lite.ops.triton.*
+```
+
+其中主要包含两层动作：
+
+1. **欺骗 transformers 通过 FLA 可用性检查**
+   ms-swift 会将 `is_flash_linear_attention_available()` patch 为 `True`，使 Qwen3.5 modeling 可以进入 linear attention 对应的 fast path 初始化流程。
+
+2. **将 FLA 的 gated-delta-rule 执行路径改接到 MindSpeed**
+   - 顶层执行入口替换为 `swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule`
+   - 该实现内部再调用 MindSpeed 的原生 Triton kernel，包括 `chunk_delta_h`、`chunk_o`、`chunk_scaled_dot_kkt`、`wy_fast`
+   - 保留 l2norm 为 torch 原生小算子
+
+需要注意：
+
+- 这里替换的是 **Qwen3.5 实际使用的 linear attention 算子路径**，不是把整个 `flash-linear-attention` Python 包逐文件完整替换。
+- `FusedRMSNormGated` 在 NPU 上不会直接走 FLA 的 CUDA 初始化逻辑，而是保持 Qwen3.5 自身的兼容实现。
+- 若要使用这条链路，请确保已经正确安装并可导入 MindSpeed；若 MindSpeed 不可用，相关 patch 不会完成算子重定向。
+
+
 ## 推理
 
 使用 ms-swift 的 `TransformersEngine` 进行推理：

--- a/docs/source/BestPractices/Qwen3_5-Best-Practice.md
+++ b/docs/source/BestPractices/Qwen3_5-Best-Practice.md
@@ -31,35 +31,7 @@ pip install -U "transformers==5.2.*"
 ```
 
 - Qwen3.5 视频数据训练卡住：使用decord后端读取视频可能导致卡住问题，参考[这个issue](https://github.com/dmlc/decord/issues/269)。你可以使用torchcodec后端，具体参考[qwen_vl_utils](https://github.com/QwenLM/Qwen3-VL/blob/50068df2334f309979ff05d75f1078c8309c63ed/qwen-vl-utils/src/qwen_vl_utils/vision_process.py#L390-L400)库。
-
-
-### NPU上的 FLA / MindSpeed 替换关系
-
-在昇腾 NPU 环境下，Qwen3.5 的 linear attention 训练链路与常规 CUDA 环境不同。当前 ms-swift 已内置针对 Qwen3.5 的 patch，用于将 `transformers` 中实际执行的 `chunk_gated_delta_rule` 替换为 ms-swift 封装的 NPU 版本，再由后者调用 MindSpeed 的原生 Triton 算子。
-
-简化后的关系如下：
-
-```text
-transformers.models.qwen3_5.modeling_qwen3_5.chunk_gated_delta_rule
-    -> swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule
-    -> mindspeed.lite.ops.triton.*
-```
-
-其中主要包含两层动作：
-
-1. **欺骗 transformers 通过 FLA 可用性检查**
-   ms-swift 会将 `is_flash_linear_attention_available()` patch 为 `True`，使 Qwen3.5 modeling 可以进入 linear attention 对应的 fast path 初始化流程。
-
-2. **将 FLA 的 gated-delta-rule 执行路径改接到 MindSpeed**
-   - 顶层执行入口替换为 `swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule`
-   - 该实现内部再调用 MindSpeed 的原生 Triton kernel，包括 `chunk_delta_h`、`chunk_o`、`chunk_scaled_dot_kkt`、`wy_fast`
-   - 保留 l2norm 为 torch 原生小算子
-
-需要注意：
-
-- 这里替换的是 **Qwen3.5 实际使用的 linear attention 算子路径**，不是把整个 `flash-linear-attention` Python 包逐文件完整替换。
-- `FusedRMSNormGated` 在 NPU 上不会直接走 FLA 的 CUDA 初始化逻辑，而是保持 Qwen3.5 自身的兼容实现。
-- 若要使用这条链路，请确保已经正确安装并可导入 MindSpeed；若 MindSpeed 不可用，相关 patch 不会完成算子重定向。
+- 如果你在昇腾 NPU 上使用 Qwen3.5，并且需要了解 FLA / MindSpeed 的替换关系、补丁生效路径以及版本验证信息，请参考 [NPU支持文档中的 Qwen3.5 FLA补丁说明](./NPU-support.md#qwen35-fla补丁说明)。
 
 
 ## 推理

--- a/docs/source_en/BestPractices/NPU-support.md
+++ b/docs/source_en/BestPractices/NPU-support.md
@@ -91,6 +91,37 @@ Run the following command to verify if MindSpeed (Megatron-LM) is configured suc
 python -c "import mindspeed.megatron_adaptor; from swift.megatron.init import init_megatron_env; init_megatron_env(); print('✓ NPU environment Megatron-SWIFT configuration verified successfully!')"
 ```
 
+### Qwen3.5 FLA Patch Notes
+
+The current repository already includes a built-in Qwen3.5 linear attention patch for Ascend NPUs, so users do not need to manually modify the `transformers` or `fla` source code. This patch does not replace the entire `flash-linear-attention` package directly. Instead, it redirects the low-level GPU Triton operator path used by `Qwen3.5` through `chunk_gated_delta_rule` to the MindSpeed NPU implementation.
+
+When the patch takes effect, ms-swift performs the following replacements:
+
+1. Set `transformers.utils.is_flash_linear_attention_available` and `transformers.utils.import_utils.is_flash_linear_attention_available` to return `True`, so that `transformers.models.qwen3_5.modeling_qwen3_5` can complete initialization through the FLA fast path.
+2. Redirect `transformers.models.qwen3_5.modeling_qwen3_5.chunk_gated_delta_rule` and `transformers.models.qwen3_5_moe.modeling_qwen3_5_moe.chunk_gated_delta_rule` to the built-in ms-swift implementation `swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule`.
+3. Inside `swift.model.chunk_gated_delta_rule`, continue calling the native Triton operators provided by MindSpeed, including:
+   - `mindspeed.lite.ops.triton.chunk_delta_h`
+   - `mindspeed.lite.ops.triton.chunk_o`
+   - `mindspeed.lite.ops.triton.chunk_scaled_dot_kkt`
+   - `mindspeed.lite.ops.triton.wy_fast`
+4. Keep the native torch l2norm helper, reducing per-layer per-step launch overhead as well as compile/autotune overhead during cold start, which improves model performance on NPU.
+5. For `FusedRMSNormGated`, which depends on `torch.cuda.current_device()` during FLA initialization, NPU keeps the native Qwen3.5 torch path to avoid compatibility issues caused by CUDA-only initialization logic.
+
+The call chain can be understood as:
+
+```text
+Qwen3.5 modeling.chunk_gated_delta_rule
+    -> swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule
+    -> MindSpeed Triton kernels
+```
+
+Therefore:
+
+- This patch mainly covers the **gated-delta-rule path of Qwen3.5 linear attention**.
+- It is not equivalent to “fully replacing the entire fla package with MindSpeed”.
+- To make this path effective, ensure that MindSpeed can be imported correctly in the current environment.
+- Verified versions for accuracy alignment: torch 2.7.1 + MindSpeed 0.12.1 + flash-linear-attention 4.1.0 + triton-ascend 3.2.0 + transformers 5.2.0
+
 ### Environment Viewing
 Check the P2P connections of the NPU, where we can see that each NPU is interconnected through 7 HCCS links with other NPUs.
 ```shell

--- a/docs/source_en/BestPractices/Qwen3_5-Best-Practice.md
+++ b/docs/source_en/BestPractices/Qwen3_5-Best-Practice.md
@@ -32,6 +32,34 @@ pip install -U "transformers==5.2.*"
 
 - Qwen3.5 video data training hangs: Using the decord backend to read videos may cause hanging issues, refer to [this issue](https://github.com/dmlc/decord/issues/269). You can use the torchcodec backend, specifically refer to the [qwen_vl_utils](https://github.com/QwenLM/Qwen3-VL/blob/50068df2334f309979ff05d75f1078c8309c63ed/qwen-vl-utils/src/qwen_vl_utils/vision_process.py#L390-L400) library.
 
+### FLA / MindSpeed Replacement on NPU
+
+In an Ascend NPU environment, the Qwen3.5 linear attention training path differs from the usual CUDA path. ms-swift includes a built-in patch for Qwen3.5 that replaces the `chunk_gated_delta_rule` actually executed by `transformers` with an NPU-oriented implementation wrapped by ms-swift, which then dispatches to MindSpeed native Triton kernels.
+
+The simplified execution path is:
+
+```text
+transformers.models.qwen3_5.modeling_qwen3_5.chunk_gated_delta_rule
+    -> swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule
+    -> mindspeed.lite.ops.triton.*
+```
+
+This patch mainly performs two actions:
+
+1. **Make transformers believe FLA is available**
+   ms-swift patches `is_flash_linear_attention_available()` to return `True`, so that Qwen3.5 modeling can enter the fast-path initialization flow for linear attention.
+
+2. **Redirect the FLA gated-delta-rule execution path to MindSpeed**
+   - The top-level execution entry is replaced with `swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule`
+   - That implementation then calls MindSpeed native Triton kernels, including `chunk_delta_h`, `chunk_o`, `chunk_scaled_dot_kkt`, and `wy_fast`
+   - l2norm remains implemented as a native torch helper
+
+Please note:
+
+- This replaces the **linear attention operator path actually used by Qwen3.5**, rather than replacing the entire `flash-linear-attention` Python package file by file.
+- `FusedRMSNormGated` does not use the CUDA-specific initialization logic from FLA on NPU, and instead keeps the Qwen3.5-compatible implementation.
+- To use this path, MindSpeed must be correctly installed and importable. If MindSpeed is unavailable, the operator redirection patch will not be completed.
+
 ## Inference
 
 Using ms-swift's `TransformersEngine` for inference:

--- a/docs/source_en/BestPractices/Qwen3_5-Best-Practice.md
+++ b/docs/source_en/BestPractices/Qwen3_5-Best-Practice.md
@@ -31,34 +31,7 @@ pip install -U "transformers==5.2.*"
 ```
 
 - Qwen3.5 video data training hangs: Using the decord backend to read videos may cause hanging issues, refer to [this issue](https://github.com/dmlc/decord/issues/269). You can use the torchcodec backend, specifically refer to the [qwen_vl_utils](https://github.com/QwenLM/Qwen3-VL/blob/50068df2334f309979ff05d75f1078c8309c63ed/qwen-vl-utils/src/qwen_vl_utils/vision_process.py#L390-L400) library.
-
-### FLA / MindSpeed Replacement on NPU
-
-In an Ascend NPU environment, the Qwen3.5 linear attention training path differs from the usual CUDA path. ms-swift includes a built-in patch for Qwen3.5 that replaces the `chunk_gated_delta_rule` actually executed by `transformers` with an NPU-oriented implementation wrapped by ms-swift, which then dispatches to MindSpeed native Triton kernels.
-
-The simplified execution path is:
-
-```text
-transformers.models.qwen3_5.modeling_qwen3_5.chunk_gated_delta_rule
-    -> swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule
-    -> mindspeed.lite.ops.triton.*
-```
-
-This patch mainly performs two actions:
-
-1. **Make transformers believe FLA is available**
-   ms-swift patches `is_flash_linear_attention_available()` to return `True`, so that Qwen3.5 modeling can enter the fast-path initialization flow for linear attention.
-
-2. **Redirect the FLA gated-delta-rule execution path to MindSpeed**
-   - The top-level execution entry is replaced with `swift.model.chunk_gated_delta_rule.chunk_gated_delta_rule`
-   - That implementation then calls MindSpeed native Triton kernels, including `chunk_delta_h`, `chunk_o`, `chunk_scaled_dot_kkt`, and `wy_fast`
-   - l2norm remains implemented as a native torch helper
-
-Please note:
-
-- This replaces the **linear attention operator path actually used by Qwen3.5**, rather than replacing the entire `flash-linear-attention` Python package file by file.
-- `FusedRMSNormGated` does not use the CUDA-specific initialization logic from FLA on NPU, and instead keeps the Qwen3.5-compatible implementation.
-- To use this path, MindSpeed must be correctly installed and importable. If MindSpeed is unavailable, the operator redirection patch will not be completed.
+- If you are using Qwen3.5 on Ascend NPU and want details about the FLA / MindSpeed replacement, effective patch path, and verified version combinations, please refer to [Qwen3.5 FLA Patch Notes in the NPU Support document](./NPU-support.md#qwen35-fla-patch-notes).
 
 ## Inference
 


### PR DESCRIPTION
Added section on FLA/MindSpeed replacement for Qwen3.5 on NPU, detailing the training link differences and patch implementation.

# PR type
- [ npu-patcher] Document Updates