### PR TITLE
[bugfix] guard _repair_ms_bench against an empty messages list

### DIFF
--- a/swift/dataset/dataset/llm.py
+++ b/swift/dataset/dataset/llm.py
@@ -93,6 +93,10 @@ register_dataset(
 def _repair_ms_bench(messages: str) -> Optional[List[Dict[str, str]]]:
     if isinstance(messages, str):
         messages = ast.literal_eval(messages)
+    if not messages:
+        # A row with no messages can't be repaired; skip it like the MOSS case
+        # below instead of crashing the whole dataset load on messages[0].
+        return None
     default_system = 'You are a helpful assistant.'
     messages: List[Dict[str, str]]
     if messages[0]['from'] == 'system' and messages[0]['value'] == default_system:

--- a/tests/general/test_repair_ms_bench.py
+++ b/tests/general/test_repair_ms_bench.py
@@ -1,0 +1,46 @@
+import unittest
+
+from swift.dataset.dataset.llm import _repair_ms_bench
+
+
+class TestRepairMsBench(unittest.TestCase):
+    """Pure unit tests for the ms_bench messages repair function (no network)."""
+
+    def test_empty_messages_returns_none(self):
+        # An empty row can't be repaired; it must be skipped (None) like the MOSS
+        # case rather than crashing the whole dataset load on messages[0].
+        self.assertIsNone(_repair_ms_bench('[]'))
+        self.assertIsNone(_repair_ms_bench([]))
+
+    def test_strips_default_system_message(self):
+        messages = [
+            {
+                'from': 'system',
+                'value': 'You are a helpful assistant.'
+            },
+            {
+                'from': 'user',
+                'value': 'hi'
+            },
+        ]
+        self.assertEqual(_repair_ms_bench(messages), [{'from': 'user', 'value': 'hi'}])
+
+    def test_keeps_a_normal_conversation(self):
+        messages = [
+            {
+                'from': 'user',
+                'value': 'hi'
+            },
+            {
+                'from': 'assistant',
+                'value': 'hello'
+            },
+        ]
+        self.assertEqual(_repair_ms_bench(messages), messages)
+
+    def test_skips_moss_rows(self):
+        self.assertIsNone(_repair_ms_bench([{'from': 'user', 'value': 'moss reply'}]))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

`_repair_ms_bench` (the `repair_messages` hook for the `iic/ms_bench` dataset) reads `messages[0]` right after `ast.literal_eval`, so a row whose messages are empty — e.g. the literal string `"[]"` — raises `IndexError: list index out of range` and aborts the whole ms_bench dataset load instead of just skipping that one row.

The function already returns `None` to skip rows it can't use (the MOSS case), and `MessagesPreprocessor` drops `None` rows, so returning `None` for an empty list is the same, consistent behaviour.

## Fix

An early `if not messages: return None` guard right after the parse.

## Test

Added `tests/general/test_repair_ms_bench.py` (pure unit tests, no network): empty `"[]"` / `[]` returns `None`, the default system message is stripped, a normal conversation passes through, and a MOSS row is skipped. The empty case raises `IndexError` without the fix.

Verified locally: `pytest tests/general/test_repair_ms_bench.py` (4 passed); `flake8` / `isort` / `yapf` clean.
