### PR TITLE
update npu scripts for qwen3 omni and 3.5 moe

### DIFF
--- a/examples/ascend/train/qwen3_5/qwen3_lora_megatron_npu.sh
+++ b/examples/ascend/train/qwen3_5/qwen3_lora_megatron_npu.sh
@@ -1,4 +1,4 @@
-# 16 * 64GiB Ascend A3
+# 8 * 64GiB Ascend A3
 
 # NPU stability environment variables
 export HCCL_OP_BASE_FFTS_MODE_ENABLE=TRUE

--- a/examples/ascend/train/qwen3_5/qwen3_lora_megatron_npu_a3.sh
+++ b/examples/ascend/train/qwen3_5/qwen3_lora_megatron_npu_a3.sh
@@ -1,21 +1,18 @@
 # 16 * 64GiB Ascend A3
+export USE_MCORE_GDN=0
 
-# NPU stability environment variables
 export HCCL_OP_BASE_FFTS_MODE_ENABLE=TRUE
 export MULTI_STREAM_MEMORY_REUSE=1
-# NPU memory management environment variables
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-# NPU performance environment variables
 export TASK_QUEUE_ENABLE=2
 
-NPROC_PER_NODE=8 \
-ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+MASTER_PORT=29609 \
+NPROC_PER_NODE=16 \
 megatron sft \
     --model Qwen/Qwen3.5-35B-A3B \
-    --save_safetensors true \
-    --dataset 'AI-ModelScope/alpaca-gpt4-data-zh#500' \
-              'AI-ModelScope/alpaca-gpt4-data-en#500' \
-              'swift/self-cognition#500' \
+    --save_safetensors false \
+    --dataset 'AI-ModelScope/MAmmoTH-VL-Instruct-12M#1000' \
     --tuner_type lora \
     --lora_rank 8 \
     --lora_alpha 32 \
@@ -33,7 +30,7 @@ megatron sft \
     --recompute_num_layers 1 \
     \
     --micro_batch_size 1 \
-    --global_batch_size 8 \
+    --global_batch_size 16 \
     --finetune true \
     --cross_entropy_loss_fusion true \
     --gradient_accumulation_fusion false \
@@ -42,11 +39,11 @@ megatron sft \
     --lr 1e-4 \
     --lr_warmup_fraction 0.05 \
     --min_lr 1e-5 \
-    --num_train_epochs 16 \
+    --num_train_epochs 32 \
     \
-    --output_dir output/Qwen3.5-35B-A3B \
+    --output_dir /Qwen3.5-35B-A3B \
     --save_steps 2000 \
-    --max_length 1024 \
+    --max_length 4096 \
     --system 'You are a helpful assistant.' \
     \
     --dataloader_num_workers 4 \

--- a/examples/ascend/train/qwen3_5/qwen3_lora_megatron_npu_a3.sh
+++ b/examples/ascend/train/qwen3_5/qwen3_lora_megatron_npu_a3.sh
@@ -41,7 +41,7 @@ megatron sft \
     --min_lr 1e-5 \
     --num_train_epochs 32 \
     \
-    --output_dir /Qwen3.5-35B-A3B \
+    --output_dir output/Qwen3.5-35B-A3B \
     --save_steps 2000 \
     --max_length 4096 \
     --system 'You are a helpful assistant.' \

--- a/examples/ascend/train/qwen3_5/qwen3_lora_megatron_npu_a5.sh
+++ b/examples/ascend/train/qwen3_5/qwen3_lora_megatron_npu_a5.sh
@@ -1,21 +1,14 @@
-# 16 * 64GiB Ascend A3
+# 8 * 96GiB Ascend A5
 
-# NPU stability environment variables
-export HCCL_OP_BASE_FFTS_MODE_ENABLE=TRUE
-export MULTI_STREAM_MEMORY_REUSE=1
-# NPU memory management environment variables
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-# NPU performance environment variables
 export TASK_QUEUE_ENABLE=2
+export USE_MCORE_GDN=0
 
 NPROC_PER_NODE=8 \
 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
 megatron sft \
     --model Qwen/Qwen3.5-35B-A3B \
     --save_safetensors true \
-    --dataset 'AI-ModelScope/alpaca-gpt4-data-zh#500' \
-              'AI-ModelScope/alpaca-gpt4-data-en#500' \
-              'swift/self-cognition#500' \
+    --dataset 'AI-ModelScope/MAmmoTH-VL-Instruct-12M#1000' \
     --tuner_type lora \
     --lora_rank 8 \
     --lora_alpha 32 \
@@ -32,8 +25,8 @@ megatron sft \
     --recompute_method uniform \
     --recompute_num_layers 1 \
     \
-    --micro_batch_size 1 \
-    --global_batch_size 8 \
+    --micro_batch_size 2 \
+    --global_batch_size 16 \
     --finetune true \
     --cross_entropy_loss_fusion true \
     --gradient_accumulation_fusion false \
@@ -42,11 +35,11 @@ megatron sft \
     --lr 1e-4 \
     --lr_warmup_fraction 0.05 \
     --min_lr 1e-5 \
-    --num_train_epochs 16 \
+    --num_train_epochs 32 \
     \
     --output_dir output/Qwen3.5-35B-A3B \
     --save_steps 2000 \
-    --max_length 1024 \
+    --max_length 4096 \
     --system 'You are a helpful assistant.' \
     \
     --dataloader_num_workers 4 \

--- a/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A3.sh
+++ b/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A3.sh
@@ -1,59 +1,54 @@
 # 16 * 64GiB Ascend A3
 
-# NPU stability environment variables
+export USE_MCORE_GDN=0
+
 export HCCL_OP_BASE_FFTS_MODE_ENABLE=TRUE
+export HCCL_CONNECT_TIMEOUT=600
 export MULTI_STREAM_MEMORY_REUSE=1
-# NPU memory management environment variables
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-# NPU performance environment variables
+
 export TASK_QUEUE_ENABLE=2
 
-NPROC_PER_NODE=8 \
-ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+NPROC_PER_NODE=16 \
 megatron sft \
-    --model Qwen/Qwen3.5-35B-A3B \
-    --save_safetensors true \
-    --dataset 'AI-ModelScope/alpaca-gpt4-data-zh#500' \
-              'AI-ModelScope/alpaca-gpt4-data-en#500' \
-              'swift/self-cognition#500' \
+    --model Qwen/Qwen3-Omni-30B-A3B-Instruct\
+    --save_safetensors false \
+    --dataset AI-ModelScope/MAmmoTH-VL-Instruct-12M \
     --tuner_type lora \
     --lora_rank 8 \
     --lora_alpha 32 \
     --target_modules all-linear \
-    \
-    --tensor_model_parallel_size 2 \
-    --expert_model_parallel_size 4 \
+    --tensor_model_parallel_size 1 \
+    --expert_model_parallel_size 8 \
     --moe_permute_fusion true \
     --moe_grouped_gemm true \
     --moe_shared_expert_overlap true \
     --moe_aux_loss_coeff 1e-6 \
     --sequence_parallel true \
+    --micro_batch_size 2 \
+    --global_batch_size 32 \
     --recompute_granularity full \
     --recompute_method uniform \
     --recompute_num_layers 1 \
-    \
-    --micro_batch_size 1 \
-    --global_batch_size 8 \
     --finetune true \
     --cross_entropy_loss_fusion true \
-    --gradient_accumulation_fusion false \
-    --masked_softmax_fusion false \
-    \
     --lr 1e-4 \
     --lr_warmup_fraction 0.05 \
     --min_lr 1e-5 \
-    --num_train_epochs 16 \
-    \
-    --output_dir output/Qwen3.5-35B-A3B \
+    --num_train_epochs 1 \
+    --output_dir megatron_output/Qwen3-omni \
     --save_steps 2000 \
-    --max_length 1024 \
+    --max_length 4096 \
     --system 'You are a helpful assistant.' \
-    \
     --dataloader_num_workers 4 \
-    --dataset_num_proc 4 \
     --no_save_optim true \
     --no_save_rng true \
-    \
+    --dataset_num_proc 4 \
+    --gradient_accumulation_fusion false \
+    --masked_softmax_fusion false \
     --attention_backend flash \
+    --padding_free false \
     --model_author swift \
     --model_name swift-robot

--- a/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A3.sh
+++ b/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A3.sh
@@ -13,7 +13,7 @@ export TASK_QUEUE_ENABLE=2
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 NPROC_PER_NODE=16 \
 megatron sft \
-    --model Qwen/Qwen3-Omni-30B-A3B-Instruct\
+    --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
     --save_safetensors false \
     --dataset AI-ModelScope/MAmmoTH-VL-Instruct-12M \
     --tuner_type lora \

--- a/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A3.sh
+++ b/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A3.sh
@@ -15,7 +15,7 @@ NPROC_PER_NODE=16 \
 megatron sft \
     --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
     --save_safetensors false \
-    --dataset AI-ModelScope/MAmmoTH-VL-Instruct-12M \
+    --dataset 'AI-ModelScope/MAmmoTH-VL-Instruct-12M#1000' \
     --tuner_type lora \
     --lora_rank 8 \
     --lora_alpha 32 \

--- a/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A5.sh
+++ b/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A5.sh
@@ -1,59 +1,54 @@
-# 16 * 64GiB Ascend A3
+# 8 * 96GiB Ascend A5
 
-# NPU stability environment variables
-export HCCL_OP_BASE_FFTS_MODE_ENABLE=TRUE
-export MULTI_STREAM_MEMORY_REUSE=1
-# NPU memory management environment variables
+export USE_MCORE_GDN=0
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-# NPU performance environment variables
 export TASK_QUEUE_ENABLE=2
+export HCCL_CONNECT_TIMEOUT=600
+
+MODEL_PATH=Qwen/Qwen3-Omni-30B-A3B-Instruct
+DATASET_PATH=AI-ModelScope/MAmmoTH-VL-Instruct-12M
 
 NPROC_PER_NODE=8 \
-ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
 megatron sft \
-    --model Qwen/Qwen3.5-35B-A3B \
-    --save_safetensors true \
-    --dataset 'AI-ModelScope/alpaca-gpt4-data-zh#500' \
-              'AI-ModelScope/alpaca-gpt4-data-en#500' \
-              'swift/self-cognition#500' \
+    --model ${MODEL_PATH} \
+    --save_safetensors false \
+    --dataset ${DATASET_PATH} \
     --tuner_type lora \
     --lora_rank 8 \
     --lora_alpha 32 \
     --target_modules all-linear \
-    \
-    --tensor_model_parallel_size 2 \
-    --expert_model_parallel_size 4 \
+    --tensor_model_parallel_size 1 \
+    --expert_model_parallel_size 8 \
     --moe_permute_fusion true \
     --moe_grouped_gemm true \
     --moe_shared_expert_overlap true \
     --moe_aux_loss_coeff 1e-6 \
     --sequence_parallel true \
+    --micro_batch_size 4 \
+    --global_batch_size 32 \
     --recompute_granularity full \
     --recompute_method uniform \
     --recompute_num_layers 1 \
-    \
-    --micro_batch_size 1 \
-    --global_batch_size 8 \
     --finetune true \
     --cross_entropy_loss_fusion true \
-    --gradient_accumulation_fusion false \
-    --masked_softmax_fusion false \
-    \
     --lr 1e-4 \
     --lr_warmup_fraction 0.05 \
     --min_lr 1e-5 \
-    --num_train_epochs 16 \
-    \
-    --output_dir output/Qwen3.5-35B-A3B \
+    --num_train_epochs 1 \
+    --output_dir megatron_output/Qwen3-omni \
     --save_steps 2000 \
-    --max_length 1024 \
+    --max_length 4096 \
     --system 'You are a helpful assistant.' \
-    \
     --dataloader_num_workers 4 \
-    --dataset_num_proc 4 \
     --no_save_optim true \
     --no_save_rng true \
-    \
+    --dataset_num_proc 4 \
+    --gradient_accumulation_fusion false \
+    --masked_softmax_fusion false \
     --attention_backend flash \
+    --padding_free false \
     --model_author swift \
     --model_name swift-robot
+
+
+

--- a/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A5.sh
+++ b/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A5.sh
@@ -50,6 +50,3 @@ megatron sft \
     --padding_free false \
     --model_author swift \
     --model_name swift-robot
-
-
-

--- a/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A5.sh
+++ b/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A5.sh
@@ -6,7 +6,7 @@ export TASK_QUEUE_ENABLE=2
 export HCCL_CONNECT_TIMEOUT=600
 
 MODEL_PATH=Qwen/Qwen3-Omni-30B-A3B-Instruct
-DATASET_PATH=AI-ModelScope/MAmmoTH-VL-Instruct-12M
+DATASET_PATH='AI-ModelScope/MAmmoTH-VL-Instruct-12M#1000'
 
 NPROC_PER_NODE=8 \
 megatron sft \

--- a/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A5.sh
+++ b/examples/ascend/train/qwen3_omni/qwen3_omni_lora_megatron_A5.sh
@@ -9,6 +9,7 @@ MODEL_PATH=Qwen/Qwen3-Omni-30B-A3B-Instruct
 DATASET_PATH='AI-ModelScope/MAmmoTH-VL-Instruct-12M#1000'
 
 NPROC_PER_NODE=8 \
+ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
 megatron sft \
     --model ${MODEL_PATH} \
     --save_safetensors false \


### PR DESCRIPTION
# PR type
- More Models or Datasets Support

# PR information
update npu scripts for qwen3 and 3.5 with megatron backend

## Experiment results
for qwen3 omni A5 throughput 1x A3. for qwen3.5 moe A5 throughput 2.7x A3.  
