### PR TITLE
[bugfix]Fix Megatron model device placement when `use_cpu_initialization` is enabled

### DIFF
--- a/swift/megatron/utils/megatron_lm_utils.py
+++ b/swift/megatron/utils/megatron_lm_utils.py
@@ -493,8 +493,7 @@ def wrap_model(args, models, wrap_with_ddp: bool = True):
     for m in models:
         for param in m.parameters():
             tensor_parallel.set_defaults_if_not_set_tensor_model_parallel_attributes(param)
-        if args.use_cpu_initialization:
-            m.cuda(torch.cuda.current_device())
+        m.cuda(torch.cuda.current_device())
     # Fp16
     config = models[0].config
     if args.fp16 or args.bf16:

--- a/swift/megatron/utils/megatron_lm_utils.py
+++ b/swift/megatron/utils/megatron_lm_utils.py
@@ -493,7 +493,7 @@ def wrap_model(args, models, wrap_with_ddp: bool = True):
     for m in models:
         for param in m.parameters():
             tensor_parallel.set_defaults_if_not_set_tensor_model_parallel_attributes(param)
-        if not args.use_cpu_initialization:
+        if args.use_cpu_initialization:
             m.cuda(torch.cuda.current_device())
     # Fp16
     config = models[0].config


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix Megatron model device placement when `use_cpu_initialization` is enabled.

Previously, `wrap_model` only moved model modules to CUDA when `args.use_cpu_initialization` was disabled. With CPU initialization enabled, some modules could remain on CPU before fp16/DDP wrapping, which may cause device mismatch errors during training, especially in LoRA tuning where frozen base modules such as embeddings are still used in forward.

This change moves the model to the current CUDA device when `args.use_cpu_initialization` is enabled, avoiding CPU/GPU tensor mismatch during Megatron training.

## Experiment results

Before this change, LoRA training with `use_cpu_initialization=True` could fail with errors like:

```text
RuntimeError: Expected all tensors to be on the same device, but got indices is on cuda:1, different from other tensors on cpu