### PR TITLE
fix elastic code in transformers>=4.57.6

### DIFF
--- a/swift/arguments/sft_args.py
+++ b/swift/arguments/sft_args.py
@@ -5,6 +5,7 @@ from transformers.utils.versions import require_version
 from typing import Literal, Optional
 
 from swift.trainers import Seq2SeqTrainingArguments, TrainerFactory
+from swift.trainers.utils import prepare_deepspeed_elastic_config
 from swift.utils import (add_version_to_work_dir, get_device_count, get_logger, get_pai_tensorboard_dir, is_mp,
                          is_pai_training_job, is_swanlab_available, json_parse_to_dict, to_abspath)
 from .base_args import BaseArguments
@@ -276,6 +277,8 @@ class SftArguments(SwanlabArguments, TunerArguments, BaseArguments, Seq2SeqTrain
                     'To use `deepspeed_autotp_size`, you need to additionally set the `--deepspeed` argument.')
                 self.deepspeed['tensor_parallel'] = {'autotp_size': self.deepspeed_autotp_size}
                 self.deepspeed['zero_optimization']['gather_16bit_weights_on_model_save'] = True
+            if 'deepspeed_elastic' in set(getattr(self, 'callbacks', []) or []):
+                prepare_deepspeed_elastic_config(self)
             logger.info(f'Using deepspeed: {self.deepspeed}')
 
     def _init_fsdp(self):

--- a/swift/callbacks/deepspeed_elastic.py
+++ b/swift/callbacks/deepspeed_elastic.py
@@ -1,49 +1,13 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import torch
 import torch.distributed as dist
-from transformers import TrainerControl, TrainerState, TrainingArguments
 
 from swift.utils import ShutdownManager, get_device
 from .base import TrainerCallback
 
 
 class DeepspeedElasticCallback(TrainerCallback):
-
-    def __init__(self, args=None, trainer=None):
-        if args is not None and trainer is not None:
-            super().__init__(args, trainer)
-
-    def on_init_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
-        """
-        Event called at the beginning of training.
-        """
-
-        if args.deepspeed:
-            from deepspeed.elasticity import compute_elastic_config
-            from deepspeed.git_version_info import version as __version__
-            args.deepspeed['checkpoint'] = {'load_universal': True}
-            if 'elasticity' not in args.deepspeed:
-                args.deepspeed['elasticity'] = {
-                    'ignore_non_elastic_batch_info': True,
-                    'enabled': True,
-                    'max_train_batch_size': 8,
-                    'micro_batch_sizes': [2],
-                    'min_gpus': 1,
-                    'max_gpus': 4,
-                    'min_time': 20,
-                    'version': 0.1
-                }
-                world_size = dist.get_world_size() if dist.is_available() and dist.is_initialized() else 1
-                final_batch_size, _, micro_batch_size = compute_elastic_config(
-                    ds_config=args.deepspeed,
-                    target_deepspeed_version=__version__,
-                    world_size=world_size,
-                )
-                denom = micro_batch_size * world_size
-                gradient_accu_steps = max(1, final_batch_size // denom)
-                args.per_device_train_batch_size = micro_batch_size
-                args.gradient_accumulation_steps = gradient_accu_steps
-                state.train_batch_size = args.per_device_train_batch_size * max(1, args.n_gpu)
+    """Compatibility marker for enabling DeepSpeed elastic setup during argument initialization."""
 
 
 class GracefulExitCallback(TrainerCallback):

--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -33,6 +33,11 @@ from transformers.trainer import OPTIMIZER_NAME, PREFIX_CHECKPOINT_DIR, SCHEDULE
 from transformers.trainer import Trainer as HfTrainer
 from transformers.trainer import reissue_pt_warnings
 from transformers.trainer_utils import IntervalStrategy
+
+try:
+    from transformers.trainer_utils import sort_checkpoints
+except ImportError:
+    sort_checkpoints = None
 from types import MethodType
 from typing import Callable, Dict, List, Optional
 
@@ -278,6 +283,12 @@ class SwiftMixin:
         if self.args.resume_only_model:
             return
         super()._load_optimizer_and_scheduler(*args, **kwargs)
+        callbacks = set(getattr(self.args, 'callbacks', []))
+        ds_config = getattr(self.args, 'deepspeed', None) or {}
+        checkpoint_config = ds_config.get('checkpoint') if isinstance(ds_config, dict) else None
+        load_universal = isinstance(checkpoint_config, dict) and checkpoint_config.get('load_universal', False)
+        if 'deepspeed_elastic' in callbacks and load_universal:
+            self._fix_optimizer_step_device(self.optimizer)
         if is_mp_ddp():
             # fix mp+ddp adamw
             for v in self.optimizer.state.values():
@@ -286,6 +297,27 @@ class SwiftMixin:
                     device_set = set([t.device for t in v.values()]) - {v['step'].device, torch.device('cpu')}
                     if len(device_set) >= 1:
                         v['step'] = v['step'].to('cpu')
+
+    @staticmethod
+    def _fix_optimizer_step_device(optimizer):
+        state = getattr(optimizer, 'state', None)
+        if not isinstance(state, dict):
+            return
+        for value in state.values():
+            if not isinstance(value, dict):
+                continue
+            step = value.get('step')
+            if not isinstance(step, torch.Tensor):
+                continue
+            target_device = None
+            for state_key, state_value in value.items():
+                if state_key == 'step':
+                    continue
+                if isinstance(state_value, torch.Tensor) and state_value.device.type != 'cpu':
+                    target_device = state_value.device
+                    break
+            if target_device is not None and step.device != target_device:
+                value['step'] = step.to(target_device)
 
     def _save_model(self, output_dir: Optional[str] = None, state_dict=None):
         # model
@@ -415,7 +447,24 @@ class SwiftMixin:
         last_step = self._get_last_checkpoint_step()
 
         # Check if we should delete older checkpoint(s)
-        checkpoints_sorted = self._sorted_checkpoints(use_mtime=use_mtime, output_dir=output_dir)
+        if hasattr(self, '_sorted_checkpoints'):
+            checkpoints_sorted = self._sorted_checkpoints(use_mtime=use_mtime, output_dir=output_dir)
+        else:
+            output_dir = output_dir if output_dir is not None else self.args.output_dir
+            if sort_checkpoints is not None:
+                checkpoints_sorted = sort_checkpoints(
+                    output_dir=output_dir,
+                    checkpoint_prefix=PREFIX_CHECKPOINT_DIR,
+                    use_mtime=use_mtime,
+                    best_model_checkpoint=self.state.best_model_checkpoint,
+                )
+            else:
+                checkpoints = []
+                for path in os.listdir(output_dir) if os.path.isdir(output_dir) else []:
+                    if re.match(f'^{PREFIX_CHECKPOINT_DIR}-([0-9]+)$', path):
+                        checkpoints.append(os.path.join(output_dir, path))
+                ordering = os.path.getmtime if use_mtime else lambda path: int(path.rsplit('-', 1)[-1])
+                checkpoints_sorted = sorted(checkpoints, key=ordering)
 
         valid_checkpoints = []
         for path in checkpoints_sorted:

--- a/swift/trainers/utils.py
+++ b/swift/trainers/utils.py
@@ -4,6 +4,7 @@ import inspect
 import math
 import os
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
 from contextlib import contextmanager
 from modelscope.hub.api import HubApi
@@ -22,6 +23,79 @@ if TYPE_CHECKING:
     from .arguments import TrainingArguments
 
 logger = get_logger()
+
+
+def _get_deepspeed_elastic_world_size():
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_world_size()
+    return get_dist_setting()[2]
+
+
+def _enable_load_universal(ds_config):
+    if isinstance(ds_config, dict):
+        checkpoint = ds_config.get('checkpoint')
+        if not isinstance(checkpoint, dict):
+            checkpoint = {}
+            ds_config['checkpoint'] = checkpoint
+        checkpoint['load_universal'] = True
+
+
+def enable_deepspeed_load_universal(args: 'TrainingArguments', trainer=None):
+    _enable_load_universal(getattr(args, 'deepspeed', None))
+
+    hf_ds_config = getattr(args, 'hf_deepspeed_config', None)
+    _enable_load_universal(getattr(hf_ds_config, 'config', None))
+
+    deepspeed_plugin = getattr(args, 'deepspeed_plugin', None)
+    if trainer is not None and deepspeed_plugin is None:
+        accelerator = getattr(trainer, 'accelerator', None)
+        state = getattr(accelerator, 'state', None)
+        deepspeed_plugin = getattr(state, 'deepspeed_plugin', None)
+    if deepspeed_plugin is not None:
+        _enable_load_universal(getattr(deepspeed_plugin, 'deepspeed_config', None))
+        plugin_hf_ds_config = getattr(deepspeed_plugin, 'hf_ds_config', None)
+        _enable_load_universal(getattr(plugin_hf_ds_config, 'config', None))
+
+
+def prepare_deepspeed_elastic_config(args: 'TrainingArguments', state=None):
+    ds_config = args.deepspeed
+    if not ds_config:
+        return
+    if not isinstance(ds_config, dict):
+        logger.warning('DeepSpeed elastic expects args.deepspeed to be a dict, but got '
+                       f'{type(ds_config).__name__}. Skip elastic config.')
+        return
+
+    from deepspeed.elasticity import compute_elastic_config
+    from deepspeed.git_version_info import version as __version__
+
+    enable_deepspeed_load_universal(args)
+    elasticity = ds_config.get('elasticity') or {}
+    if not elasticity:
+        logger.warning_once('DeepSpeed elastic callback is enabled, but no `elasticity` section is found in '
+                            'the DeepSpeed config. Only `checkpoint.load_universal` is enabled.')
+        return
+    if elasticity.get('enabled') is False:
+        return
+
+    world_size = _get_deepspeed_elastic_world_size()
+    final_batch_size, _, micro_batch_size = compute_elastic_config(
+        ds_config=ds_config,
+        target_deepspeed_version=__version__,
+        world_size=world_size,
+    )
+    if world_size <= 0 or micro_batch_size <= 0:
+        raise ValueError('DeepSpeed elastic config produced invalid batch settings: '
+                         f'world_size={world_size}, micro_batch_size={micro_batch_size}.')
+    gradient_accu_steps = max(1, final_batch_size // (micro_batch_size * world_size))
+    args.per_device_train_batch_size = micro_batch_size
+    args.gradient_accumulation_steps = gradient_accu_steps
+    if state is not None:
+        state.train_batch_size = args.per_device_train_batch_size * max(1, args.n_gpu)
+    logger.info_once('DeepSpeed elastic config is enabled. '
+                     f'world_size: {world_size}, '
+                     f'per_device_train_batch_size: {args.per_device_train_batch_size}, '
+                     f'gradient_accumulation_steps: {args.gradient_accumulation_steps}')
 
 
 def can_return_loss(model: Module) -> bool:


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

1 修复transformers>=4.57.6 时 _sorted_checkpoints 不存在问题；
2 开启deepspeed 弹性开关时，改为在_init_deepspeed 中通过prepare_deepspeed_elastic_config 方法用deepspeed 中通过compute_elastic_config 计算出来的final_batch_size, micro_batch_size  覆盖实际配置的，因为弹性扩缩容需要保证总体batch_size 不变才不影响训练效果

## Experiment results

Paste your experiment result here(if needed).
