### PR TITLE
[Bugfix] Fix NPU FSDP2 parameter device placement for full_tensor access

### DIFF
--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -617,7 +617,7 @@ class RolloutTrainerMixin(RLHFTrainerMixin):
             # Convert DTensor to regular Tensor if needed (FSDP2)
             if hasattr(param, 'full_tensor'):
                 if param.is_cpu:
-                    param = param.to(torch.device('cuda'))
+                    param = param.to(get_current_device())
                 param = param.full_tensor()
 
             processed[clean_name] = param
@@ -718,7 +718,7 @@ class RolloutTrainerMixin(RLHFTrainerMixin):
                     continue
                 if hasattr(param, 'full_tensor'):
                     if param.is_cpu:
-                        param = param.to(torch.device('cuda'))
+                        param = param.to(get_current_device())
                     param = param.full_tensor()
                 raw_state_dict[name] = param
         else:


### PR DESCRIPTION
# PR type
- [ √] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

**Problem:** In NPU FSDP2 training, `param.full_tensor` may reside on CPU, 
causing device mismatch errors when the code hardcodes `torch.device('cuda')`.

**Fix:** Use `get_current_device()` to dynamically move the tensor to the 
correct compute device (NPU/CUDA) instead of assuming CUDA.

**Scope:** This change is NPU-specific and does not affect CUDA behavior.
