### PR TITLE
Fix: restore requires_grad after _save_converted_model to work around peft inject_adapter side effect

### DIFF
--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -246,10 +246,6 @@ class SwiftMixin:
                                     os.path.dirname(output_dir), 'initial_model'),
                             )
                             model.peft_config['default'] = config
-                # Restore requires_grad state after conversion to prevent peft side effects
-                for n, p in model.named_parameters():
-                    if n in requires_grad_state:
-                        p.requires_grad = requires_grad_state[n]
                     except ImportError as e:
                         error_message = """
                         Since 'LoRA-GA' is not implemented by PEFT, you will need to install it directly from GitHub.
@@ -264,6 +260,10 @@ class SwiftMixin:
                             os.path.dirname(output_dir), 'initial_model'),
                     )
                     model.peft_config['default'] = config
+                # Restore requires_grad state after conversion to prevent peft side effects
+                for n, p in model.named_parameters():
+                    if n in requires_grad_state:
+                        p.requires_grad = requires_grad_state[n]
 
     def _load_rng_state(self, *args, **kwargs):
         if self.args.resume_only_model:

--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -232,6 +232,9 @@ class SwiftMixin:
             init_lora_weights = getattr(config, 'init_lora_weights', None)
             if isinstance(init_lora_weights, str):
                 config = copy(config)
+                # Save requires_grad state to protect against peft inject_adapter side effects
+                # (peft >= 0.18.1 incorrectly freezes active adapter when loading a temporary adapter)
+                requires_grad_state = {n: p.requires_grad for n, p in model.named_parameters()}
                 os.makedirs(os.path.join(output_dir, 'converted'), exist_ok=True)
                 if 'lora-ga' in init_lora_weights:
                     try:
@@ -243,6 +246,10 @@ class SwiftMixin:
                                     os.path.dirname(output_dir), 'initial_model'),
                             )
                             model.peft_config['default'] = config
+                # Restore requires_grad state after conversion to prevent peft side effects
+                for n, p in model.named_parameters():
+                    if n in requires_grad_state:
+                        p.requires_grad = requires_grad_state[n]
                     except ImportError as e:
                         error_message = """
                         Since 'LoRA-GA' is not implemented by PEFT, you will need to install it directly from GitHub.


### PR DESCRIPTION
## Problem

When using PiSSA/OLoRA/LoRA-GA with peft >= 0.18.1, the first `save_checkpoint` freezes the training adapter's parameters due to a side effect in peft's `inject_adapter`. After saving, `grad_norm` drops to 0 and training effectively stops.

**Trigger path**: `_save_converted_model` → `model.save_pretrained(path_initial_model_for_weight_conversion=...)` → `save_mutated_as_lora` → `load_adapter` → `inject_adapter` → freezes active adapter

**Root cause**: peft 0.18.1 introduced a regression where `inject_adapter` passes the new adapter's `inference_mode=True` to `set_adapter(self.active_adapters, inference_mode=True)`, which incorrectly sets `requires_grad=False` on the training adapter. See huggingface/peft#3290 for the upstream fix.

## Fix

Save and restore `requires_grad` state of all parameters around the `save_pretrained` call in `_save_converted_model`. This applies to both the `pissa/olora` and `lora-ga` branches.

This is a defensive workaround that protects against the peft side effect without depending on any specific peft version. Once the upstream peft fix is merged and adopted, this workaround becomes a no-op safety net.

## Related

- Upstream peft fix: huggingface/peft#3290
- peft regression introduced in commit `13fa0aea` (PR #2765)
