### PR TITLE
fix: 更新 MindSpeed import 路径 (lite.ops.triton → ops.triton，适配 core_r0.16.0)

### DIFF
--- a/swift/model/chunk_gated_delta_rule.py
+++ b/swift/model/chunk_gated_delta_rule.py
@@ -4,13 +4,13 @@
 
 import torch
 import warnings
-from mindspeed.lite.ops.triton.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
-from mindspeed.lite.ops.triton.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local, chunk_fwd_o
-from mindspeed.lite.ops.triton.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
-from mindspeed.lite.ops.triton.cumsum import chunk_local_cumsum
-from mindspeed.lite.ops.triton.solve_tril import solve_tril
-from mindspeed.lite.ops.triton.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
-from mindspeed.lite.ops.triton.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
+from mindspeed.ops.triton.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
+from mindspeed.ops.triton.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local, chunk_fwd_o
+from mindspeed.ops.triton.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+from mindspeed.ops.triton.cumsum import chunk_local_cumsum
+from mindspeed.ops.triton.solve_tril import solve_tril
+from mindspeed.ops.triton.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from mindspeed.ops.triton.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
 from typing import Optional
 
 


### PR DESCRIPTION
## 背景

MindSpeed core_r0.16.0 通过 MR !3432 将 Triton 算子路径从 `mindspeed.lite.ops.triton.*` 统一到 `mindspeed.ops.triton.*`（路径规范化），旧路径 `mindspeed.lite.ops.triton` 已不存在。

当前 ms-swift 的 `swift/model/chunk_gated_delta_rule.py` 仍使用旧路径，在搭配 MindSpeed core_r0.16.0 训练 Qwen3.5/3.6 GDN 模型时直接 ImportError。

用户目前需要手动创建桥接文件（`mkdir -p mindspeed/lite/ops/triton` + 重导出文件）才能运行，体验不佳。

## 修复

将 `chunk_gated_delta_rule.py` 中 7 处 import 路径从 `mindspeed.lite.ops.triton` 更新为 `mindspeed.ops.triton`。

## 实测验证

在昇腾 910B3 + MindSpeed core_r0.16.0 + mcore-bridge release/1.4 上验证：
- 模型：qwen3.6-27B 全量 SFT（TP=4, PP=2）
- 修改后无需手动创建桥接文件，直接 import 成功，训练正常运行

## 兼容性

- MindSpeed core_r0.16.0+：直接兼容（新路径）
- MindSpeed 旧版本（< core_r0.16.0）：需要用旧版 ms-swift 或手动创建反向桥接