### PR TITLE
[bugfix] Skip fps append in vllm mode for Qwen2.5-VL video (#9357)

### DIFF
--- a/swift/template/templates/qwen.py
+++ b/swift/template/templates/qwen.py
@@ -344,7 +344,8 @@ class Qwen2VLTemplate(Template):
             video, video_kwargs = fetch_video(video_inputs, return_video_sample_fps=True, **kwargs)
             tokens = ['<|vision_start|><|video_pad|><|vision_end|>']
             if self.version == 'v2_5':
-                inputs.mm_processor_kwargs.setdefault('fps', []).append(video_kwargs)
+                if self.mode != 'vllm':
+                    inputs.mm_processor_kwargs.setdefault('fps', []).append(video_kwargs)
             elif self.version == 'v3':
                 if self.mode != 'vllm':
                     video, video_metadata = video


### PR DESCRIPTION
## Motivation

Fixes #9357.

Running `swift infer --infer_backend vllm` on `Qwen/Qwen2.5-VL-3B-Instruct`
with a video dataset crashes during prompt rendering under
`transformers v5` / latest `huggingface_hub`:

```
File "huggingface_hub/dataclasses.py", line 144, in __strict_setattr__
    validator(value)
File "huggingface_hub/dataclasses.py", line 625, in validator
    type_validator(field.name, value, field.type)
File "huggingface_hub/dataclasses.py", line 482, in type_validator
    type_validator(name, value, args[0])
TypeError: ... fps must be a scalar, got list ...
```

`tf` backend works; only `vllm` is broken.

## Root cause

`swift/template/templates/qwen.py:347` — the `Qwen2VLTemplate.replace_tag`
path for `version == 'v2_5'` appends the per-video `video_kwargs`
(a dict that includes `fps`) into `inputs.mm_processor_kwargs['fps']`
unconditionally:

```python
inputs.mm_processor_kwargs.setdefault('fps', []).append(video_kwargs)
```

In vLLM mode this list of dicts is then forwarded to the new
`huggingface_hub` strict dataclass validator inside the HF processor,
which expects `fps` to be a scalar and rejects the list.

The neighbouring branches already special-case vLLM:

```python
elif self.version == 'v3':
    if self.mode != 'vllm':
        video, video_metadata = ...
elif self.version == 'omni':
    if self.mode != 'vllm':
        ...
```

The `'v2_5'` branch was simply missing the same guard.

## Modifications

`swift/template/templates/qwen.py` — wrap the `'v2_5'` branch's
`mm_processor_kwargs['fps'].append(...)` in `if self.mode != 'vllm':`,
matching the v3 / omni pattern (+2 / -1):

```diff
 if self.version == 'v2_5':
-    inputs.mm_processor_kwargs.setdefault('fps', []).append(video_kwargs)
+    if self.mode != 'vllm':
+        inputs.mm_processor_kwargs.setdefault('fps', []).append(video_kwargs)
 elif self.version == 'v3':
```

Net diff: +2 / -1 lines in one file. The `tf` backend path is
unchanged.
