### PR TITLE
[bugfix] pin MeanMetric all_reduce tensor to float32 to avoid cross-rank dtype mismatch

### DIFF
--- a/swift/metrics/utils.py
+++ b/swift/metrics/utils.py
@@ -101,7 +101,7 @@ class MeanMetric(Metric):
 
     def compute(self):
         if dist.is_initialized():
-            tensor = torch.tensor([self.state, self.count], device=self.device)
+            tensor = torch.tensor([self.state, self.count], dtype=torch.float64, device=self.device)
             dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=self.group)
             self.state, self.count = tensor[0].item(), int(tensor[1].item())
         if self.count == 0:

--- a/swift/metrics/utils.py
+++ b/swift/metrics/utils.py
@@ -101,7 +101,7 @@ class MeanMetric(Metric):
 
     def compute(self):
         if dist.is_initialized():
-            tensor = torch.tensor([self.state, self.count], dtype=torch.float64, device=self.device)
+            tensor = torch.tensor([self.state, self.count], dtype=torch.float32, device=self.device)
             dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=self.group)
             self.state, self.count = tensor[0].item(), int(tensor[1].item())
         if self.count == 0:


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information

Fixes #9550.

`MeanMetric.compute()` (`swift/metrics/utils.py`) builds the all-reduce tensor with an **inferred** dtype:

```python
tensor = torch.tensor([self.state, self.count], device=self.device)
```

In sequence-level accuracy, `compute_acc()` appends `np.all(...)` (a `numpy.bool_`). Accumulating that into `self.state` promotes it from a python `float` to `numpy.float64` on the ranks that take that path. `torch.tensor([...])` then infers **float64** on those ranks but **float32** on ranks where `self.state` stayed a python float. The ranks enter `dist.all_reduce()` with mismatched dtypes and the collective hangs (matching the debug screenshots in #9550).

Pinning the tensor to `float64` makes every rank reduce with the same dtype regardless of `self.state`'s runtime type. float64 also keeps `count` exact for large totals (float32 loses integer precision above 2^24).

## Experiment results

Reproducing the hang needs a multi-rank run; minimal demo of the dtype inference (one rank's state promoted to `numpy.float64` via `np.bool_`, the other left a python float):

```
rank-A state type: float | rank-B state type: float64
CURRENT  -> rankA=torch.float32  rankB=torch.float64  all_reduce MATCH=False
FIX      -> rankA=torch.float64  rankB=torch.float64  all_reduce MATCH=True
```
