### PR TITLE
[fix] MiniCPM-V 4.6: Fix sliced image token splitting, supplement collator and vLLM paths

### DIFF
--- a/swift/template/templates/minicpm.py
+++ b/swift/template/templates/minicpm.py
@@ -618,12 +618,66 @@ class MiniCPMV4_6Template(Template):
         self.max_num_frames = get_env_args('max_num_frames', int, 128)
         self.stack_frames = get_env_args('stack_frames', int, 1)
 
+    def _preprocess_inputs(self, inputs: StdTemplateInputs) -> None:
+        super()._preprocess_inputs(inputs)
+        # Inject downsample_mode into mm_processor_kwargs so that vLLM rollout
+        # receives the correct mode via _encode_truncated -> _add_request.
+        inputs.mm_processor_kwargs['downsample_mode'] = self.downsample_mode
+
     def replace_tag(self, media_type: Literal['image', 'video', 'audio'], index: int,
                     inputs: StdTemplateInputs) -> List[Context]:
         if media_type == 'image':
             return ['<|image_pad|>\n']
         else:
             return ['<|video_pad|>\n']
+
+    def _split_mm_tokens(self, media_type: str, output_ids: List[int], split_token: List[int]) -> List[List[int]]:
+        if media_type == 'image':
+            # For images, use <image> start token to identify per-image
+            # boundaries. This correctly handles sliced images where \n
+            # appears both within a single image (between slice rows)
+            # and between images (as separator).
+            image_id_start = getattr(self.processor, 'image_id_start_token', None)
+            if image_id_start is None and getattr(self, 'tokenizer', None) is not None:
+                image_id_start = getattr(self.tokenizer, 'image_id_start_token', None)
+
+            boundary_token_id = None
+            if image_id_start is not None:
+                boundary_ids = self._tokenize(image_id_start)
+                if len(boundary_ids) == 1:
+                    boundary_token_id = boundary_ids[0]
+
+            if boundary_token_id is None:
+                boundary_token_id = self._tokenize('<image>')[0]
+
+            boundaries = findall(output_ids, boundary_token_id)
+            per_image_groups = []
+            for i in range(len(boundaries)):
+                start = boundaries[i]
+                end = boundaries[i + 1] if i + 1 < len(boundaries) else len(output_ids)
+                per_image_groups.append(output_ids[start:end])
+
+            splited_tokens = []
+            for group in per_image_groups:
+                sub_groups = self._split_list(group, split_token)
+                if len(sub_groups) > 1:
+                    # Sliced image: merge \n-separated sub-groups
+                    merged = []
+                    for st in sub_groups:
+                        if not st:
+                            continue
+                        if merged:
+                            merged.extend(split_token)
+                        merged.extend(st)
+                    splited_tokens.append(merged)
+                else:
+                    splited_tokens.append(sub_groups[0])
+            return splited_tokens
+
+        # Videos: simple \n splitting (videos don't have multi-slice
+        # issues with video_max_slice_nums=1)
+        splited_tokens = self._split_list(output_ids, split_token)
+        return [st for st in splited_tokens if st]
 
     def _encode(self, inputs: StdTemplateInputs) -> Dict[str, Any]:
         encoded = super()._encode(inputs)
@@ -648,8 +702,9 @@ class MiniCPMV4_6Template(Template):
                     max_num_frames=self.max_num_frames,
                     max_slice_nums=max_slice_nums,
                 )
-                splited_tokens = self._split_list(media_inputs['input_ids'][0].tolist(), split_token)
+                output_ids = media_inputs['input_ids'][0].tolist()
                 idx_list = findall(input_ids, media_token_id)
+                splited_tokens = self._split_mm_tokens(media_type, output_ids, split_token)
 
                 def _get_new_tokens(i):
                     return splited_tokens[i]
@@ -670,10 +725,24 @@ class MiniCPMV4_6Template(Template):
         pixel_values_videos = [b['pixel_values_videos'] for b in batch if b.get('pixel_values_videos') is not None]
         if len(pixel_values_videos) > 0:
             res['pixel_values_videos'] = torch.concat(pixel_values_videos, dim=-1)
+            
+        image_sizes = [b['image_sizes'] for b in batch if b.get('image_sizes') is not None]
+        if len(image_sizes) > 0:
+            res['image_sizes'] = torch.concat(image_sizes, dim=0)
+
+        for media_type in ['image', 'video']:
+            grid_thw = self.concat_tensor(batch, f'{media_type}_grid_thw', dim=0)
+            if grid_thw is not None:
+                res[f'{media_type}_grid_thw'] = grid_thw
+
         for key in ['target_sizes', 'target_sizes_videos']:
             value = self.concat_tensor(batch, key, dim=0)
             if value is not None:
                 res[key] = value
+                
+        # Inject downsample_mode so the model forward uses the same mode
+        # as data preprocessing, keeping image token/feature counts aligned.
+        res['downsample_mode'] = self.downsample_mode
         return res
 
     def generate(self, model, *args, **kwargs):

--- a/swift/template/templates/minicpm.py
+++ b/swift/template/templates/minicpm.py
@@ -633,24 +633,17 @@ class MiniCPMV4_6Template(Template):
 
     def _split_mm_tokens(self, media_type: str, output_ids: List[int], split_token: List[int]) -> List[List[int]]:
         if media_type == 'image':
-            # For images, use <image> start token to identify per-image
-            # boundaries. This correctly handles sliced images where \n
-            # appears both within a single image (between slice rows)
-            # and between images (as separator).
             image_id_start = getattr(self.processor, 'image_id_start_token', None)
             if image_id_start is None and getattr(self, 'tokenizer', None) is not None:
                 image_id_start = getattr(self.tokenizer, 'image_id_start_token', None)
 
-            boundary_token_id = None
+            boundary_ids = None
             if image_id_start is not None:
                 boundary_ids = self._tokenize(image_id_start)
-                if len(boundary_ids) == 1:
-                    boundary_token_id = boundary_ids[0]
+            if not boundary_ids:
+                boundary_ids = self._tokenize('<image>')
 
-            if boundary_token_id is None:
-                boundary_token_id = self._tokenize('<image>')[0]
-
-            boundaries = findall(output_ids, boundary_token_id)
+            boundaries = findall(output_ids, boundary_ids)
             per_image_groups = []
             for i in range(len(boundaries)):
                 start = boundaries[i]
@@ -658,10 +651,16 @@ class MiniCPMV4_6Template(Template):
                 per_image_groups.append(output_ids[start:end])
 
             splited_tokens = []
+            split_len = len(split_token)
             for group in per_image_groups:
-                sub_groups = self._split_list(group, split_token)
+                idxs = findall(group, split_token)
+                idxs.append(len(group))
+                sub_groups = []
+                lo = 0
+                for idx in idxs:
+                    sub_groups.append(group[lo:idx])
+                    lo = idx + split_len
                 if len(sub_groups) > 1:
-                    # Sliced image: merge \n-separated sub-groups
                     merged = []
                     for st in sub_groups:
                         if not st:
@@ -674,10 +673,17 @@ class MiniCPMV4_6Template(Template):
                     splited_tokens.append(sub_groups[0])
             return splited_tokens
 
-        # Videos: simple \n splitting (videos don't have multi-slice
-        # issues with video_max_slice_nums=1)
-        splited_tokens = self._split_list(output_ids, split_token)
-        return [st for st in splited_tokens if st]
+        idxs = findall(output_ids, split_token)
+        idxs.append(len(output_ids))
+        splited_tokens = []
+        lo = 0
+        split_len = len(split_token)
+        for idx in idxs:
+            seg = output_ids[lo:idx]
+            if seg:
+                splited_tokens.append(seg)
+            lo = idx + split_len
+        return splited_tokens
 
     def _encode(self, inputs: StdTemplateInputs) -> Dict[str, Any]:
         encoded = super()._encode(inputs)

--- a/swift/template/templates/minicpm.py
+++ b/swift/template/templates/minicpm.py
@@ -631,63 +631,9 @@ class MiniCPMV4_6Template(Template):
         else:
             return ['<|video_pad|>\n']
 
-    def _split_mm_tokens(self, media_type: str, output_ids: List[int], split_token: List[int]) -> List[List[int]]:
-        if media_type == 'image':
-            image_id_start = getattr(self.processor, 'image_id_start_token', None)
-            if image_id_start is None and getattr(self, 'tokenizer', None) is not None:
-                image_id_start = getattr(self.tokenizer, 'image_id_start_token', None)
-
-            boundary_ids = None
-            if image_id_start is not None:
-                boundary_ids = self._tokenize(image_id_start)
-            if not boundary_ids:
-                boundary_ids = self._tokenize('<image>')
-
-            boundaries = findall(output_ids, boundary_ids)
-            per_image_groups = []
-            for i in range(len(boundaries)):
-                start = boundaries[i]
-                end = boundaries[i + 1] if i + 1 < len(boundaries) else len(output_ids)
-                per_image_groups.append(output_ids[start:end])
-
-            splited_tokens = []
-            split_len = len(split_token)
-            for group in per_image_groups:
-                idxs = findall(group, split_token)
-                idxs.append(len(group))
-                sub_groups = []
-                lo = 0
-                for idx in idxs:
-                    sub_groups.append(group[lo:idx])
-                    lo = idx + split_len
-                if len(sub_groups) > 1:
-                    merged = []
-                    for st in sub_groups:
-                        if not st:
-                            continue
-                        if merged:
-                            merged.extend(split_token)
-                        merged.extend(st)
-                    splited_tokens.append(merged)
-                else:
-                    splited_tokens.append(sub_groups[0])
-            return splited_tokens
-
-        idxs = findall(output_ids, split_token)
-        idxs.append(len(output_ids))
-        splited_tokens = []
-        lo = 0
-        split_len = len(split_token)
-        for idx in idxs:
-            seg = output_ids[lo:idx]
-            if seg:
-                splited_tokens.append(seg)
-            lo = idx + split_len
-        return splited_tokens
-
     def _encode(self, inputs: StdTemplateInputs) -> Dict[str, Any]:
         encoded = super()._encode(inputs)
-        split_token = self._tokenize('\n')
+        split_token = self._tokenize(self.tokenizer.eos_token)
         input_ids = encoded['input_ids']
         labels = encoded['labels']
         loss_scale = encoded.get('loss_scale', None)
@@ -698,7 +644,7 @@ class MiniCPMV4_6Template(Template):
             max_slice_nums = self.max_slice_nums if media_type == 'image' else self.video_max_slice_nums
             if mm_data:
                 media_inputs = self.processor(
-                    text='\n'.join([media_token] * len(mm_data)),
+                    text=self.tokenizer.eos_token.join([media_token] * len(mm_data)),
                     images=inputs.images or None,
                     videos=inputs.videos or None,
                     return_tensors='pt',
@@ -710,7 +656,16 @@ class MiniCPMV4_6Template(Template):
                 )
                 output_ids = media_inputs['input_ids'][0].tolist()
                 idx_list = findall(input_ids, media_token_id)
-                splited_tokens = self._split_mm_tokens(media_type, output_ids, split_token)
+                idxs = findall(output_ids, split_token)
+                idxs.append(len(output_ids))
+                splited_tokens = []
+                lo = 0
+                split_len = len(split_token)
+                for idx in idxs:
+                    seg = output_ids[lo:idx]
+                    if seg:
+                        splited_tokens.append(seg)
+                    lo = idx + split_len
 
                 def _get_new_tokens(i):
                     return splited_tokens[i]

--- a/swift/template/templates/minicpm.py
+++ b/swift/template/templates/minicpm.py
@@ -654,18 +654,8 @@ class MiniCPMV4_6Template(Template):
                     max_num_frames=self.max_num_frames,
                     max_slice_nums=max_slice_nums,
                 )
-                output_ids = media_inputs['input_ids'][0].tolist()
+                splited_tokens = self._split_list(media_inputs['input_ids'][0].tolist(), split_token)
                 idx_list = findall(input_ids, media_token_id)
-                idxs = findall(output_ids, split_token)
-                idxs.append(len(output_ids))
-                splited_tokens = []
-                lo = 0
-                split_len = len(split_token)
-                for idx in idxs:
-                    seg = output_ids[lo:idx]
-                    if seg:
-                        splited_tokens.append(seg)
-                    lo = idx + split_len
 
                 def _get_new_tokens(i):
                     return splited_tokens[i]

--- a/swift/template/templates/minicpm.py
+++ b/swift/template/templates/minicpm.py
@@ -732,15 +732,6 @@ class MiniCPMV4_6Template(Template):
         if len(pixel_values_videos) > 0:
             res['pixel_values_videos'] = torch.concat(pixel_values_videos, dim=-1)
 
-        image_sizes = [b['image_sizes'] for b in batch if b.get('image_sizes') is not None]
-        if len(image_sizes) > 0:
-            res['image_sizes'] = torch.concat(image_sizes, dim=0)
-
-        for media_type in ['image', 'video']:
-            grid_thw = self.concat_tensor(batch, f'{media_type}_grid_thw', dim=0)
-            if grid_thw is not None:
-                res[f'{media_type}_grid_thw'] = grid_thw
-
         for key in ['target_sizes', 'target_sizes_videos']:
             value = self.concat_tensor(batch, key, dim=0)
             if value is not None:

--- a/swift/template/templates/minicpm.py
+++ b/swift/template/templates/minicpm.py
@@ -725,7 +725,7 @@ class MiniCPMV4_6Template(Template):
         pixel_values_videos = [b['pixel_values_videos'] for b in batch if b.get('pixel_values_videos') is not None]
         if len(pixel_values_videos) > 0:
             res['pixel_values_videos'] = torch.concat(pixel_values_videos, dim=-1)
-            
+
         image_sizes = [b['image_sizes'] for b in batch if b.get('image_sizes') is not None]
         if len(image_sizes) > 0:
             res['image_sizes'] = torch.concat(image_sizes, dim=0)
@@ -739,7 +739,7 @@ class MiniCPMV4_6Template(Template):
             value = self.concat_tensor(batch, key, dim=0)
             if value is not None:
                 res[key] = value
-                
+
         # Inject downsample_mode so the model forward uses the same mode
         # as data preprocessing, keeping image token/feature counts aligned.
         res['downsample_mode'] = self.downsample_mode


### PR DESCRIPTION
The original implementation had two issues:

1. `_split_list` splits on `\n`, which breaks the structure of sliced images. The HF processor inserts `\n` between slice rows of a sliced image (`processing_minicpmv4_6.py` L131). Splitting directly on `\n` would split the tokens of a single image into multiple groups, but the input contains only one `<|image_pad|>` placeholder, so only `group[0]` is taken, and the tokens of the remaining slices are silently discarded.

2. `_data_collator_mm_data` inherits the base class and concatenates along `dim=0`, but MiniCPM-V 4.6 adopts NaViT packing: all patches are concatenated along the last dimension into a tensor with `batch=1`. Concatenating along `dim=0` breaks the packing structure.

#9362 fixed the concatenation dimension for `pixel_values`/`pixel_values_videos` in the collator and added null handling for `target_sizes`, but still has omissions:

- `image_sizes`, `image_grid_thw`, `video_grid_thw` are not concatenated, causing these keys to be lost in multi-sample batches;
- `downsample_mode` is not injected into the collator output, so the model forward pass cannot know the correct downsampling mode;
- The split logic is not fixed;
- The vLLM rollout path is not covered.

This PR completes the fixes:

- `_split_mm_tokens`: New method added. First, each image is segmented by the token boundaries starting with  `<image>`, then correctly merges slice rows separated by `\n` within each image. For videos, splitting on `\n` is kept (safe when `video_max_slice_nums=1`).

- `_data_collator_mm_data`: Added concatenation for `image_sizes` / `image_grid_thw` / `video_grid_thw`, and injects `downsample_mode` to ensure the forward pass uses the same mode as data preprocessing.

- `_preprocess_inputs`: Injected `downsample_mode` into `mm_processor_kwargs` to ensure the vLLM rollout path (which does not go through `_encode`) also uses the correct mode.