### PR TITLE
[bugfix] fix vit_gradient_checkpointing_kwargs passing in megatron tr…

### DIFF
--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -499,7 +499,8 @@ class BaseMegatronTrainer(ABC):
             if self.args.vit_gradient_checkpointing:
                 dynamic_gradient_checkpointing(module, False)
                 try:
-                    module.gradient_checkpointing_enable(**(self.args.vit_gradient_checkpointing_kwargs or {}))
+                    module.gradient_checkpointing_enable(
+                        gradient_checkpointing_kwargs=self.args.vit_gradient_checkpointing_kwargs)
                     module.enable_input_require_grads()
                 except AttributeError:
                     pass


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix `vit_gradient_checkpointing_kwargs` not correctly passed to `gradient_checkpointing_enable()` in megatron trainer.

Previously, `vit_gradient_checkpointing_kwargs` was unpacked with `**` as top-level keyword arguments, which does not match the HuggingFace API signature of `gradient_checkpointing_enable(gradient_checkpointing_kwargs=...)`. This caused the kwargs (e.g. `use_reentrant`) to be silently ignored instead of being forwarded to the underlying checkpointing function.

Now `vit_gradient_checkpointing_kwargs` is correctly wrapped in the `gradient_checkpointing_kwargs` parameter.