### PR TITLE
fix(megatron): align moe_router_load_balancing_type to single-string Literal (#8480)

### DIFF
--- a/swift/megatron/arguments/megatron_args.py
+++ b/swift/megatron/arguments/megatron_args.py
@@ -586,7 +586,8 @@ class MegatronArguments(RLHFMegatronArgumentsMixin, MegatronTunerMixin):
     accumulate_allreduce_grads_in_fp32: bool = False
 
     # moe
-    moe_router_load_balancing_type: Optional[List[str]] = None
+    moe_router_load_balancing_type: Optional[Literal['aux_loss', 'seq_aux_loss', 'global_aux_loss', 'sinkhorn',
+                                                     'none']] = None
     moe_router_dtype: Literal['none', 'fp32', 'fp64'] = 'fp32'
     moe_token_dispatcher_type: Literal['allgather', 'alltoall', 'flex'] = 'alltoall'
     moe_enable_deepep: bool = False


### PR DESCRIPTION
## What

Fixes the type inconsistency reported in #8480.

`moe_router_load_balancing_type` was declared as `Optional[List[str]]` in `swift/megatron/arguments/megatron_args.py`, but everywhere else in the stack it is a single string:
- `mcore_bridge` `ModelConfig.moe_router_load_balancing_type` is `Literal['aux_loss', 'seq_aux_loss', 'global_aux_loss', 'sinkhorn', 'none']`.
- `swift/megatron/trainers/base.py` compares it as a string (`config.moe_router_load_balancing_type == 'aux_loss'`, etc.).

Because the arg was a `List[str]`, `--moe_router_load_balancing_type none` (the documented way to disable load balancing) parsed to `['none']`, which then never matches the string comparisons downstream — so the disable path and the metric logging were effectively broken, and the type was inconsistent with `ModelConfig`.

## Change

Make the arg a string `Literal` matching `mcore_bridge`'s `ModelConfig` (keeping `Optional`/`None` for the "not set → inherit from `config.json`" default):

```python
moe_router_load_balancing_type: Optional[Literal['aux_loss', 'seq_aux_loss', 'global_aux_loss', 'sinkhorn',
                                                 'none']] = None
```

Now `--moe_router_load_balancing_type none` becomes the string `'none'` and disables load balancing as documented, and the value is type-consistent with `ModelConfig` and the string comparisons in `base.py`.

## Note

Megatron-core's own `transformer_config.py` types this as `Union[str, List[str]]` (it can take a list of per-something types), but `mcore_bridge.ModelConfig` — which ms-swift actually feeds — exposes only the single-string form, and ms-swift has no list-handling code for it. So aligning to the single-string `Literal` matches the real stack behavior and resolves #8480. If exposing the list form is ever wanted, that would be a separate feature (arg + `ModelConfig` + `base.py` all need to handle lists).
