### PR TITLE
[bugfix] Fix LLaVA OneVision 1.5 vit_gradient_checkpointing issue

### DIFF
--- a/swift/model/models/llava.py
+++ b/swift/model/models/llava.py
@@ -9,6 +9,7 @@ from swift.utils import git_clone_github, safe_snapshot_download
 from ..constant import MLLMModelType
 from ..model_arch import ModelArch
 from ..model_meta import Model, ModelGroup, ModelMeta
+from ..patcher import patch_get_input_embeddings
 from ..register import ModelLoader, register_model
 
 
@@ -429,7 +430,9 @@ class LlavaOnevisionLoader(ModelLoader):
         model_cls = get_class_from_dynamic_module(
             'modeling_llavaonevision1_5.LLaVAOneVision1_5_ForConditionalGeneration', model_dir)
         model_cls._no_split_modules = ['LLaVAOneVision1_5_DecoderLayer', 'RiceBlock']
-        return super().get_model(model_dir, *args, **kwargs)
+        model = super().get_model(model_dir, *args, **kwargs)
+        patch_get_input_embeddings(model.visual, 'patch_embed')
+        return model
 
 
 register_model(


### PR DESCRIPTION
Fix the bug of below:
```
[INFO:swift] Successfully registered post_encode hook: ['LLaVAOneVision1_5_ForConditionalGeneration'].
[WARNING:swift] prepare gradient_checkpointing failed: `get_input_embeddings` not auto‑handled for RiceTransformerPretrainedModel; please override in the subclass.
```