### PR TITLE
support logging MFU

### DIFF
--- a/swift/trainers/patcher.py
+++ b/swift/trainers/patcher.py
@@ -69,9 +69,12 @@ class ProgressCallbackNewWithMFU(ProgressCallback):
     def on_log(self, args: TrainingArguments, state: TrainerState, control, logs=None, **kwargs):
         add_train_message(logs, state, self.start_time, self.start_step)
         total_flos = getattr(state, 'total_flos', 0)
-        actual_flops = total_flos / self.elapsed
-        theoretical_max_flops = self.device_tflops * 1e12
-        mfu = actual_flops / theoretical_max_flops
+        if self.elapsed > 0 and self.device_tflops:
+            actual_flops = total_flos / self.elapsed
+            theoretical_max_flops = self.device_tflops * 1e12
+            mfu = actual_flops / theoretical_max_flops
+        else:
+            mfu = 0.0
         logger.debug(f'Total_flos[{total_flos}] elapsed_time[{self.elapsed}]sec Average MFU[{mfu}]')
         logs['MFU'] = round(mfu, 6)
         if not is_pai_training_job() and state.is_world_process_zero:

--- a/swift/trainers/patcher.py
+++ b/swift/trainers/patcher.py
@@ -7,10 +7,8 @@ from transformers import trainer
 from transformers.trainer_callback import (DefaultFlowCallback, PrinterCallback, ProgressCallback, TrainerControl,
                                            TrainerState)
 from transformers.trainer_utils import IntervalStrategy, has_length
-
-from swift.utils import append_to_jsonl, format_time, get_logger, get_max_reserved_memory, is_pai_training_job
+from swift.utils import get_env_args, get_device_count, append_to_jsonl, format_time, get_logger, get_max_reserved_memory, is_pai_training_job
 from .arguments import TrainingArguments
-
 logger = get_logger()
 
 
@@ -29,6 +27,59 @@ def add_train_message(logs, state, start_time, start_step) -> None:
         logs['memory(GiB)'] = round(state.max_memory, 2)
     logs['train_speed(s/it)'] = round(train_speed, 6)
 
+
+class ProgressCallbackNewWithMFU(ProgressCallback):
+    def __init__(self):
+        super().__init__()
+        self.device_tflops = None
+        self.elapsed = 0.0
+        self.step_start_time = None
+        
+    def on_init_end(self, args: 'TrainingArguments', state: TrainerState, control: TrainerControl, **kwargs):
+
+        # Top priority. Specify by ENV
+        tflops = get_env_args('DEVICE_TFLOPS', float, None)
+        device_count = max(get_device_count(), 1)
+        self.device_tflops = tflops * device_count
+        super().on_init_end(args, state, control, **kwargs)
+    def on_step_begin(self, args: 'TrainingArguments', state: TrainerState, control: TrainerControl, **kwargs):
+        self.step_start_time = time.time()
+        super().on_step_begin(args, state, control, **kwargs)
+        
+    def on_step_end(self, args: 'TrainingArguments', state: TrainerState, control: TrainerControl, **kwargs):
+        self.elapsed += time.time() - self.step_start_time
+        super().on_step_end(args, state, control, **kwargs)
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        if state.is_world_process_zero:
+            self.training_bar = tqdm(desc='Train', total=state.max_steps, dynamic_ncols=True)
+        self.start_step = state.global_step
+        self.current_step = 0
+        self.start_time = time.time()
+
+    def on_prediction_step(self, args, state: TrainerState, control, eval_dataloader=None, **kwargs):
+        if state.is_world_process_zero and has_length(eval_dataloader):
+            if self.prediction_bar is None:
+                if self.training_bar is not None:
+                    self.training_bar.fp.write('\n')
+                self.prediction_bar = tqdm(
+                    desc='Val', total=len(eval_dataloader), leave=True, dynamic_ncols=True, position=0)
+            self.prediction_bar.update()
+
+    def on_log(self, args: TrainingArguments, state: TrainerState, control, logs=None, **kwargs):
+        add_train_message(logs, state, self.start_time, self.start_step)
+        total_flos = getattr(state, 'total_flos', 0)
+        actual_flops = total_flos / self.elapsed
+        theoretical_max_flops = self.device_tflops * 1e12
+        mfu = actual_flops / theoretical_max_flops
+        logger.debug(f'Total_flos[{total_flos}] elapsed_time[{self.elapsed}]sec Average MFU[{mfu}]')
+        logs['MFU'] = round(mfu, 6)
+        if not is_pai_training_job() and state.is_world_process_zero:
+            jsonl_path = os.path.join(args.output_dir, 'logging.jsonl')
+            append_to_jsonl(jsonl_path, logs)
+        super().on_log(args, state, control, logs, **kwargs)
+        if state.is_world_process_zero and self.training_bar is not None:
+            self.training_bar.refresh()
 
 class ProgressCallbackNew(ProgressCallback):
 
@@ -100,9 +151,11 @@ class PrinterCallbackNew(PrinterCallback):
         _ = logs.pop('total_flos', None)
         if state.is_world_process_zero:
             print(logs, flush=True)
-
-
 # monkey patching
-trainer.DEFAULT_PROGRESS_CALLBACK = ProgressCallbackNew
+tflops = get_env_args('DEVICE_TFLOPS', float, None)
+if tflops is not None:
+    trainer.DEFAULT_PROGRESS_CALLBACK = ProgressCallbackNewWithMFU
+else:
+    trainer.DEFAULT_PROGRESS_CALLBACK = ProgressCallbackNew
 trainer.DEFAULT_CALLBACKS = [DefaultFlowCallbackNew]
 trainer.PrinterCallback = PrinterCallbackNew

--- a/swift/trainers/patcher.py
+++ b/swift/trainers/patcher.py
@@ -38,7 +38,7 @@ class ProgressCallbackNewWithMFU(ProgressCallback):
     def on_init_end(self, args: 'TrainingArguments', state: TrainerState, control: TrainerControl, **kwargs):
 
         # Top priority. Specify by ENV
-        tflops = get_env_args('DEVICE_TFLOPS', float, None)
+        tflops = get_env_args('DEVICE_TFLOPS', float, 0.0) or 0.0
         device_count = max(get_device_count(), 1)
         self.device_tflops = tflops * device_count
         super().on_init_end(args, state, control, **kwargs)

--- a/swift/trainers/patcher.py
+++ b/swift/trainers/patcher.py
@@ -47,7 +47,8 @@ class ProgressCallbackNewWithMFU(ProgressCallback):
         super().on_step_begin(args, state, control, **kwargs)
         
     def on_step_end(self, args: 'TrainingArguments', state: TrainerState, control: TrainerControl, **kwargs):
-        self.elapsed += time.time() - self.step_start_time
+        if self.step_start_time is not None:
+            self.elapsed += time.time() - self.step_start_time
         super().on_step_end(args, state, control, **kwargs)
 
     def on_train_begin(self, args, state, control, **kwargs):

--- a/swift/trainers/patcher.py
+++ b/swift/trainers/patcher.py
@@ -7,8 +7,11 @@ from transformers import trainer
 from transformers.trainer_callback import (DefaultFlowCallback, PrinterCallback, ProgressCallback, TrainerControl,
                                            TrainerState)
 from transformers.trainer_utils import IntervalStrategy, has_length
-from swift.utils import get_env_args, get_device_count, append_to_jsonl, format_time, get_logger, get_max_reserved_memory, is_pai_training_job
+
+from swift.utils import (append_to_jsonl, format_time, get_device_count, get_env_args, get_logger,
+                         get_max_reserved_memory, is_pai_training_job)
 from .arguments import TrainingArguments
+
 logger = get_logger()
 
 
@@ -29,12 +32,13 @@ def add_train_message(logs, state, start_time, start_step) -> None:
 
 
 class ProgressCallbackNewWithMFU(ProgressCallback):
+
     def __init__(self):
         super().__init__()
         self.device_tflops = None
         self.elapsed = 0.0
         self.step_start_time = None
-        
+
     def on_init_end(self, args: 'TrainingArguments', state: TrainerState, control: TrainerControl, **kwargs):
 
         # Top priority. Specify by ENV
@@ -42,10 +46,11 @@ class ProgressCallbackNewWithMFU(ProgressCallback):
         device_count = max(get_device_count(), 1)
         self.device_tflops = tflops * device_count
         super().on_init_end(args, state, control, **kwargs)
+
     def on_step_begin(self, args: 'TrainingArguments', state: TrainerState, control: TrainerControl, **kwargs):
         self.step_start_time = time.time()
         super().on_step_begin(args, state, control, **kwargs)
-        
+
     def on_step_end(self, args: 'TrainingArguments', state: TrainerState, control: TrainerControl, **kwargs):
         if self.step_start_time is not None:
             self.elapsed += time.time() - self.step_start_time
@@ -84,6 +89,7 @@ class ProgressCallbackNewWithMFU(ProgressCallback):
         super().on_log(args, state, control, logs, **kwargs)
         if state.is_world_process_zero and self.training_bar is not None:
             self.training_bar.refresh()
+
 
 class ProgressCallbackNew(ProgressCallback):
 
@@ -155,6 +161,8 @@ class PrinterCallbackNew(PrinterCallback):
         _ = logs.pop('total_flos', None)
         if state.is_world_process_zero:
             print(logs, flush=True)
+
+
 # monkey patching
 tflops = get_env_args('DEVICE_TFLOPS', float, None)
 if tflops is not None:


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR aims to **restore the MFU (Model FLOPs Utilization) monitoring feature** for the Swift framework.

- **Background**: The MFU feature was previously supported (ref: #6434) but became incompatible and non-functional due to subsequent framework updates. The original implementation code was also found to be unused.
- **Changes**:  Restored the MFU calculation and logging functionality.
 
- **Usage**: Users can set the environment variable `export DEVICE_TFLOPS=320` (or their specific hardware peak) to enable MFU calculation.

## Experiment results

After setting `export DEVICE_TFLOPS=320`, the MFU is successfully calculated and displayed in the training log:

```log
'loss': 1.17579222, 'learning_rate': 2.5e-05, 'epoch': 0.02, 
'global_step/max_steps': '1/63', 'elapsed_time': '5s', 
'memory(GiB)': 16.12, 'train_speed(s/it)': 5.372522, 
'MFU': 0.159499'
```
comparison: Without this PR, the MFU field was missing from the performance log
```log
'loss': 1.17579222, 'learning_rate': 2.5e-05, 'epoch': 0.02, 
'global_step/max_steps': '1/63', 'elapsed_time': '5s', 
'memory(GiB)': 16.12, 'train_speed(s/it)': 5.372522,'
```
by the way,the old implementation had no actual references.I would like to know if I can remove the obsolete code in `ms-swift/swift/callbacks/mapping.py` and `ms-swift/swift/callbacks/perf_log.py` to maintain codebase cleanliness.