### PR TITLE
fix(megatron): pre-initialize NCCL communicator for MoE expert DP group to prevent lazy-init deadlock

### DIFF
--- a/swift/megatron/utils/megatron_lm_utils.py
+++ b/swift/megatron/utils/megatron_lm_utils.py
@@ -94,12 +94,13 @@ def _initialize_mpu(args):
         # Calling a barrier here forces bootstrap while GPU memory is still empty, eliminating the race.
         # get_inter_distributed_optimizer_instance_group returns _INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP,
         # which is None for dense models or when EP=1, so the guard is safe in all configurations.
-        inter_ep_dp_group = mpu.get_inter_distributed_optimizer_instance_group(check_initialized=False)
-        if inter_ep_dp_group is not None:
-            logger.info('Pre-initializing INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP NCCL communicator '
-                        'to avoid lazy-init deadlock during first optimizer step.')
-            torch.distributed.barrier(group=inter_ep_dp_group, device_ids=[torch.cuda.current_device()])
-            torch.cuda.synchronize()
+        if hasattr(mpu, 'get_inter_distributed_optimizer_instance_group'):
+            inter_ep_dp_group = mpu.get_inter_distributed_optimizer_instance_group(check_initialized=False)
+            if inter_ep_dp_group is not None:
+                logger.info('Pre-initializing INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP NCCL communicator '
+                            'to avoid lazy-init deadlock during first optimizer step.')
+                torch.distributed.barrier(group=inter_ep_dp_group, device_ids=[torch.cuda.current_device()])
+                torch.cuda.synchronize()
 
 
 def initialize_megatron(args):

--- a/swift/megatron/utils/megatron_lm_utils.py
+++ b/swift/megatron/utils/megatron_lm_utils.py
@@ -82,6 +82,25 @@ def _initialize_mpu(args):
                         f'VPP: {args.virtual_pipeline_model_parallel_size}, CP: {args.context_parallel_size}, '
                         f'EP: {args.expert_model_parallel_size}, ETP: {args.expert_tensor_parallel_size}')
 
+        # before model weights are loaded onto GPU.
+        #
+        # Background: PyTorch lazily initializes NCCL communicators — dist.new_group() only registers
+        # metadata; the actual ncclCommInitRankConfig bootstrap runs on first collective use.
+        # For MoE models this group's first use is the very first optimizer step, by which point GPU
+        # memory is near its limit (~125-130 GiB on H200). If any rank cannot allocate the NCCL
+        # temporary buffer at that moment, its bootstrap thread stalls silently — NCCL_TIMEOUT does
+        # NOT cover the bootstrap phase — and all other ranks wait forever (deadlock).
+        #
+        # Calling a barrier here forces bootstrap while GPU memory is still empty, eliminating the race.
+        # get_inter_distributed_optimizer_instance_group returns _INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP,
+        # which is None for dense models or when EP=1, so the guard is safe in all configurations.
+        inter_ep_dp_group = mpu.get_inter_distributed_optimizer_instance_group(check_initialized=False)
+        if inter_ep_dp_group is not None:
+            logger.info('Pre-initializing INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP NCCL communicator '
+                        'to avoid lazy-init deadlock during first optimizer step.')
+            torch.distributed.barrier(group=inter_ep_dp_group, device_ids=[torch.cuda.current_device()])
+            torch.cuda.synchronize()
+
 
 def initialize_megatron(args):
     # Pytorch distributed.


### PR DESCRIPTION
  ## Problem

  When training large MoE models (e.g. Qwen3.5-122B-A10B) with Expert Parallelism (EP=8, 4 nodes × 8 GPUs), training hangs permanently at the first optimizer step with no error output. After NCCL_TIMEOUT, the watchdog outputs: `Watchdog caught collective operation timeout`. **Root cause**: PyTorch lazily initializes NCCL communicators.  `dist.new_group()` only registers metadata; the actual`ncclCommInitRankConfig` bootstrap fires on the first collective use. For `INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP` (the cross-node expert DP group), this first use is the very first optimizer step, by which point GPU memory is near its limit (e.g. ~128/140 GiB on H200). If any rank cannot allocate the NCCL bootstrap buffer, its bootstrap thread stalls silently — `NCCL_TIMEOUT` does **not** cover the bootstrap phase —and all other ranks wait forever.

  If any rank cannot allocate the NCCL bootstrap buffer, its bootstrap thread stalls silently — `NCCL_TIMEOUT` does **not** cover the bootstrap phase — and all other ranks wait forever.

  ## Fix

  In `_initialize_mpu()`, immediately after `mpu.initialize_model_parallel()` returns (while GPU memory is still nearly empty), call a barrier on this group to force NCCL bootstrap at a safe time. Uses the public API `mpu.get_inter_distributed_optimizer_instance_group(check_initialized=False)`, which returns `None` for dense models or when `EP=1`, making this change a no-op for all non-MoE configurations.

  ## Tested on

  - Qwen3.5-122B-A10B, 4 nodes × 8 × H200, EP=8, TP=1, PP=1
  - megatron-core: 0.17
  - Without this fix: deadlock at step 1, every run
  - With this fix: training runs to completion, no deadlock
