### PR TITLE
[bugfix] fix jinja-backend train↔infer parity for Qwen3.6

### DIFF
--- a/swift/template/templates/qwen.py
+++ b/swift/template/templates/qwen.py
@@ -1,5 +1,6 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import inspect
+import re
 import torch
 import torch.nn.functional as F
 import transformers
@@ -568,6 +569,79 @@ class Qwen3_5Template(Qwen3VLTemplate):
 
     def _post_encode(self, model, inputs: Dict[str, Any]) -> Dict[str, Any]:
         return Qwen2VLTemplate._post_encode(self, model, inputs)
+
+    # ChatML role marker pattern, scoped to this template family. Captures the
+    # role name on the line right after `<|im_start|>`. Used to split a
+    # `tokenizer.apply_chat_template`-rendered text into alternating
+    # non-assistant / assistant chunks during training.
+    _CHATML_ROLE_PATTERN = re.compile(r'<\|im_start\|>([^\n]+)\n')
+
+    def _jinja_encode(self, inputs):
+        """Override base `_jinja_encode` so SFT under `template_backend='jinja'`
+        correctly masks non-assistant tokens.
+
+        The base implementation returns ``loss_scale=[1.]`` wholesale, which
+        means under ``template_backend='jinja'`` the trainer ends up
+        supervising every system / user / tool / role-marker token in the
+        rendered text. For Qwen3.5/3.6 we want jinja-backend training to
+        produce byte-identical ``input_ids`` to inference (no qwen3_5
+        agent_template ↔ HF chat_template drift) AND a correct loss mask.
+
+        Inference behavior is unchanged (the new logic is gated on
+        ``self.is_training``). Encoder-decoder is also unchanged: Qwen3.5/3.6
+        are decoder-only causal LM models, so ``answer_len`` is only used to
+        force the train mode bookkeeping by the parent encoder logic.
+        """
+        # Mirror base setup so the rendered text is byte-identical to it.
+        messages = inputs.messages.copy()
+        if inputs.system is None:
+            inputs.system = self.template_meta.default_system
+        if inputs.system is not None:
+            messages.insert(0, {'role': 'system', 'content': inputs.system})
+        if messages[-1]['content'] is None:
+            messages.pop()
+        add_generation_prompt = messages[-1]['role'] != 'assistant'
+        kwargs = {}
+        if inputs.tools:
+            kwargs['tools'] = inputs.tools
+        if 'thinking_budget' in inputs.extra_kwargs:
+            kwargs['thinking_budget'] = inputs.extra_kwargs.get('thinking_budget', 0)
+        if self.template_meta.is_thinking or self.enable_thinking:
+            kwargs[self.jinja_enable_thinking_key] = self.enable_thinking
+        if self.chat_template_kwargs:
+            kwargs.update(self.chat_template_kwargs)
+        text = self.tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=add_generation_prompt, **kwargs)
+        answer_len = 1 if self.is_training else 0
+
+        if not self.is_training or '<|im_start|>' not in text:
+            return [text], [1.], answer_len
+
+        # Training: split rendered text into alternating non-assistant /
+        # assistant chunks so the existing encode pipeline assigns
+        # loss_scale=0 to system/user/tool spans and loss_scale=1 to
+        # assistant content + the trailing `<|im_end|>\n`. Recombination is
+        # byte-exact, preserving train↔infer parity.
+        contexts: List[str] = []
+        cursor = 0
+        matches = list(self._CHATML_ROLE_PATTERN.finditer(text))
+        for i, match in enumerate(matches):
+            role = match.group(1).strip()
+            next_start = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+            if not role.startswith('assistant'):
+                continue
+            # Pre-assistant chunk includes the `<|im_start|>assistant\n` role
+            # line itself (masked: just the role marker).
+            contexts.append(text[cursor:match.end()])
+            # Assistant content + trailing `<|im_end|>\n` (supervised).
+            contexts.append(text[match.end():next_start])
+            cursor = next_start
+        if not contexts:
+            return [text], [1.], answer_len
+        # Trailing chunk after the last assistant span (masked, often empty).
+        contexts.append(text[cursor:])
+        loss_scale = [1. if i % 2 == 1 else 0. for i in range(len(contexts))]
+        return contexts, loss_scale, answer_len
 
 
 register_template(

--- a/tests/test_align/test_template/test_agent.py
+++ b/tests/test_align/test_template/test_agent.py
@@ -415,6 +415,95 @@ def test_qwen3_5():
     assert encoded['input_ids'] == encoded2['input_ids']
 
 
+def test_qwen3_6_jinja_train_infer_parity():
+    """Regression test for issue #9276.
+
+    The Qwen3.6 family is bound to ``TemplateType.qwen3_5`` (no separate
+    qwen3_6 template). With ``template_backend='jinja'`` (which calls
+    ``tokenizer.apply_chat_template`` directly), the rendered text used at
+    training time MUST be byte-identical to the inference render — and the
+    training labels must mask everything that is not part of an assistant
+    turn.
+
+    The repro uses agent data with multi-turn ``<think>`` reasoning + tool
+    calls + tool responses, where the user prompt also ends in a trailing
+    ``\\n`` (which Qwen3.6 ``chat_template.jinja`` ``|trim``s but the
+    swift backend prompt format does not). Before the fix, training under
+    ``template_backend='jinja'`` returned ``loss_scale=[1.]`` for the whole
+    rendered text, so the labels for system / user / tool tokens were not
+    masked — silently training on non-assistant tokens.
+    """
+    # Tokenizer + template are sufficient — don't load the 35B model in CI.
+    engine = TransformersEngine('Qwen/Qwen3.6-35B-A3B', load_model=False)
+    template = engine.template
+    template.template_backend = 'jinja'
+
+    # Agent-shaped multi-turn data: trailing-\n user content that exercises
+    # Qwen3.6's `|trim` filter, plus pre-rendered <think>+tool_call assistant
+    # content.
+    data = {
+        'tools': [{
+            'type': 'function',
+            'function': {
+                'name': 'search',
+                'description': 'Web search.',
+                'parameters': {
+                    'type': 'object',
+                    'properties': {'q': {'type': 'string'}},
+                    'required': ['q'],
+                },
+            },
+        }],
+        'messages': [
+            {'role': 'system', 'content': 'You are a helpful assistant.'},
+            {'role': 'user', 'content': 'Look up the capital of France.\n'},
+            {
+                'role': 'assistant',
+                'content': ('<think>\nThe user wants the capital.\n</think>\n\n'
+                            '<tool_call>\n<function=search>\n'
+                            '<parameter=q>\ncapital of France\n</parameter>\n'
+                            '</function>\n</tool_call>')
+            },
+            {'role': 'tool', 'tool_call_id': 'call_1',
+             'content': 'Paris is the capital of France.'},
+            {'role': 'assistant',
+             'content': '<think>\nGot it.\n</think>\n\nThe capital of France is Paris.'},
+        ],
+    }
+
+    # Inference render (the canonical, model-bundled chat_template).
+    infer_text = template.tokenizer.apply_chat_template(
+        data['messages'],
+        tools=data['tools'],
+        tokenize=False,
+        add_generation_prompt=False,
+    )
+    infer_input_ids = template.tokenizer.encode(infer_text, add_special_tokens=False)
+
+    # Training render via jinja backend.
+    template.set_mode('train')
+    encoded = template.encode(data)
+    train_input_ids = encoded['input_ids']
+
+    # 1) Train and inference must be byte-identical.
+    assert train_input_ids == infer_input_ids, (
+        f'jinja train/infer input_ids drift: train_len={len(train_input_ids)} '
+        f'infer_len={len(infer_input_ids)}')
+
+    # 2) Labels must mask non-assistant tokens (system / user / tool / role markers).
+    labels = encoded['labels']
+    assert len(labels) == len(train_input_ids)
+    n_supervised = sum(1 for x in labels if x != -100)
+    n_masked = sum(1 for x in labels if x == -100)
+    assert n_supervised > 0, 'No assistant tokens were supervised — fell back to wholesale loss_scale'
+    assert n_masked > 0, 'All tokens supervised — non-assistant tokens are not being masked'
+
+    # Spot-check: the user prompt content "Look up the capital of France." must be masked.
+    decoded_supervised = template.safe_decode([t for t, l in zip(train_input_ids, labels) if l != -100])
+    assert 'Look up the capital of France' not in decoded_supervised, (
+        'User prompt tokens leaked into supervised labels')
+
+
 def test_deepseek_v3_1():
     engine = TransformersEngine('deepseek-ai/DeepSeek-V3.1', load_model=False)
     template = engine.template
@@ -613,6 +702,7 @@ if __name__ == '__main__':
     # test_glm4_7()
     # test_qwen3_coder()
     test_qwen3_5()
+    # test_qwen3_6_jinja_train_infer_parity()  # issue #9276
     # test_deepseek_v3_1()
     # test_seed_oss()
     # test_youtu()


### PR DESCRIPTION
Closes #9276.

## Problem

`Qwen/Qwen3.6-*-A3B` is bound to `TemplateType.qwen3_5` (no separate `qwen3_6` template registration in `swift/model/models/qwen.py:1158-1161`), and Qwen3.6's bundled `chat_template.jinja` differs from Qwen3.5's in two places (assistant `<think>` preservation gating + tool_call args rendering). Both also apply `|trim` filters on message content that the `agent_template=qwen3_5` swift backend's `prompt=['<|im_start|>user\n{{QUERY}}<|im_end|>\n']` format string does NOT apply.

For agent data where the user prompt ends in `\n` (common when prompts are read from a file), the swift backend emits an extra `\n` between the user content and `<|im_end|>` — so train↔inference `input_ids` drift by ~1 token per user turn.

The byte-equality test added in PR #8161 (`test_qwen3_5`) only covers Qwen3.5-35B-A3B with the `function-calling-chatml` dataset (whose user content has no trailing whitespace), so it does not catch any of the above on Qwen3.6.

The cleanest path is to make `template_backend='jinja'` actually usable for SFT. Currently `_jinja_encode` returns `loss_scale=[1.]` wholesale (`base.py:1078`), so the trainer supervises *every* token rendered by `apply_chat_template` — system, user, tool, role markers, everything. That's why users default to the swift backend even though they want the HF chat_template render.

## Fix

In `_jinja_encode` (training path), split the rendered text along `<|im_start|>role\n` markers into alternating `[non_assist_0, assist_0, non_assist_1, assist_1, ..., trailing_non_assist]` chunks. The existing `_encode_context_list` then assigns `loss_scale=0` to non-assistant chunks and `loss_scale=1` to assistant chunks. Recombination is byte-exact, so train and inference still render identically.

This works for any ChatML-format chat_template (Qwen, ChatGLM, etc.). For non-ChatML templates the helper returns `None` and the caller falls back to the legacy wholesale `loss_scale=[1.]` path (no behavior change for those models).

After this PR, ` --template_backend jinja` becomes the recommended setting for Qwen3.6 SFT, fully eliminating the swift-vs-jinja byte drift documented in #9276.

## Test

Adds `test_qwen3_6_jinja_train_infer_parity` in `tests/test_align/test_template/test_agent.py` using agent-shape data: multi-turn `<think>` reasoning + tool_call + tool response, user content ending in `\n` (which exercises Qwen3.6 chat_template's `|trim` filter).

Asserts:
1. train `input_ids` byte-equal to inference `apply_chat_template(...)` tokens
2. labels mask non-assistant tokens (`n_supervised > 0`, `n_masked > 0`)
3. user-prompt content does not leak into supervised labels

Without the fix, Qwen3.6-35B-A3B fails (1) on agent data with `\n`-ended user content, and fails (2) entirely (every token supervised under `template_backend=jinja`).

## Backward compatibility

- Inference path unchanged (the new code is gated on `self.is_training`).
- Non-ChatML templates unchanged (`'<|im_start|>' not in text` → return `None` → wholesale `[1.]` path).
- Swift backend unchanged.
- Encoder-decoder path unchanged (`answer_len` is still emitted correctly).