### PR TITLE
[bugfix] avoid swanlab.get_run() on non-main ranks in profiling_context

### DIFF
--- a/swift/rlhf_trainers/utils.py
+++ b/swift/rlhf_trainers/utils.py
@@ -607,7 +607,7 @@ def profiling_context(trainer, name: str):
     if 'wandb' in trainer.args.report_to and wandb.run is not None and is_main_process:
         wandb.log(profiling_metrics, commit=False)
 
-    if 'swanlab' in trainer.args.report_to and swanlab.get_run() is not None and is_main_process:
+    if is_main_process and 'swanlab' in trainer.args.report_to and swanlab.get_run() is not None:
         swanlab.log(profiling_metrics)
 
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information

Fixes #9545.

In distributed GRPO with `--report_to swanlab`, swanlab is only initialized on the main process. On non-main ranks `swanlab.get_run()` **raises** `RuntimeError: No active Run. Call swanlab.init() first.` instead of returning `None`, so `profiling_context` in `swift/rlhf_trainers/utils.py` crashes during rollout profiling:

```
File ".../swift/rlhf_trainers/rollout_mixin.py", line 943, in _fast_infer
    self._move_model_to_vllm()
File ".../swift/rlhf_trainers/utils.py", in profiling_context
    if 'swanlab' in trainer.args.report_to and swanlab.get_run() is not None and is_main_process:
RuntimeError: No active Run. Call swanlab.init() first.
```

`is_main_process` was evaluated last, after `swanlab.get_run()`. Moving it first makes the check short-circuit on non-main ranks before `get_run()` is ever called:

```python
if is_main_process and 'swanlab' in trainer.args.report_to and swanlab.get_run() is not None:
```

The `wandb` branch just above is already safe — `wandb.run` is an attribute that returns `None`, not a call that raises. The other `swanlab.get_run()` use (`reward_trainer.py:112`) already sits inside an `if self.accelerator.process_index == 0:` guard, so it only runs on the main rank and isn't affected.

## Experiment results

Reproducing the original crash needs a multi-rank distributed run. Minimal mechanism demo of the short-circuit order on a non-main rank (where `swanlab.get_run()` raises):

```
OLD (current main): CRASH -> No active Run. Call swanlab.init() first.
NEW (fix):          result=False
```
