### PR TITLE
[Bugfix] Fix loss missing from logs when context parallelism is enabled

### DIFF
--- a/swift/megatron/trainers/trainer.py
+++ b/swift/megatron/trainers/trainer.py
@@ -66,7 +66,7 @@ class MegatronTrainer(BaseMegatronTrainer):
 
         # Reduce loss for logging.
         reporting_loss = loss.detach().clone()
-        torch.distributed.all_reduce(reporting_loss, group=mpu.get_data_parallel_group())
+        torch.distributed.all_reduce(reporting_loss, group=mpu.get_data_parallel_group(with_context_parallel=True))
 
         lm_loss = loss[0]
         lm_loss = lm_loss.clone()
@@ -96,12 +96,13 @@ class MegatronTrainer(BaseMegatronTrainer):
                 metrics[f'loss_{channel}'][1] += c_loss.shape[0]
 
         # Synchronize keys to avoid getting stuck.
-        all_keys = [None] * mpu.get_data_parallel_world_size()
-        dist.all_gather_object(all_keys, list(metrics.keys()), group=mpu.get_data_parallel_group())
+        dp_cp_group = mpu.get_data_parallel_group(with_context_parallel=True)
+        all_keys = [None] * torch.distributed.get_world_size(group=dp_cp_group)
+        dist.all_gather_object(all_keys, list(metrics.keys()), group=dp_cp_group)
         new_metrics = {}
         for key in sorted(set().union(*all_keys)):
             new_metrics[key] = metrics[key]
-        new_metrics = self._all_reduce_metric(new_metrics, torch.distributed.ReduceOp.SUM)
+        new_metrics = self._all_reduce_metric(new_metrics, torch.distributed.ReduceOp.SUM, group=dp_cp_group)
         return new_metrics
 
     def forward_step(self, data_iterator, model):


### PR DESCRIPTION
## PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

## Summary

- Fix `loss` key missing from training logs when context parallelism (CP) is enabled
- The root cause is that `reporting_loss` was all-reduced only over `get_data_parallel_group()` (excludes CP ranks), so CP ranks whose sequence chunk has no valid tokens (all labels=-100) would report `loss_mask.sum()=0`, causing the `loss` key to be skipped in `_aggregated_metrics`
- Also fix the same issue in `_compute_channel_loss` which used the DP-only group for key synchronization and metric reduction

## Root Cause

This issue is caused by how Swift splits sequence data across CP ranks. Swift uses a zigzag pattern to distribute sequence chunks (e.g., with CP=2: GPU0 gets chunk_0+chunk_3, GPU1 gets chunk_1+chunk_2). In SFT scenarios where prompts are long and responses are short, the loss-bearing tokens (response part) tend to concentrate at one end of the sequence. As a result, certain CP ranks may receive chunks where all labels are -100 (prompt-only), making `loss_mask.sum()=0` on those ranks. Since `reporting_loss` was only all-reduced within the DP group (not across CP ranks), the aggregated token count remains zero on these ranks, and the `loss` key gets skipped entirely during metric aggregation.

## Changes

- `trainer.py:69`: Use `get_data_parallel_group(with_context_parallel=True)` for `reporting_loss` all-reduce
- `trainer.py:98-104`: Use DP+CP group for channel loss key synchronization and metric reduction