### PR TITLE
Add logger initialization to main CLI

### DIFF
--- a/swift/cli/main.py
+++ b/swift/cli/main.py
@@ -7,6 +7,10 @@ import sys
 import yaml
 from typing import Dict, List, Optional
 
+from swift.utils import get_logger
+
+logger = get_logger()
+
 ROUTE_MAPPING: Dict[str, str] = {
     'pt': 'swift.cli.pt',
     'sft': 'swift.cli.sft',


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixes https://github.com/modelscope/ms-swift/issues/9575.

This PR restores the missing logger initialization in `swift/cli/main.py`.

`parse_yaml_args()` uses `logger.warning(...)` when environment variables from a config file conflict with existing environment values, but `logger` was not defined. This adds:
```python
from swift.utils import get_logger

logger = get_logger()
```
so the CLI can correctly emit the warning instead of raising a `NameError`.

## Experiment results
No special Experiment results.

#9575 
