### PR TITLE
feat: add multimodal (image) support for Kimi-K2.5/K2.6 training

### DIFF
--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -14,10 +14,13 @@ from swift.utils import empty_cache, get_current_device, get_logger, to_device
 
 logger = get_logger()
 
-
 _MM_TENSOR_KEYS = frozenset({
-    'pixel_values', 'grid_thws', 'image_grid_hws', 'image_grid_thw',
-    'video_grid_thw', 'second_per_grid_ts',
+    'pixel_values',
+    'grid_thws',
+    'image_grid_hws',
+    'image_grid_thw',
+    'video_grid_thw',
+    'second_per_grid_ts',
 })
 
 

--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -15,6 +15,12 @@ from swift.utils import empty_cache, get_current_device, get_logger, to_device
 logger = get_logger()
 
 
+_MM_TENSOR_KEYS = frozenset({
+    'pixel_values', 'grid_thws', 'image_grid_hws', 'image_grid_thw',
+    'video_grid_thw', 'second_per_grid_ts',
+})
+
+
 def get_batch_on_this_pp_rank(args, data, vp_stage=None):
     if args.task_type == 'causal_lm':
         data['labels'] = torch.roll(data['labels'], -1, dims=-1)
@@ -27,6 +33,13 @@ def get_batch_on_this_pp_rank(args, data, vp_stage=None):
     if not is_pp_last_stage:
         batch['labels'] = None
         batch['loss_scale'] = None
+    # MM pixel tensors are consumed by the vision encoder on the first PP stage.
+    # Subsequent stages receive image features as activations via the PP channel.
+    if getattr(args, 'is_multimodal', False):
+        is_pp_first_stage = mpu.is_pipeline_first_stage(ignore_virtual=False, vp_stage=vp_stage)
+        if not is_pp_first_stage:
+            for key in _MM_TENSOR_KEYS:
+                batch.pop(key, None)
 
     return batch
 

--- a/swift/model/models/moonshot.py
+++ b/swift/model/models/moonshot.py
@@ -51,6 +51,7 @@ register_model(
         ],
         template=TemplateType.kimi_k25,
         model_arch=ModelArch.kimi_k25,
+        mcore_model_type='kimi_k25',
         architectures=['KimiK25ForConditionalGeneration'],
         requires=['transformers>=4.57.1,<5.0.0'],
     ))

--- a/swift/model/models/moonshot.py
+++ b/swift/model/models/moonshot.py
@@ -51,7 +51,6 @@ register_model(
         ],
         template=TemplateType.kimi_k25,
         model_arch=ModelArch.kimi_k25,
-        mcore_model_type='kimi_k25',
         architectures=['KimiK25ForConditionalGeneration'],
         requires=['transformers>=4.57.1,<5.0.0'],
     ))

--- a/swift/template/templates/moonshot.py
+++ b/swift/template/templates/moonshot.py
@@ -112,8 +112,68 @@ class KimiK25Template(Template):
 
     def replace_tag(self, media_type: Literal['image', 'video', 'audio'], index: int,
                     inputs: StdTemplateInputs) -> List[Context]:
-        raise ValueError('KimiK25Template does not currently support image or video. '
+        if media_type == 'image':
+            return ['<|media_start|>image<|media_content|><|media_pad|><|media_end|>']
+        raise ValueError(f'KimiK25Template does not currently support {media_type}. '
                          'Please open an issue to request support.')
+
+    def _encode(self, inputs: StdTemplateInputs) -> Dict[str, Any]:
+        encoded = super()._encode(inputs)
+        input_ids = encoded['input_ids']
+        labels = encoded['labels']
+        loss_scale = encoded.get('loss_scale', None)
+        media_token = self._tokenize('<|media_pad|>')[0]
+        idx_list = findall(input_ids, media_token)
+        if inputs.images:
+            image_processor = self.processor.image_processor
+            medias = [{'type': 'image', 'image': img} for img in inputs.images]
+            image_inputs = image_processor.preprocess(medias, return_tensors='pt')
+            grid_thws = image_inputs['grid_thws']
+            merge_kernel_size = image_processor.media_proc_cfg['merge_kernel_size']
+            merge_length = merge_kernel_size[0] * merge_kernel_size[1]
+
+            def _get_new_tokens(i):
+                token_len = (grid_thws[i].prod() // merge_length).item()
+                return [media_token] * token_len
+
+            input_ids, labels, loss_scale = self._extend_tokens(input_ids, labels, loss_scale, idx_list,
+                                                                _get_new_tokens)
+            encoded['loss_scale'] = loss_scale
+            encoded['input_ids'] = input_ids
+            encoded['labels'] = labels
+            encoded.update(image_inputs)
+        return encoded
+
+    def _data_collator_mm_data(self, batch: List[Dict[str, Any]]) -> Dict[str, Any]:
+        res = super()._data_collator_mm_data(batch)
+        grid_thws = self.concat_tensor(batch, 'grid_thws', 0)
+        if grid_thws is not None:
+            res['grid_thws'] = grid_thws
+        return res
+
+    def _post_encode(self, model: nn.Module, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        input_ids = inputs['input_ids']
+        pixel_values = inputs.get('pixel_values')
+        inputs_embeds = model.get_input_embeddings()(input_ids)
+
+        if pixel_values is not None and pixel_values.size(0) > 0:
+            vision_dtype = model.vision_tower.patch_embed.proj.weight.dtype
+            pixel_values = pixel_values.to(vision_dtype)
+            image_features: list = model._extract_image_features(pixel_values, inputs['grid_thws'])
+            all_features = torch.cat(image_features, dim=0).to(inputs_embeds.dtype)
+            media_token_id = model.config.media_placeholder_token_id
+            inputs_embeds = inputs_embeds.clone()
+            inputs_embeds[input_ids == media_token_id] = all_features
+        elif is_deepspeed_enabled():
+            image_processor = self.processor.image_processor
+            dummy_image = Image.new('RGB', (32, 32), (0, 0, 0))
+            dummy_inputs = image_processor.preprocess([{'type': 'image', 'image': dummy_image}], return_tensors='pt')
+            vision_dtype = model.vision_tower.patch_embed.proj.weight.dtype
+            dummy_pixels = dummy_inputs['pixel_values'].to(vision_dtype).to(inputs_embeds.device)
+            dummy_grid = dummy_inputs['grid_thws'].to(inputs_embeds.device)
+            image_features = model._extract_image_features(dummy_pixels, dummy_grid)
+            inputs_embeds = inputs_embeds + torch.cat(image_features, dim=0).mean() * 0.
+        return {'inputs_embeds': inputs_embeds}
 
 
 register_template(

--- a/swift/template/templates/moonshot.py
+++ b/swift/template/templates/moonshot.py
@@ -160,15 +160,20 @@ class KimiK25Template(Template):
         pixel_values = inputs.get('pixel_values')
         inputs_embeds = model.get_input_embeddings()(input_ids)
 
+        base_model = self.get_base_model(model)
         if pixel_values is not None and pixel_values.size(0) > 0:
-            vision_tower = self.get_base_model(model).vision_tower
+            vision_tower = base_model.vision_tower
             vision_dtype = next(vision_tower.parameters()).dtype
             pixel_values = pixel_values.to(device=inputs_embeds.device, dtype=vision_dtype)
             grid_thws = inputs.get('grid_thws')
             if grid_thws is None:
                 raise KeyError('pixel_values present in inputs but grid_thws is missing')
             grid_thws = grid_thws.to(inputs_embeds.device)
-            image_features: list = model._extract_image_features(pixel_values, grid_thws)
+            # vision_tower produces un-projected features; the mm_projector maps them to
+            # the language hidden size (mirrors KimiK25ForConditionalGeneration.forward).
+            image_features: list = base_model._extract_image_features(pixel_values, grid_thws)
+            if getattr(base_model, 'mm_projector', None):
+                image_features = base_model.mm_projector(image_features)
             all_features = torch.cat(image_features, dim=0).to(device=inputs_embeds.device, dtype=inputs_embeds.dtype)
             media_token_id = (getattr(model.config, 'media_placeholder_token_id', None)
                               or self.tokenizer.convert_tokens_to_ids('<|media_pad|>'))
@@ -179,11 +184,13 @@ class KimiK25Template(Template):
             image_processor = self.processor.image_processor
             dummy_image = Image.new('RGB', (32, 32), (0, 0, 0))
             dummy_inputs = image_processor.preprocess([{'type': 'image', 'image': dummy_image}], return_tensors='pt')
-            vision_tower = self.get_base_model(model).vision_tower
+            vision_tower = base_model.vision_tower
             vision_dtype = next(vision_tower.parameters()).dtype
             dummy_pixels = dummy_inputs['pixel_values'].to(device=inputs_embeds.device, dtype=vision_dtype)
             dummy_grid = dummy_inputs['grid_thws'].to(inputs_embeds.device)
-            image_features = model._extract_image_features(dummy_pixels, dummy_grid)
+            image_features = base_model._extract_image_features(dummy_pixels, dummy_grid)
+            if getattr(base_model, 'mm_projector', None):
+                image_features = base_model.mm_projector(image_features)
             if image_features:
                 inputs_embeds = inputs_embeds + torch.cat(image_features, dim=0).mean().to(
                     dtype=inputs_embeds.dtype) * 0.

--- a/swift/template/templates/moonshot.py
+++ b/swift/template/templates/moonshot.py
@@ -164,7 +164,10 @@ class KimiK25Template(Template):
             vision_tower = self.get_base_model(model).vision_tower
             vision_dtype = next(vision_tower.parameters()).dtype
             pixel_values = pixel_values.to(device=inputs_embeds.device, dtype=vision_dtype)
-            grid_thws = inputs['grid_thws'].to(inputs_embeds.device)
+            grid_thws = inputs.get('grid_thws')
+            if grid_thws is None:
+                raise KeyError('pixel_values present in inputs but grid_thws is missing')
+            grid_thws = grid_thws.to(inputs_embeds.device)
             image_features: list = model._extract_image_features(pixel_values, grid_thws)
             all_features = torch.cat(image_features, dim=0).to(device=inputs_embeds.device, dtype=inputs_embeds.dtype)
             media_token_id = (getattr(model.config, 'media_placeholder_token_id', None)
@@ -181,7 +184,9 @@ class KimiK25Template(Template):
             dummy_pixels = dummy_inputs['pixel_values'].to(device=inputs_embeds.device, dtype=vision_dtype)
             dummy_grid = dummy_inputs['grid_thws'].to(inputs_embeds.device)
             image_features = model._extract_image_features(dummy_pixels, dummy_grid)
-            inputs_embeds = inputs_embeds + torch.cat(image_features, dim=0).mean().to(dtype=inputs_embeds.dtype) * 0.
+            if image_features:
+                inputs_embeds = inputs_embeds + torch.cat(image_features, dim=0).mean().to(
+                    dtype=inputs_embeds.dtype) * 0.
         return {'inputs_embeds': inputs_embeds}
 
 

--- a/swift/template/templates/moonshot.py
+++ b/swift/template/templates/moonshot.py
@@ -130,7 +130,10 @@ class KimiK25Template(Template):
             image_inputs = image_processor.preprocess(medias, return_tensors='pt')
             grid_thws = image_inputs['grid_thws']
             merge_kernel_size = image_processor.media_proc_cfg['merge_kernel_size']
-            merge_length = merge_kernel_size[0] * merge_kernel_size[1]
+            if isinstance(merge_kernel_size, (list, tuple)):
+                merge_length = merge_kernel_size[0] * merge_kernel_size[1]
+            else:
+                merge_length = merge_kernel_size * merge_kernel_size
 
             def _get_new_tokens(i):
                 token_len = (grid_thws[i].prod() // merge_length).item()
@@ -157,9 +160,10 @@ class KimiK25Template(Template):
         inputs_embeds = model.get_input_embeddings()(input_ids)
 
         if pixel_values is not None and pixel_values.size(0) > 0:
-            vision_dtype = model.vision_tower.patch_embed.proj.weight.dtype
-            pixel_values = pixel_values.to(vision_dtype)
-            grid_thws = inputs['grid_thws'].to(pixel_values.device)
+            vision_tower = self.get_base_model(model).vision_tower
+            vision_dtype = next(vision_tower.parameters()).dtype
+            pixel_values = pixel_values.to(device=inputs_embeds.device, dtype=vision_dtype)
+            grid_thws = inputs['grid_thws'].to(inputs_embeds.device)
             image_features: list = model._extract_image_features(pixel_values, grid_thws)
             all_features = torch.cat(image_features, dim=0).to(inputs_embeds.dtype)
             media_token_id = model.config.media_placeholder_token_id
@@ -170,8 +174,9 @@ class KimiK25Template(Template):
             image_processor = self.processor.image_processor
             dummy_image = Image.new('RGB', (32, 32), (0, 0, 0))
             dummy_inputs = image_processor.preprocess([{'type': 'image', 'image': dummy_image}], return_tensors='pt')
-            vision_dtype = model.vision_tower.patch_embed.proj.weight.dtype
-            dummy_pixels = dummy_inputs['pixel_values'].to(vision_dtype).to(inputs_embeds.device)
+            vision_tower = self.get_base_model(model).vision_tower
+            vision_dtype = next(vision_tower.parameters()).dtype
+            dummy_pixels = dummy_inputs['pixel_values'].to(device=inputs_embeds.device, dtype=vision_dtype)
             dummy_grid = dummy_inputs['grid_thws'].to(inputs_embeds.device)
             image_features = model._extract_image_features(dummy_pixels, dummy_grid)
             inputs_embeds = inputs_embeds + torch.cat(image_features, dim=0).mean() * 0.

--- a/swift/template/templates/moonshot.py
+++ b/swift/template/templates/moonshot.py
@@ -175,8 +175,9 @@ class KimiK25Template(Template):
             if getattr(base_model, 'mm_projector', None):
                 image_features = base_model.mm_projector(image_features)
             all_features = torch.cat(image_features, dim=0).to(device=inputs_embeds.device, dtype=inputs_embeds.dtype)
-            media_token_id = (getattr(model.config, 'media_placeholder_token_id', None)
-                              or self.tokenizer.convert_tokens_to_ids('<|media_pad|>'))
+            media_token_id = (
+                getattr(model.config, 'media_placeholder_token_id', None)
+                or self.tokenizer.convert_tokens_to_ids('<|media_pad|>'))
             inputs_embeds = inputs_embeds.clone()
             mask = input_ids.reshape(-1) == media_token_id
             inputs_embeds.reshape(-1, inputs_embeds.size(-1))[mask] = all_features
@@ -192,8 +193,8 @@ class KimiK25Template(Template):
             if getattr(base_model, 'mm_projector', None):
                 image_features = base_model.mm_projector(image_features)
             if image_features:
-                inputs_embeds = inputs_embeds + torch.cat(image_features, dim=0).mean().to(
-                    dtype=inputs_embeds.dtype) * 0.
+                inputs_embeds = inputs_embeds + torch.cat(
+                    image_features, dim=0).mean().to(dtype=inputs_embeds.dtype) * 0.
         return {'inputs_embeds': inputs_embeds}
 
 

--- a/swift/template/templates/moonshot.py
+++ b/swift/template/templates/moonshot.py
@@ -193,8 +193,10 @@ class KimiK25Template(Template):
             if getattr(base_model, 'mm_projector', None):
                 image_features = base_model.mm_projector(image_features)
             if image_features:
-                inputs_embeds = inputs_embeds + torch.cat(
-                    image_features, dim=0).mean().to(dtype=inputs_embeds.dtype) * 0.
+                # nan_to_num guards against a non-finite value from the all-zero dummy
+                # pass leaking into the text batch (NaN * 0 == NaN in IEEE-754).
+                zero_term = torch.nan_to_num(torch.cat(image_features, dim=0).mean() * 0.)
+                inputs_embeds = inputs_embeds + zero_term.to(dtype=inputs_embeds.dtype)
         return {'inputs_embeds': inputs_embeds}
 
 

--- a/swift/template/templates/moonshot.py
+++ b/swift/template/templates/moonshot.py
@@ -129,7 +129,8 @@ class KimiK25Template(Template):
             medias = [{'type': 'image', 'image': img} for img in inputs.images]
             image_inputs = image_processor.preprocess(medias, return_tensors='pt')
             grid_thws = image_inputs['grid_thws']
-            merge_kernel_size = image_processor.media_proc_cfg['merge_kernel_size']
+            media_proc_cfg = getattr(image_processor, 'media_proc_cfg', {})
+            merge_kernel_size = media_proc_cfg.get('merge_kernel_size', (2, 2))
             if isinstance(merge_kernel_size, (list, tuple)):
                 merge_length = merge_kernel_size[0] * merge_kernel_size[1]
             else:
@@ -165,8 +166,9 @@ class KimiK25Template(Template):
             pixel_values = pixel_values.to(device=inputs_embeds.device, dtype=vision_dtype)
             grid_thws = inputs['grid_thws'].to(inputs_embeds.device)
             image_features: list = model._extract_image_features(pixel_values, grid_thws)
-            all_features = torch.cat(image_features, dim=0).to(inputs_embeds.dtype)
-            media_token_id = model.config.media_placeholder_token_id
+            all_features = torch.cat(image_features, dim=0).to(device=inputs_embeds.device, dtype=inputs_embeds.dtype)
+            media_token_id = (getattr(model.config, 'media_placeholder_token_id', None)
+                              or self.tokenizer.convert_tokens_to_ids('<|media_pad|>'))
             inputs_embeds = inputs_embeds.clone()
             mask = input_ids.reshape(-1) == media_token_id
             inputs_embeds.reshape(-1, inputs_embeds.size(-1))[mask] = all_features
@@ -179,7 +181,7 @@ class KimiK25Template(Template):
             dummy_pixels = dummy_inputs['pixel_values'].to(device=inputs_embeds.device, dtype=vision_dtype)
             dummy_grid = dummy_inputs['grid_thws'].to(inputs_embeds.device)
             image_features = model._extract_image_features(dummy_pixels, dummy_grid)
-            inputs_embeds = inputs_embeds + torch.cat(image_features, dim=0).mean() * 0.
+            inputs_embeds = inputs_embeds + torch.cat(image_features, dim=0).mean().to(dtype=inputs_embeds.dtype) * 0.
         return {'inputs_embeds': inputs_embeds}
 
 

--- a/swift/template/templates/moonshot.py
+++ b/swift/template/templates/moonshot.py
@@ -159,11 +159,13 @@ class KimiK25Template(Template):
         if pixel_values is not None and pixel_values.size(0) > 0:
             vision_dtype = model.vision_tower.patch_embed.proj.weight.dtype
             pixel_values = pixel_values.to(vision_dtype)
-            image_features: list = model._extract_image_features(pixel_values, inputs['grid_thws'])
+            grid_thws = inputs['grid_thws'].to(pixel_values.device)
+            image_features: list = model._extract_image_features(pixel_values, grid_thws)
             all_features = torch.cat(image_features, dim=0).to(inputs_embeds.dtype)
             media_token_id = model.config.media_placeholder_token_id
             inputs_embeds = inputs_embeds.clone()
-            inputs_embeds[input_ids == media_token_id] = all_features
+            mask = input_ids.reshape(-1) == media_token_id
+            inputs_embeds.reshape(-1, inputs_embeds.size(-1))[mask] = all_features
         elif is_deepspeed_enabled():
             image_processor = self.processor.image_processor
             dummy_image = Image.new('RGB', (32, 32), (0, 0, 0))


### PR DESCRIPTION
## Summary

Fixes #9469 — adds image training support for `moonshotai/Kimi-K2.5` and `moonshotai/Kimi-K2.6` in `KimiK25Template`.

**Changes in `swift/template/templates/moonshot.py`:**

- **`replace_tag`**: Returns the standard Kimi media token sequence `<|media_start|>image<|media_content|><|media_pad|><|media_end|>` for `image` media type; raises `ValueError` for unsupported types (video/audio) with a helpful message.

- **`_encode`**: Wraps PIL images as `[{'type': 'image', 'image': img}]` dicts (the format expected by `KimiK25ImageProcessor.preprocess`), obtains `pixel_values` and `grid_thws`, reads `merge_kernel_size` from `image_processor.media_proc_cfg`, then expands each `<|media_pad|>` placeholder to the correct number of tokens: `grid_thws[i].prod() // (kH * kW)`.

- **`_data_collator_mm_data`**: Concatenates per-sample `grid_thws` tensors along dim 0 for batched training.

- **`_post_encode`**: Extracts vision features via `model._extract_image_features(pixel_values, grid_thws)`, concatenates the per-image feature tensors, and fills the pre-expanded `<|media_pad|>` positions in `inputs_embeds` using a boolean mask on `model.config.media_placeholder_token_id`. Includes a DeepSpeed dummy forward pass to keep all parameters in the computation graph.

## Implementation notes

The `KimiK25ImageProcessor` returns `grid_thws` of shape `(N, 3)` (T, H, W in patch units), unlike Kimi-VL which returns `image_grid_hws` of shape `(N, 2)` (H, W). Token count per image is `T * H * W / (kH * kW)` — for static images T=1, so this reduces to `H * W / 4` with the default `merge_kernel_size=(2,2)`.

The merge is done by pre-expanding tokens in `_encode` (same pattern as `KimiVLTemplate`) rather than calling the model's `_merge_input_ids_with_image_features` (which assumes single-token placeholders and changes sequence length), keeping the implementation consistent with the rest of ms-swift's template framework.