### PR TITLE
[docs] remove obsolete packing_cache reference from FAQ

### DIFF
--- a/docs/source/Instruction/Frequently-asked-questions.md
+++ b/docs/source/Instruction/Frequently-asked-questions.md
@@ -73,7 +73,7 @@ SWIFT多卡训练底层依赖torchrun。`deepspeed` 和 `device_map`不兼容，
 断点续训时，流式只能往前索引，不能随机索引，跳过已经训练的数据耗时特别长，不建议用流式。
 
 ### Q15: packing相关问题
-packing要和flash_attn一起使用，不然是有误差，attention_mask会出问题。packing_cache这个参数，在多机训练时，需要设置为共享的磁盘路径。
+packing要和flash_attn一起使用，不然是有误差，attention_mask会出问题。
 Qwen3.5模型中的linear-attention不支持var_len，不建议开启packing。
 开启packing，多模态数据会有两次map，map完一次后还会进行第二次mapping，一次是数据集的，一次是template的。如果速度非常慢，可以设置`OMP_NUM_THREADS=14`加速，或者可以把packing去掉，就不会有第二次了。
 

--- a/docs/source_en/Instruction/Frequently-asked-questions.md
+++ b/docs/source_en/Instruction/Frequently-asked-questions.md
@@ -73,7 +73,7 @@ Note: Streaming does not shuffle the data and does not automatically create a va
 When resuming training with streaming, the data can only be indexed forward, not randomly. Skipping already trained data is very time-consuming, so using streaming for resuming is not recommended.
 
 ### Q15: Issues related to packing
-Packing should be used with FlashAttention; otherwise, there will be discrepancies, and the attention_mask will have issues. The packing_cache parameter needs to be set to a shared disk path for multi-node training.
+Packing should be used with FlashAttention; otherwise, there will be discrepancies, and the attention_mask will have issues.
 The linear-attention in the Qwen3.5 model does not support var_len, so enabling packing is not recommended.
 When packing is enabled, multimodal data will undergo two map operations: one for the dataset and one for the template. If this is very slow, you can set `OMP_NUM_THREADS=14` to accelerate it, or disable packing to avoid the second mapping.
 


### PR DESCRIPTION
## Summary

The `packing_cache` parameter mentioned in Q15 of the FAQ no longer exists in the codebase. This PR removes the stale sentence from both the Chinese and English FAQ.

## Why this is outdated

The `packing_cache` description dates back to the pre-v4 multi-node packing implementation, which wrote packed-index shards to a shared disk path. The [v4 refactor (#7238)](https://github.com/modelscope/ms-swift/pull/7238) replaced that with an in-memory implementation: rank 0 computes `packed_idx` / `packed_length` and synchronizes them to other ranks via `dist.broadcast_object_list` (see `swift/dataset/packing.py:54-87`). Multi-node packing no longer needs a shared disk path for any packing cache.

The `PACKING_CACHE` environment variable is still read in `swift/dataset/indexed_dataset.py:101`, but that module is no longer imported anywhere — `swift/dataset/__init__.py` does not export it, and a repo-wide grep shows no other reference. It is effectively dead code, so the FAQ guidance is misleading.

## Change

Removes one sentence each from:
- `docs/source/Instruction/Frequently-asked-questions.md` (Chinese)
- `docs/source_en/Instruction/Frequently-asked-questions.md` (English)

No code changes. The remaining FAQ guidance (flash_attn requirement, Qwen3.5 linear-attention caveat, multimodal mapping notes) is unchanged.

## Test plan

- [x] Verified `--packing_cache` is not a registered CLI argument anywhere in `swift/arguments/`
- [x] Verified `IndexedDataset` / `IndexedDatasetBuilder` are not imported by any module outside `swift/dataset/indexed_dataset.py` itself
- [x] Verified current `PackingDataset` uses `dist.broadcast_object_list` rather than filesystem sync
- [ ] Docs-only change, no functional tests required