### PR TITLE
fix: add noqa annotation for dataset utils import

### DIFF
--- a/swift/dataset/utils.py
+++ b/swift/dataset/utils.py
@@ -9,7 +9,7 @@ from torch.utils.data import Dataset
 from typing import Any, Callable, Dict, Optional, Union
 
 from swift.template import MaxLengthError, Template
-from swift.utils import get_logger
+from swift.utils import get_logger  # noqa
 from .preprocessor import RowPreprocessor
 
 logger = get_logger()


### PR DESCRIPTION
## Summary
Add `# noqa` annotation to suppress unnecessary lint warning in `swift/dataset/utils.py`.

## Changes
- Added `# noqa` comment to `get_logger` import line

## Test Plan
- [ ] Verify existing tests still pass