### PR TITLE
fix(template): preserve non-string prefix elements in _replace_system

### DIFF
--- a/swift/template/template_meta.py
+++ b/swift/template/template_meta.py
@@ -69,7 +69,7 @@ class TemplateMeta:
 
     @staticmethod
     def _replace_system(prefix: Prompt) -> Prompt:
-        return [p.replace('{{SYSTEM}}', '') for p in prefix if isinstance(p, str)]
+        return [p.replace('{{SYSTEM}}', '') if isinstance(p, str) else p for p in prefix]
 
     def _check_template_meta(self):
         # check

--- a/tests/general/test_template_meta.py
+++ b/tests/general/test_template_meta.py
@@ -1,0 +1,24 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+from swift.template import TemplateMeta
+
+
+def test_replace_system_preserves_non_string_elements():
+    """_replace_system must not drop list elements like ['bos_token_id'].
+
+    Templates such as ziya, bluelm and emu3_chat use
+    ``prefix=[['bos_token_id'], '{{SYSTEM}}']``.  When no system message is
+    provided the prefix is produced by _replace_system, which should keep every
+    non-string element intact and only strip the placeholder from strings.
+    """
+    meta = TemplateMeta(
+        template_type='_test_replace_system_bug',
+        prefix=[['bos_token_id'], '{{SYSTEM}}'],
+        prompt=['{{QUERY}}'],
+        chat_sep=['\n'],
+    )
+    # __post_init__ moves prefix to system_prefix and builds a no-system prefix
+    # via _replace_system.  The list element must survive.
+    assert any(isinstance(p, list) for p in meta.prefix), (
+        f'_replace_system dropped the bos_token_id list; '
+        f'meta.prefix={meta.prefix!r}'
+    )

--- a/tests/general/test_template_meta.py
+++ b/tests/general/test_template_meta.py
@@ -18,7 +18,5 @@ def test_replace_system_preserves_non_string_elements():
     )
     # __post_init__ moves prefix to system_prefix and builds a no-system prefix
     # via _replace_system.  The list element must survive.
-    assert any(isinstance(p, list) for p in meta.prefix), (
-        f'_replace_system dropped the bos_token_id list; '
-        f'meta.prefix={meta.prefix!r}'
-    )
+    assert any(isinstance(p, list) for p in meta.prefix), (f'_replace_system dropped the bos_token_id list; '
+                                                           f'meta.prefix={meta.prefix!r}')


### PR DESCRIPTION
`_replace_system` is responsible for building the no-system variant of `prefix` by replacing the `{{SYSTEM}}` placeholder in string elements. The current implementation uses a filter comprehension:

```python
# before
return [p.replace('{{SYSTEM}}', '') for p in prefix if isinstance(p, str)]
```

The `if isinstance(p, str)` clause silently **drops** every non-string element. Token-ID lists like `['bos_token_id']` are legitimate prefix components — templates such as `ziya`, `bluelm`, and `emu3_chat` (and others in `baai.py`) use `prefix=[['bos_token_id'], '{{SYSTEM}}']`. When `_replace_system` runs (i.e. no system message is provided), the BOS token-ID entry disappears from `meta.prefix`, so every training and inference sequence for these templates starts without the expected leading token.

**Fix:** change the filter to a conditional expression so non-strings pass through unchanged:

```python
# after
return [p.replace('{{SYSTEM}}', '') if isinstance(p, str) else p for p in prefix]
```

Adds a focused unit test in `tests/general/test_template_meta.py` that instantiates a `TemplateMeta` with a mixed prefix and asserts the list element survives `__post_init__`.
