### PR TITLE
feat(megatron): expose muon_coefficient_type for the Muon optimizer

### DIFF
--- a/docs/source/Megatron-SWIFT/Command-line-parameters.md
+++ b/docs/source/Megatron-SWIFT/Command-line-parameters.md
@@ -99,6 +99,7 @@
 - muon_use_nesterov: 是否在内部 SGD 中使用 Nesterov 风格的动量，默认为False。
 - muon_scale_mode: Muon 优化器的缩放模式。可选为'spectral', 'unit_rms_norm', 'shape_scaling'。默认为'spectral'。
 - muon_fp32_matmul_prec: Newton-Schulz 迭代的 FP32 矩阵乘法精度，可选为'low', 'medium', 'high'。默认为'medium'。
+- muon_coefficient_type: Muon 优化器 Newton-Schulz 迭代的系数类型，传递给 Megatron 的 `--muon-coefficient-type`。可选值取决于所安装的 emerging_optimizers 版本（如'quintic', 'polar_express', 'simple', 'cans', 'aol', 'deepseekv4', 'cubic5', 'custom'）。默认为'quintic'。
 - muon_num_ns_steps: Muon 优化器的 Newton-Schulz 步数。默认为5。
 - muon_tp_mode: 张量模型并行权重的 NS 计算方式。可选为'blockwise', 'duplicated', 'distributed'。默认为'blockwise'。
 - muon_extra_scale_factor: Muon 更新的额外缩放因子，默认为1。

--- a/docs/source_en/Megatron-SWIFT/Command-line-parameters.md
+++ b/docs/source_en/Megatron-SWIFT/Command-line-parameters.md
@@ -105,6 +105,7 @@
 - muon_use_nesterov: Whether to use Nesterov-style momentum in the internal SGD. Default is False.
 - muon_scale_mode: Scale mode for the Muon optimizer. Options include 'spectral', 'unit_rms_norm', and 'shape_scaling'. Default is 'spectral'.
 - muon_fp32_matmul_prec: FP32 matrix multiplication precision for Newton-Schulz iteration. Options include 'low', 'medium', and 'high'. Default is 'medium'.
+- muon_coefficient_type: Newton-Schulz coefficient type for the Muon optimizer, forwarded to Megatron's `--muon-coefficient-type`. Available options depend on the installed emerging_optimizers version (e.g. 'quintic', 'polar_express', 'simple', 'cans', 'aol', 'deepseekv4', 'cubic5', 'custom'). Default is 'quintic'.
 - muon_num_ns_steps: Number of Newton-Schulz steps for the Muon optimizer. Default is 5.
 - muon_tp_mode: NS calculation method for tensor model parallel weights. Options include 'blockwise', 'duplicated', and 'distributed'. Default is 'blockwise'.
 - muon_extra_scale_factor: Additional scale factor for Muon updates. Default is 1.

--- a/swift/megatron/arguments/megatron_args.py
+++ b/swift/megatron/arguments/megatron_args.py
@@ -497,6 +497,7 @@ class MegatronArguments(RLHFMegatronArgumentsMixin, MegatronTunerMixin):
     muon_use_nesterov: bool = False
     muon_scale_mode: Literal['spectral', 'unit_rms_norm', 'shape_scaling'] = 'spectral'
     muon_fp32_matmul_prec: Literal['low', 'medium', 'high'] = 'medium'
+    muon_coefficient_type: str = 'quintic'
     muon_num_ns_steps: int = 5
     muon_tp_mode: Literal['blockwise', 'duplicated', 'distributed'] = 'blockwise'
     muon_extra_scale_factor: float = 1.


### PR DESCRIPTION
## What

Megatron-SWIFT's `MegatronArguments` exposes 8 Muon hyperparameters (`muon_momentum`, `muon_split_qkv`, `muon_use_nesterov`, `muon_scale_mode`, `muon_fp32_matmul_prec`, `muon_num_ns_steps`, `muon_tp_mode`, `muon_extra_scale_factor`) but is **missing `muon_coefficient_type`**, which Megatron-Core supports:

- Megatron CLI: `--muon-coefficient-type` (`megatron/training/arguments.py`), default `'quintic'`
- Megatron config: `OptimizerConfig.muon_coefficient_type` (`megatron/core/optimizer/optimizer_config.py`)

`muon_coefficient_type` selects the Newton–Schulz coefficient set (`quintic`, `polar_express`, …), which affects convergence. Without it exposed, recipes that rely on a non-default coefficient set (e.g. `polar_express`) cannot be expressed through Megatron-SWIFT.

## Change

- Add `muon_coefficient_type: str = 'quintic'` to `MegatronArguments` (matching Megatron's CLI default and `type=str`).
- Document it in the zh/en command-line-parameters docs.

No forwarding code is needed: `MegatronArguments` is forwarded to Megatron via the existing `asdict()` mechanism (`swift/megatron/pipelines/train/sft.py`), exactly like the other `muon_*` args, and Megatron already has the matching `--muon-coefficient-type` argument.

## Notes

Typed as `str` (rather than a `Literal`) to mirror Megatron's own CLI, since the supported set is version-dependent and validated by Megatron at runtime (`emerging_optimizers.validate_coefficient_type`). Happy to switch to a `Literal` if preferred. Verified against current `main`; the field was the only `muon_*` argument absent relative to Megatron's CLI.
