### PR TITLE
[bugfix] Gemma4 suffix: drop trailing newline

### DIFF
--- a/swift/template/templates/gemma.py
+++ b/swift/template/templates/gemma.py
@@ -341,7 +341,7 @@ class Gemma4TemplateMeta(TemplateMeta):
     prefix: Prompt = field(default_factory=lambda: ['<bos>'])
     prompt: Prompt = field(default_factory=lambda: ['<|turn>user\n{{QUERY}}<turn|>\n<|turn>model\n'])
     chat_sep: Optional[Prompt] = field(default_factory=lambda: ['<turn|>\n'])
-    suffix: Prompt = field(default_factory=lambda: ['<turn|>\n'])
+    suffix: Prompt = field(default_factory=lambda: ['<turn|>'])
     system_prefix: Optional[Prompt] = field(default_factory=lambda: ['<bos><|turn>system\n{{SYSTEM}}<turn|>\n'])
 
 


### PR DESCRIPTION
## Summary
- `Gemma4TemplateMeta.suffix` was `['<turn|>\n']`, causing the base template's `_add_dynamic_eos` to reopen supervision on both `<turn|>` (106) and `\n` (107) at the end of each response.
- The trailing `\n` belongs to the next user turn's prompt; the official Gemma IT model is never trained to predict it (inferred by testing on IT checkpoint), so supervising it is spurious.
- Change `suffix` to `['<turn|>']`. `chat_sep` stays `['<turn|>\n']` so the multi-turn wire format is unchanged — only the supervised position set shrinks by one token per response.

## Test plan
- [ ] Encode a Gemma4 sample and confirm `labels` ends with `[..., <answer_token>, 106]` (only `<turn|>` supervised) instead of `[..., <answer_token>, 106, 107]`.
- [ ] Multi-turn conversation still tokenizes with `<turn|>\n` between turns (verify `input_ids` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)