### PR TITLE
fix(dataset): propagate system message to rejected_messages in DPO preprocessing

### DIFF
--- a/swift/dataset/preprocessor/core.py
+++ b/swift/dataset/preprocessor/core.py
@@ -514,7 +514,7 @@ class MessagesPreprocessor(RowPreprocessor):
     def preprocess(self, row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         if 'rejected_messages' in row:
             row['rejected_messages'] = MessagesPreprocessor.preprocess(
-                self, {'messages': row['rejected_messages']})['messages']
+                self, {'messages': row['rejected_messages'], 'system': row.get('system')})['messages']
         messages = row['messages']
         if self.inner_key is not None:
             messages = messages[self.inner_key]

--- a/tests/general/test_data_preprocess.py
+++ b/tests/general/test_data_preprocess.py
@@ -1,6 +1,6 @@
 import unittest
 
-from swift.dataset import EncodePreprocessor, PackingDataset, load_dataset
+from swift.dataset import EncodePreprocessor, MessagesPreprocessor, PackingDataset, load_dataset
 from swift.model import get_processor
 from swift.template import get_template
 
@@ -145,6 +145,37 @@ class TestDataPreprocess(unittest.TestCase):
         self.assertGreater(len(packed), 0)
         self.assertIn('input_ids', packed[0])
         self.assertIn('labels', packed[0])
+
+
+class TestMessagesPreprocessor(unittest.TestCase):
+    """Unit tests for MessagesPreprocessor (no model required)."""
+
+    def test_system_propagated_to_rejected_messages(self):
+        """system message must be prepended to rejected_messages, not only to messages.
+
+        Regression test for the bug where the recursive preprocess() call for
+        rejected_messages omitted the 'system' key, causing chosen and rejected
+        to have asymmetric conversation prefixes during DPO training.
+        """
+        row = {
+            'messages': [
+                {'role': 'user', 'content': 'Q'},
+                {'role': 'assistant', 'content': 'good'},
+            ],
+            'rejected_messages': [
+                {'role': 'user', 'content': 'Q'},
+                {'role': 'assistant', 'content': 'bad'},
+            ],
+            'system': 'You are helpful.',
+        }
+        result = MessagesPreprocessor().preprocess(row)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['messages'][0]['role'], 'system',
+                         'system message should be first in chosen messages')
+        self.assertEqual(result['rejected_messages'][0]['role'], 'system',
+                         'system message should also be first in rejected_messages')
+        self.assertEqual(result['messages'][0]['content'], 'You are helpful.')
+        self.assertEqual(result['rejected_messages'][0]['content'], 'You are helpful.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When a DPO dataset row has both a `system` key and `rejected_messages`, the system message is never added to `rejected_messages`. The recursive call to `preprocess` only passes `{'messages': row['rejected_messages']}` — the `system` key is dropped on the way in.

DPO training requires chosen and rejected to have the same prompt context; this silently produces asymmetric encoding. Anything downstream that encodes both sides will see different conversation prefixes, which corrupts the training signal.

One-line fix: pass `'system': row.get('system')` to the recursive call so the system message is forwarded.

Also adds a regression test covering the scenario.
