### PR TITLE
modify NPU Qwen3.5 Megatron practice 

### DIFF
--- a/docs/source/BestPractices/NPU-support.md
+++ b/docs/source/BestPractices/NPU-support.md
@@ -263,11 +263,12 @@ Qwen3.5 modeling.chunk_gated_delta_rule
 
 当前 Qwen3.5 在 NPU 上如果走 Megatron-SWIFT 训练，还需要额外注意版本和功能约束：
 
-1. 当前 NPU 文档中约定的 MindSpeed 训练组合是 `Megatron-LM v0.15.3 + MindSpeed core_r0.15.3`。这个版本的 `megatron-core` 还没有包含 `0.16` 才引入的 `core.ssm.gated_delta_net` 原生 GDN 内核。
-2. `ms-swift>=4.1.0` 默认使用 Megatron 原生 GDN（`USE_MCORE_GDN=1`），而这条路径要求 `megatron-core>=0.16`。因此在当前 NPU 环境下，需要显式设置 `USE_MCORE_GDN=0`，将 GDN 切回由 `mcore-bridge` 包装的 transformers 原生实现，再配合 ms-swift 内置的 Qwen3.5 FLA NPU 补丁，把 `chunk_gated_delta_rule` 重定向到 MindSpeed Triton 算子。
-3. 这条回退路径的已知代价是：transformers 版 GDN 不支持 packing，也不支持 GDN 的 TP/CP。
-4. 此外，transformers 版 GDN 在 NPU + flash-attn 组合下还有一个已知 mask 链路问题：`padding_free=False` 时，GDN 会读到 trainer 处理后的 `attention_mask`，而不是实际需要的 `attention_mask_2d`，从而触发 `aclnnFlashAttentionScore` 异步报错。该问题已在 `mcore-bridge` 的 `qwen3_5_npu` 分支修复，NPU 用户需要使用包含该修复的版本。
-5. 后续如果 MindSpeed 提供 `core_r0.16.x` 适配分支，上述 `USE_MCORE_GDN=0` 和 transformers GDN 功能受限这两个约束就可以一并解除。
+1. 当前 NPU 文档中约定的 MindSpeed 训练组合是 `Megatron-LM v0.15.3 + MindSpeed core_r0.15.3`，这个版本的 `megatron-core` 还没有包含 `0.16` 才引入的 `core.ssm.gated_delta_net` 原生 GDN 内核。因此需要显式从默认值改为 `USE_MCORE_GDN=0`，将 GDN 切回由 `mcore-bridge` 包装的 transformers 原生实现，再配合 ms-swift 内置的 Qwen3.5 FLA NPU 补丁，把 `chunk_gated_delta_rule` 重定向到 MindSpeed Triton 算子。这条回退路径的已知代价是：
+
+   - transformers 版 GDN 不支持 packing，也不支持 GDN 的 TP/CP。
+   - transformers 版 GDN 在 NPU + flash-attn 组合下还有一个已知 mask 链路问题：`padding_free=False` 时，GDN 会读到 trainer 处理后的 `attention_mask`，而不是实际需要的 `attention_mask_2d`，从而触发 `aclnnFlashAttentionScore` 异步报错。该问题已在 `mcore-bridge` 的 `qwen3_5_npu` 分支修复，NPU 用户需要使用包含该修复的版本。
+
+2. 后续如果 MindSpeed 提供 `core_r0.16.x` 适配分支，上述 `USE_MCORE_GDN=0` 和 transformers GDN 功能受限这两个约束就可以一并解除。
 
 ### 环境查看
 

--- a/docs/source/BestPractices/NPU-support.md
+++ b/docs/source/BestPractices/NPU-support.md
@@ -220,6 +220,9 @@ cd ..
 # 4. 设置环境变量
 export PYTHONPATH=$PYTHONPATH:<your_local_megatron_lm_path>
 export MEGATRON_LM_PATH=<your_local_megatron_lm_path>
+
+# 5. 如需回退到 transformers 的 GatedDeltaNet 实现，可关闭 Megatron GDN
+export USE_MCORE_GDN=0
 ```
 
 执行如下命令验证 MindSpeed(Megatron-LM) 是否配置成功：

--- a/docs/source/BestPractices/NPU-support.md
+++ b/docs/source/BestPractices/NPU-support.md
@@ -261,6 +261,14 @@ Qwen3.5 modeling.chunk_gated_delta_rule
 - 若需要这条路径生效，请确保当前环境中可以正确导入 MindSpeed。
 - 精度对齐验证版本：torch 2.7.1 + MindSpeed 0.12.1 + flash-linear-attention 4.1.0 + triton-ascend 3.2.0 + transformers 5.2.0
 
+当前 Qwen3.5 在 NPU 上如果走 Megatron-SWIFT 训练，还需要额外注意版本和功能约束：
+
+1. 当前 NPU 文档中约定的 MindSpeed 训练组合是 `Megatron-LM v0.15.3 + MindSpeed core_r0.15.3`。这个版本的 `megatron-core` 还没有包含 `0.16` 才引入的 `core.ssm.gated_delta_net` 原生 GDN 内核。
+2. `ms-swift>=4.1.0` 默认使用 Megatron 原生 GDN（`USE_MCORE_GDN=1`），而这条路径要求 `megatron-core>=0.16`。因此在当前 NPU 环境下，需要显式设置 `USE_MCORE_GDN=0`，将 GDN 切回由 `mcore-bridge` 包装的 transformers 原生实现，再配合 ms-swift 内置的 Qwen3.5 FLA NPU 补丁，把 `chunk_gated_delta_rule` 重定向到 MindSpeed Triton 算子。
+3. 这条回退路径的已知代价是：transformers 版 GDN 不支持 packing，也不支持 GDN 的 TP/CP。
+4. 此外，transformers 版 GDN 在 NPU + flash-attn 组合下还有一个已知 mask 链路问题：`padding_free=False` 时，GDN 会读到 trainer 处理后的 `attention_mask`，而不是实际需要的 `attention_mask_2d`，从而触发 `aclnnFlashAttentionScore` 异步报错。该问题已在 `mcore-bridge` 的 `qwen3_5_npu` 分支修复，NPU 用户需要使用包含该修复的版本。
+5. 后续如果 MindSpeed 提供 `core_r0.16.x` 适配分支，上述 `USE_MCORE_GDN=0` 和 transformers GDN 功能受限这两个约束就可以一并解除。
+
 ### 环境查看
 
 查看NPU的P2P连接，这里看到每个NPU都通过7条HCCS与其他NPU互联

--- a/docs/source_en/BestPractices/NPU-support.md
+++ b/docs/source_en/BestPractices/NPU-support.md
@@ -222,6 +222,9 @@ cd ..
 # 4. Set environment variables
 export PYTHONPATH=$PYTHONPATH:<your_local_megatron_lm_path>
 export MEGATRON_LM_PATH=<your_local_megatron_lm_path>
+
+# 5. Disable Megatron GDN if you need to fall back to the transformers GatedDeltaNet implementation
+export USE_MCORE_GDN=0
 ```
 
 Run the following command to verify that MindSpeed(Megatron-LM) is configured correctly:
@@ -260,6 +263,14 @@ Therefore:
 - It is not equivalent to “fully replacing the entire fla package with MindSpeed”.
 - To make this path effective, ensure that MindSpeed can be imported correctly in the current environment.
 - Verified versions for accuracy alignment: torch 2.7.1 + MindSpeed 0.12.1 + flash-linear-attention 4.1.0 + triton-ascend 3.2.0 + transformers 5.2.0
+
+When running Qwen3.5 with Megatron-SWIFT on NPU, note the following version and feature constraints:
+
+1. The NPU documentation currently pins the MindSpeed training stack to `Megatron-LM v0.15.3 + MindSpeed core_r0.15.3`. This version of `megatron-core` does not yet include the native `core.ssm.gated_delta_net` GDN kernel introduced in `0.16`.
+2. `ms-swift>=4.1.0` uses Megatron native GDN by default (`USE_MCORE_GDN=1`), but that path requires `megatron-core>=0.16`. Therefore, on the current NPU stack you must explicitly set `USE_MCORE_GDN=0` to switch GDN back to the transformers-native implementation wrapped by `mcore-bridge`, and then rely on the built-in ms-swift Qwen3.5 FLA NPU patch to redirect `chunk_gated_delta_rule` to MindSpeed Triton kernels.
+3. The known cost of this fallback path is that the transformers GDN implementation does not support packing or GDN TP/CP.
+4. In addition, the transformers GDN path has a known mask-path issue under the NPU + flash-attn combination: when `padding_free=False`, GDN reads the trainer-processed `attention_mask` instead of the required `attention_mask_2d`, which can trigger an asynchronous `aclnnFlashAttentionScore` error. This issue has been fixed on the `qwen3_5_npu` branch of `mcore-bridge`, so NPU users should use a version that includes that fix.
+5. Once MindSpeed provides a `core_r0.16.x` compatible branch, both constraints can be lifted together: the explicit `USE_MCORE_GDN=0` override and the current transformers GDN feature limitations.
 
 ### Environment Viewing
 Check the P2P connections of the NPU, where we can see that each NPU is interconnected through 7 HCCS links with other NPUs.

--- a/docs/source_en/BestPractices/NPU-support.md
+++ b/docs/source_en/BestPractices/NPU-support.md
@@ -266,11 +266,30 @@ Therefore:
 
 When running Qwen3.5 with Megatron-SWIFT on NPU, note the following version and feature constraints:
 
-1. The NPU documentation currently pins the MindSpeed training stack to `Megatron-LM v0.15.3 + MindSpeed core_r0.15.3`. This version of `megatron-core` does not yet include the native `core.ssm.gated_delta_net` GDN kernel introduced in `0.16`.
-2. `ms-swift>=4.1.0` uses Megatron native GDN by default (`USE_MCORE_GDN=1`), but that path requires `megatron-core>=0.16`. Therefore, on the current NPU stack you must explicitly set `USE_MCORE_GDN=0` to switch GDN back to the transformers-native implementation wrapped by `mcore-bridge`, and then rely on the built-in ms-swift Qwen3.5 FLA NPU patch to redirect `chunk_gated_delta_rule` to MindSpeed Triton kernels.
-3. The known cost of this fallback path is that the transformers GDN implementation does not support packing or GDN TP/CP.
-4. In addition, the transformers GDN path has a known mask-path issue under the NPU + flash-attn combination: when `padding_free=False`, GDN reads the trainer-processed `attention_mask` instead of the required `attention_mask_2d`, which can trigger an asynchronous `aclnnFlashAttentionScore` error. This issue has been fixed on the `qwen3_5_npu` branch of `mcore-bridge`, so NPU users should use a version that includes that fix.
-5. Once MindSpeed provides a `core_r0.16.x` compatible branch, both constraints can be lifted together: the explicit `USE_MCORE_GDN=0` override and the current transformers GDN feature limitations.
+1. The MindSpeed training combination currently pinned by the NPU documentation
+   is `Megatron-LM v0.15.3 + MindSpeed core_r0.15.3`. This version of
+   `megatron-core` does not yet ship the native GDN kernel
+   `core.ssm.gated_delta_net` introduced in `0.16`. As a result, you must
+   override the default and explicitly set `USE_MCORE_GDN=0`, which switches
+   GDN back to the transformers-native implementation wrapped by
+   `mcore-bridge`. Combined with ms-swift's built-in Qwen3.5 FLA NPU patch,
+   `chunk_gated_delta_rule` is then redirected to MindSpeed's Triton kernels.
+   The known costs of this fallback path are:
+
+   - The transformers GDN implementation does not support packing, nor TP/CP
+     for the GDN layer.
+   - Under the NPU + flash-attn combination, the transformers GDN
+     implementation also has a known mask-routing issue: when
+     `padding_free=False`, GDN ends up reading the `attention_mask` that has
+     already been transformed by the trainer instead of the `attention_mask_2d`
+     it actually needs, which triggers an asynchronous
+     `aclnnFlashAttentionScore` failure. This has been fixed on the
+     `qwen3_5_npu` branch of `mcore-bridge`; NPU users must therefore install
+     a version that includes the fix.
+
+2. Once MindSpeed ships a `core_r0.16.x` adaptation branch, both constraints
+   — the required `USE_MCORE_GDN=0` override and the feature limitations of
+   the transformers GDN implementation — can be lifted together.
 
 ### Environment Viewing
 Check the P2P connections of the NPU, where we can see that each NPU is interconnected through 7 HCCS links with other NPUs.


### PR DESCRIPTION
# PR type
- Document Updates

# PR information
Add USE_MCORE_GDN=0 for Qwen 3.5 practice. The core reason is that MindSpeed has not yet completed the adaptation for GDN.
