### PR TITLE
Fix DDP fp32 grad reduce arg mapping

### DIFF
--- a/swift/megatron/utils/megatron_lm_utils.py
+++ b/swift/megatron/utils/megatron_lm_utils.py
@@ -522,6 +522,11 @@ def wrap_model(args, models, wrap_with_ddp: bool = True):
     for f in dataclasses.fields(DistributedDataParallelConfig):
         if hasattr(args, f.name):
             kwargs[f.name] = getattr(args, f.name)
+
+    # compat: SWIFT keeps the user-facing Megatron-LM arg name, while MCore
+    # DistributedDataParallelConfig expects grad_reduce_in_fp32.
+    if hasattr(args, 'accumulate_allreduce_grads_in_fp32'):
+        kwargs['grad_reduce_in_fp32'] = args.accumulate_allreduce_grads_in_fp32
     kwargs['check_for_nan_in_grad'] = True
     ddp_config = DistributedDataParallelConfig(**kwargs)
 


### PR DESCRIPTION
## PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

## PR information

This PR fixes a Megatron DDP config argument mapping regression in `wrap_model`.

SWIFT exposes the user-facing Megatron-LM argument:

```python
accumulate_allreduce_grads_in_fp32
```

while MCore `DistributedDataParallelConfig` expects:

```python
grad_reduce_in_fp32
```

The current `wrap_model` implementation only forwards arguments whose names exactly match fields in `DistributedDataParallelConfig`:

```python
for f in dataclasses.fields(DistributedDataParallelConfig):
    if hasattr(args, f.name):
        kwargs[f.name] = getattr(args, f.name)
```

As a result, setting `accumulate_allreduce_grads_in_fp32=True` is silently dropped and `ddp_config.grad_reduce_in_fp32` falls back to the default value `False`.

This PR explicitly maps:

```python
args.accumulate_allreduce_grads_in_fp32
```

to:

```python
DistributedDataParallelConfig.grad_reduce_in_fp32
```

before constructing `DistributedDataParallelConfig`, so fp32 gradient reduction is honored as intended.

## Experiment results

Not run. This is a narrow config propagation fix.