### PR TITLE
ci: add pip/pre-commit cache and fix mirror override in NPU CI

### DIFF
--- a/.dev_scripts/ci_container_test.sh
+++ b/.dev_scripts/ci_container_test.sh
@@ -1,6 +1,6 @@
 if [ "$MODELSCOPE_SDK_DEBUG" == "True" ]; then
     # pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
-    pip install -r requirements/tests.txt -i https://mirrors.aliyun.com/pypi/simple/
+    pip install -r requirements/tests.txt
     git config --global --add safe.directory /ms-swift
     git config --global user.email tmp
     git config --global user.name tmp.com
@@ -20,8 +20,8 @@ if [ "$MODELSCOPE_SDK_DEBUG" == "True" ]; then
         fi
     fi
 
-    pip install -r requirements/framework.txt -U -i https://mirrors.aliyun.com/pypi/simple/
-    pip install decord einops -U -i https://mirrors.aliyun.com/pypi/simple/
+    pip install -r requirements/framework.txt -U
+    pip install decord einops -U
     pip uninstall autoawq -y
     pip install optimum
     pip install diffusers
@@ -30,7 +30,7 @@ if [ "$MODELSCOPE_SDK_DEBUG" == "True" ]; then
 
     # test with install
     pip install .
-    pip install auto_gptq bitsandbytes deepspeed -U -i https://mirrors.aliyun.com/pypi/simple/
+    pip install auto_gptq bitsandbytes deepspeed -U
 else
     echo "Running case in release image, run case directly!"
 fi

--- a/.github/workflows/citest_npu.yaml
+++ b/.github/workflows/citest_npu.yaml
@@ -51,9 +51,17 @@ jobs:
           pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ hashFiles('requirements/framework.txt', 'requirements/tests.txt') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-pip-
+
       - name: Get changed files
         id: changed-files
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,11 +10,18 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+          cache: pip
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: pre-commit-${{ runner.os }}-
       - name: Install pre-commit hook
         run: |
           pip install pre-commit


### PR DESCRIPTION
## Summary

- **lint.yaml**: upgrade `actions/setup-python` to v5 with built-in `cache: pip` enabled; add `actions/cache@v4` for pre-commit environments keyed on `.pre-commit-config.yaml` hash
- **citest_npu.yaml**: add `actions/cache@v4` for `~/.cache/pip` keyed on `requirements/framework.txt` and `requirements/tests.txt` hashes, reducing redundant pip downloads across runs
- **ci_container_test.sh**: remove explicit `-i https://mirrors.aliyun.com/pypi/simple/` flags from all `pip install` commands so they use the internal cache server already configured in the `Config mirrors` step, rather than overriding it

## Motivation

The `Config mirrors` step in `citest_npu.yaml` correctly sets the internal K8s pip cache service via `pip config set global.index-url`, but `ci_container_test.sh` was overriding this with explicit `-i` flags pointing to the public Aliyun mirror. This PR fixes the inconsistency and adds standard pip/pre-commit caching to speed up CI.

## Test plan

- [ ] Lint workflow: verify pre-commit cache is restored on subsequent runs
- [ ] NPU CI: verify pip cache is restored and `ci_container_test.sh` uses the configured index URL