### PR TITLE
Stabilize NPU CI device assignment and enable math-verify tests

### DIFF
--- a/.dev_scripts/ci_container_test.sh
+++ b/.dev_scripts/ci_container_test.sh
@@ -206,6 +206,9 @@ if [ "$MODELSCOPE_SDK_DEBUG" == "True" ]; then
     pip uninstall autoawq -y
     pip install optimum
     pip install diffusers
+    if [ "$SWIFT_CI_USE_NPU" == "True" ]; then
+        pip install math-verify -i "$NPU_PIP_INDEX"
+    fi
     pip install "transformers<5.0" "peft<0.19"
     # pip install autoawq -U --no-deps
 

--- a/tests/run.py
+++ b/tests/run.py
@@ -28,6 +28,27 @@ def deduplicate_preserve_order(items):
     return list(dict.fromkeys(items))
 
 
+def get_available_npu_devices(visible_npus):
+    npu_devices = [device.strip() for device in visible_npus.split(',') if device.strip()]
+    if not npu_devices:
+        return []
+
+    try:
+        import torch_npu  # noqa: F401
+        npu_count = torch.npu.device_count() if hasattr(torch, 'npu') and torch.npu.is_available() else 0
+    except Exception as e:
+        logger.warning('Failed to query torch.npu.device_count(): %s' % e)
+        return []
+
+    if npu_count <= 0:
+        logger.warning('ASCEND_RT_VISIBLE_DEVICES=%s, but torch.npu.device_count()=%s' % (visible_npus, npu_count))
+        return []
+    if npu_count < len(npu_devices):
+        logger.warning('ASCEND_RT_VISIBLE_DEVICES=%s, but torch.npu.device_count()=%s; using %s' %
+                       (visible_npus, npu_count, ','.join(npu_devices[:npu_count])))
+    return npu_devices[:npu_count]
+
+
 def test_cases_result_to_df(result_list):
     table_header = ['Name', 'Result', 'Info', 'Start time', 'Stop time', 'Time cost(seconds)']
     df = pandas.DataFrame(result_list, columns=table_header).sort_values(by=['Start time'], ascending=True)
@@ -138,7 +159,7 @@ def async_run_command_with_popen(cmd, device_id):
     env = os.environ.copy()
     visible_npus = env.get('ASCEND_RT_VISIBLE_DEVICES')
     if visible_npus:
-        npu_devices = [device.strip() for device in visible_npus.split(',') if device.strip()]
+        npu_devices = get_available_npu_devices(visible_npus)
         if npu_devices:
             env['ASCEND_RT_VISIBLE_DEVICES'] = npu_devices[device_id % len(npu_devices)]
             logger.info('Worker id: %s ASCEND_RT_VISIBLE_DEVICES: %s' % (device_id, env['ASCEND_RT_VISIBLE_DEVICES']))


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR fixes two NPU CI stability and coverage issues in `citest-npu`.

First, the NPU test runner now validates the runtime-visible NPU count before assigning devices to parallel workers. Previously, `tests/run.py` assigned workers only from `ASCEND_RT_VISIBLE_DEVICES`. In some CANN container runs, the environment variable may list multiple devices while `torch_npu` only exposes a smaller number of runtime-visible devices. For example, the CI environment may have:

```text
ASCEND_RT_VISIBLE_DEVICES=0,1
torch.npu.device_count()=1
```

In that case, assigning a worker to device `1` can make the NPU CI fail intermittently. This PR adds a runtime check based on `torch_npu` and `torch.npu.device_count()`, and only uses devices that are actually visible to the current Python process. If only one NPU is visible, `--parallel 2` can still run with both workers sharing the available NPU instead of assigning one worker to an unavailable device.

The GPU path is kept unchanged. The new NPU device assignment logic only runs when `ASCEND_RT_VISIBLE_DEVICES` is present. If it is not present, the existing `CUDA_VISIBLE_DEVICES` worker assignment behavior is preserved.

Second, this PR installs `math-verify` in the NPU CI dependency setup. Without this dependency, math/reward-related UTs are skipped in `citest-npu`, so the NPU CI covers fewer cases than expected. The installation is limited to the `SWIFT_CI_USE_NPU=True` branch and does not affect the GPU CI workflow.

Changed files:

- `tests/run.py`
  - Adds runtime-visible NPU device detection.
  - Uses the detected NPU device list for NPU worker assignment.
  - Keeps CUDA/GPU worker assignment unchanged when `ASCEND_RT_VISIBLE_DEVICES` is absent.
- `.dev_scripts/ci_container_test.sh`
  - Installs `math-verify` only in the NPU CI branch.

## Experiment results

Result:

```text
SUCCESS (Runs=81,success=72,failures=0,errors=0,skipped=9,expected failures=0,unexpected successes=0)
```