### PR TITLE
[rollout] Don't hard-import vllm in multi_turn (breaks use_vllm=False)

### DIFF
--- a/swift/rollout/multi_turn.py
+++ b/swift/rollout/multi_turn.py
@@ -3,19 +3,27 @@
 import asyncio
 from abc import ABC
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from swift.infer_engine import GRPOVllmEngine
 from swift.infer_engine.protocol import (ChatCompletionResponse, ChatCompletionResponseChoice, RequestConfig,
                                          RolloutInferRequest, RolloutOutput)
 from swift.template import Messages
 from swift.utils import remove_response
 from .gym_env import Env, envs
 
+if TYPE_CHECKING:
+    # Imported only for type hints; importing it at runtime pulls in vllm, which would make
+    # `swift.rollout` (and thus GRPO trainer init) hard-require vllm even when use_vllm=False.
+    from swift.infer_engine import GRPOVllmEngine
+
 
 class RolloutScheduler(ABC):
     # Single Turn Rollout Scheduler
-    def __init__(self, infer_engine: Optional[GRPOVllmEngine] = None, max_turns: Optional[int] = None, *args, **kwargs):
+    def __init__(self,
+                 infer_engine: Optional['GRPOVllmEngine'] = None,
+                 max_turns: Optional[int] = None,
+                 *args,
+                 **kwargs):
         self.infer_engine = infer_engine
         # Tokenizer can be passed explicitly (e.g., in colocate mode where infer_engine may be None)
         self._tokenizer = kwargs.get('tokenizer', None)
@@ -722,7 +730,7 @@ class GYMScheduler(MultiTurnScheduler):
     server mode (``run()``) and colocate mode (``run_multi_turn()``).
     """
 
-    def __init__(self, infer_engine: Optional[GRPOVllmEngine] = None, max_turns: Optional[int] = None, **kwargs):
+    def __init__(self, infer_engine: Optional['GRPOVllmEngine'] = None, max_turns: Optional[int] = None, **kwargs):
         super().__init__(infer_engine, max_turns, **kwargs)
         self.gym_env_name = kwargs.get('gym_env', None)
         # Per-trajectory state (keyed by uuid)


### PR DESCRIPTION
`swift/rollout/multi_turn.py` imported `GRPOVllmEngine` at module top level, but only uses it as a type annotation (`Optional[GRPOVllmEngine]`). Because the GRPO trainer's `rollout_mixin` imports `swift.rollout` at init time, this made `import vllm` happen unconditionally whenever GRPO starts — even with `--use_vllm false`, where `_prepare_vllm()` returns early and no vllm engine is ever built. On an env without vllm installed, GRPO crashed at startup with `ModuleNotFoundError: No module named 'vllm'`.

Move the import under `TYPE_CHECKING` and quote the annotations so vllm stays optional, matching the existing design (early-return on use_vllm=False, lazy `from swift.infer_engine import GRPOVllmEngine` inside `_prepare_vllm_engine`, and the friendly "please install vllm" guard gated on use_vllm=True).

Verified: in an env without vllm, `import swift.rollout.multi_turn` and resolving the lazy `swift.rollout` exports no longer pull vllm into sys.modules.

# PR type
- [x] Bug Fix


# PR information

`swift/rollout/multi_turn.py` imports `GRPOVllmEngine` at module top level, but
only uses it as a type annotation. Since the GRPO trainer's `rollout_mixin`
imports `swift.rollout` at init time, this makes `import vllm` run
unconditionally on GRPO startup — even with `--use_vllm false`, where
`_prepare_vllm()` returns early and no vllm engine is ever built. On an env
without vllm, GRPO crashes with `ModuleNotFoundError: No module named 'vllm'`.

Fix: move the import under `TYPE_CHECKING` and quote the annotations, matching
the existing design (early-return on use_vllm=False, lazy engine import in
`_prepare_vllm_engine`, vllm guard gated on use_vllm=True).

Verified: on an env without vllm, importing `swift.rollout.multi_turn` and
resolving `swift.rollout`'s lazy exports no longer pulls vllm into sys.modules.