### PR TITLE
fix argument bug "is_binary_loss_scale"

### DIFF
--- a/swift/arguments/base_args/template_args.py
+++ b/swift/arguments/base_args/template_args.py
@@ -131,6 +131,7 @@ class TemplateArguments:
     padding_free: bool = False
     loss_scale: str = 'default'
     sequence_parallel_size: int = 1
+    is_binary_loss_scale: Optional[bool] = None
     # infer/deploy
     template_backend: Literal['swift', 'jinja'] = 'swift'
     # thinking
@@ -175,6 +176,7 @@ class TemplateArguments:
             # train
             'padding_free': self.padding_free,
             'loss_scale': self.loss_scale,
+            'is_binary_loss_scale': self.is_binary_loss_scale,
             'sequence_parallel_size': self.sequence_parallel_size,
             # infer/deploy
             'template_backend': self.template_backend,


### PR DESCRIPTION
# PR type
- [✓] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

The current version cannot recognize the `--is_binary_loss_scale` parameter because the corresponding parameter is missing in the parameter template. This branch fixes this bug and adds two parameter definitions.

