### PR TITLE
[bugfix] include image mode and size in tmp image cache key

### DIFF
--- a/swift/template/base.py
+++ b/swift/template/base.py
@@ -810,8 +810,12 @@ class Template(ProcessorMixin):
 
     @staticmethod
     def _save_pil_image(image: Image.Image) -> str:
+        # `Image.tobytes()` only returns the flattened pixel stream, without mode or shape.
+        # Include them in the cache key so images that share pixel bytes but differ in
+        # mode/size do not collide onto the same cached file.
         img_bytes = image.tobytes()
-        img_hash = hashlib.sha256(img_bytes).hexdigest()
+        meta = f'{image.mode}-{image.width}x{image.height}-'.encode()
+        img_hash = hashlib.sha256(meta + img_bytes).hexdigest()
         tmp_dir = os.path.join(get_cache_dir(), 'tmp', 'images')
         logger.info_once(f'create tmp_dir: {tmp_dir}')
         os.makedirs(tmp_dir, exist_ok=True)

--- a/tests/general/test_template.py
+++ b/tests/general/test_template.py
@@ -72,8 +72,38 @@ def test_mllm_dataset_map():
     _test_dataset_map('Qwen/Qwen2-VL-7B-Instruct', 'modelscope/coco_2014_caption:validation#100')
 
 
+def test_save_pil_image_dimension_collision():
+    from PIL import Image
+
+    from swift.template.base import Template
+
+    # Two images that share the same flattened pixel bytes but differ in shape.
+    width_a, height_a = 120, 80
+    width_b, height_b = 80, 120
+    assert width_a * height_a == width_b * height_b
+    pixels = bytearray()
+    for i in range(width_a * height_a):
+        row = i // width_a
+        pixels.extend((255, 60, 60) if row % 10 < 5 else (60, 60, 255))
+    img_bytes = bytes(pixels)
+    image_a = Image.frombytes('RGB', (width_a, height_a), img_bytes)
+    image_b = Image.frombytes('RGB', (width_b, height_b), img_bytes)
+    assert image_a.tobytes() == image_b.tobytes()
+
+    path_a = Template._save_pil_image(image_a)
+    path_b = Template._save_pil_image(image_b)
+
+    # Different dimensions must not collide onto the same cache file.
+    assert path_a != path_b
+    with Image.open(path_a) as saved_a:
+        assert saved_a.size == (width_a, height_a)
+    with Image.open(path_b) as saved_b:
+        assert saved_b.size == (width_b, height_b)
+
+
 if __name__ == '__main__':
     test_template()
     test_mllm()
     test_llm_dataset_map()
     test_mllm_dataset_map()
+    test_save_pil_image_dimension_collision()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixes #9360.

`Template._save_pil_image()` keyed the temp image cache on `sha256(image.tobytes())`. `Image.tobytes()` returns only the flattened pixel stream, without the image mode, width, or height. Two images that share the same pixel bytes but differ in shape (e.g. `120x80` and `80x120`) therefore hash to the same cache path. Since the method skips saving when the path already exists, the second image silently reuses the first image's PNG, so multimodal inference/training can read the wrong image.

This includes the mode and size in the hash input so images with different dimensions get distinct cache files. Behavior for any single image is unchanged (the file is still written once and reused on repeat).

## Experiment results

Added `test_save_pil_image_dimension_collision` in `tests/general/test_template.py`: it builds two RGB images with identical pixel bytes but transposed dimensions, saves both, and asserts the cache paths differ and each saved file keeps its own size. The test fails on the previous hash and passes after this change.

```
$ python -m pytest tests/general/test_template.py::test_save_pil_image_dimension_collision -q
1 passed
```
