### PR TITLE
feat(megatron): add nccl_comm_warmup to avoid iteration-1 NCCL cudaMalloc OOM (#6387)

### DIFF
--- a/swift/megatron/arguments/megatron_args.py
+++ b/swift/megatron/arguments/megatron_args.py
@@ -546,6 +546,9 @@ class MegatronArguments(RLHFMegatronArgumentsMixin, MegatronTunerMixin):
     overlap_param_gather: bool = False
     overlap_param_gather_with_optimizer_step: bool = False
     align_grad_reduce: bool = True
+    # Eagerly create NCCL communicators before the training loop to avoid the lazy
+    # first-use allocation hitting the iteration-1 memory peak (Failed to CUDA calloc async).
+    nccl_comm_warmup: bool = False
     virtual_pipeline_model_parallel_size: Optional[int] = None
     microbatch_group_size_per_vp_stage: Optional[int] = None
     pipeline_model_parallel_layout: Optional[str] = None

--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -615,6 +615,37 @@ class BaseMegatronTrainer(ABC):
             self._saved_param_sync_func = config.param_sync_func
             config.param_sync_func = None
 
+        if args.nccl_comm_warmup:
+            # Eagerly create NCCL communicators while GPU memory is still free. Lazily-initialized
+            # comms (e.g. the dp/cp loss all-reduce and grad-sync coalescing) otherwise first fire
+            # at the iteration-1 memory peak, where NCCL's internal cudaMalloc can fail with
+            # "Failed to CUDA calloc async N bytes". A 1-element dummy all-reduce per group is
+            # numerically inert and forces the communicator to be created up front.
+            dummy = torch.zeros(1, device=get_current_device())
+            warmed = 0
+            for getter, kwargs in (
+                (mpu.get_data_parallel_group, {
+                    'with_context_parallel': True
+                }),
+                (mpu.get_data_parallel_group, {}),
+                (mpu.get_context_parallel_group, {}),
+                (mpu.get_tensor_model_parallel_group, {}),
+                (mpu.get_pipeline_model_parallel_group, {}),
+                (mpu.get_model_parallel_group, {}),
+                (mpu.get_embedding_group, {}),
+                (mpu.get_position_embedding_group, {}),
+            ):
+                try:
+                    group = getter(**kwargs)
+                except (AssertionError, ValueError, TypeError):
+                    continue
+                for g in (group if isinstance(group, list) else [group]):
+                    if g is not None:
+                        torch.distributed.all_reduce(dummy, group=g)
+                        warmed += 1
+            torch.cuda.synchronize()
+            logger.info(f'NCCL communicator warm-up done ({warmed} groups).')
+
         self.call_event('on_train_begin')
         self._train_metrics = {}
 


### PR DESCRIPTION
## What

Adds an opt-in `nccl_comm_warmup` flag that eagerly creates the NCCL communicators before the training loop, to avoid an iteration-1 OOM.

## Why

NCCL communicators are created lazily on first use. For the per-step collectives that ms-swift/Megatron issue inside the training step (e.g. the dp/cp loss all-reduce and grad-sync coalescing), that first use happens at the **iteration-1 memory peak**. At that point NCCL's internal `cudaMalloc` for the communicator buffers can fail with:

```
Failed to CUDA calloc async N bytes
```

so training dies on the very first step on large models / tight-memory configs. This is the error reported in #6387 (Qwen3-Next-80B-A3B, 8×H20), which was only worked around by changing the parallel layout (`--expert_model_parallel_size 8`) rather than fixed in code. We hit the same failure on Qwen3.5-35B-A3B.

## Change

When `--nccl_comm_warmup true`, right before `on_train_begin` (in `setup_model_training`), fire one numerically-inert 1-element `all_reduce` on each parallel group (dp, dp+cp, cp, tp, pp, model, embedding, position-embedding). This forces the communicators to be allocated while memory is still free; groups that don't exist for the current parallel config are skipped. Default is `False`, so behavior is unchanged unless explicitly enabled.

## Notes

- Opt-in and default-off; zero effect on existing runs.
- The dummy all-reduce is a no-op numerically (a 1-element zero tensor).
- Verified the two files compile; could not run a multi-GPU job locally — relying on CI / users who hit #6387.
