### PR TITLE
Fix NPU MindSpeed 0.16 compatibility issues

### DIFF
--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -983,8 +983,11 @@ class BaseMegatronTrainer(ABC):
         pass
 
     def _should_use_npu_generated_attention_mask(self, args) -> bool:
-        return (is_torch_npu_available() and args.task_type == 'causal_lm' and not args.padding_free
-                and getattr(args, 'attention_backend', None) != 'local' and getattr(args, 'use_flash_attn', False))
+        if not (is_torch_npu_available() and args.task_type == 'causal_lm' and not args.padding_free
+                and getattr(args, 'attention_backend', None) != 'local' and getattr(args, 'use_flash_attn', False)):
+            return False
+        gdn_model_types = {'qwen3_next', 'qwen3_5', 'qwen3_5_moe'}
+        return getattr(args, 'model_type', None) in gdn_model_types
 
     def _prepare_batch(self, data, vp_stage=None):
         return prepare_batch(self.args, data, vp_stage=vp_stage)

--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -22,7 +22,6 @@ from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelpe
 from modelscope import check_local_model_is_latest
 from packaging import version
 from pathlib import Path
-from transformers.utils import is_torch_npu_available
 from typing import Callable, Dict, List, Optional
 
 from swift.dataset import RowPreprocessor
@@ -981,13 +980,6 @@ class BaseMegatronTrainer(ABC):
     @abstractmethod
     def forward_step(self, data_iterator, model):
         pass
-
-    def _should_use_npu_generated_attention_mask(self, args) -> bool:
-        if not (is_torch_npu_available() and args.task_type == 'causal_lm' and not args.padding_free
-                and getattr(args, 'attention_backend', None) != 'local' and getattr(args, 'use_flash_attn', False)):
-            return False
-        gdn_model_types = {'qwen3_next', 'qwen3_5', 'qwen3_5_moe'}
-        return getattr(args, 'model_type', None) in gdn_model_types
 
     def _prepare_batch(self, data, vp_stage=None):
         return prepare_batch(self.args, data, vp_stage=vp_stage)

--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -365,7 +365,7 @@ def _prepare_npu_generated_attention_mask(batch, *, keep_attention_mask_2d: bool
     if keep_attention_mask_2d:
         attention_mask = batch.get('attention_mask')
         if 'attention_mask_2d' not in batch and attention_mask is not None:
-            batch['attention_mask_2d'] = (~attention_mask).sum(dim=(1, 2)) > 0
+            batch['attention_mask_2d'] = (attention_mask == 0).sum(dim=(1, 2)) > 0
     else:
         batch.pop('attention_mask_2d', None)
     batch['attention_mask'] = None

--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -347,13 +347,32 @@ def build_streaming_dataloader(args, dataset, collate_fn):
     return MegatronDataLoaderDispatcher(base_dataloader)
 
 
-def _should_use_npu_attention_mask(args) -> bool:
+_NPU_ATTENTION_MASK_2D_MODEL_TYPES = {'qwen3_5', 'qwen3_5_moe'}
+
+
+def _should_use_npu_generated_attention_mask(args) -> bool:
     from transformers.utils import is_torch_npu_available
-    if not (is_torch_npu_available() and args.task_type == 'causal_lm' and not args.padding_free
-            and getattr(args, 'attention_backend', None) != 'local' and getattr(args, 'use_flash_attn', False)):
+    if not is_torch_npu_available():
         return False
-    gdn_model_types = {'qwen3_next', 'qwen3_5', 'qwen3_5_moe'}
-    return getattr(args, 'model_type', None) in gdn_model_types
+    if args.task_type != 'causal_lm' or args.padding_free:
+        return False
+    if getattr(args, 'attention_backend', None) == 'local':
+        return False
+    return bool(getattr(args, 'use_flash_attn', False))
+
+
+def _should_keep_npu_attention_mask_2d(args) -> bool:
+    return getattr(args, 'model_type', None) in _NPU_ATTENTION_MASK_2D_MODEL_TYPES
+
+
+def _prepare_npu_generated_attention_mask(args, batch) -> None:
+    keep_attention_mask_2d = _should_keep_npu_attention_mask_2d(args)
+    attention_mask = batch.get('attention_mask')
+    if keep_attention_mask_2d and 'attention_mask_2d' not in batch and attention_mask is not None:
+        batch['attention_mask_2d'] = (~attention_mask).sum(dim=(1, 2)) > 0
+    elif not keep_attention_mask_2d:
+        batch.pop('attention_mask_2d', None)
+    batch['attention_mask'] = None
 
 
 def prepare_batch(args, data, vp_stage=None):
@@ -373,10 +392,8 @@ def prepare_batch(args, data, vp_stage=None):
     text_position_ids = batch.pop('text_position_ids', None)
     if text_position_ids is None:
         text_position_ids = batch.get('position_ids')
-    if _should_use_npu_attention_mask(args):
-        if 'attention_mask_2d' not in batch and batch.get('attention_mask') is not None:
-            batch['attention_mask_2d'] = (~batch['attention_mask']).sum(dim=(1, 2)) > 0
-        batch['attention_mask'] = None
+    if _should_use_npu_generated_attention_mask(args):
+        _prepare_npu_generated_attention_mask(args, batch)
     else:
         batch.pop('attention_mask_2d', None)
     if args.padding_free and text_position_ids is not None:

--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -349,8 +349,11 @@ def build_streaming_dataloader(args, dataset, collate_fn):
 
 def _should_use_npu_attention_mask(args) -> bool:
     from transformers.utils import is_torch_npu_available
-    return (is_torch_npu_available() and args.task_type == 'causal_lm' and not args.padding_free
-            and getattr(args, 'attention_backend', None) != 'local' and getattr(args, 'use_flash_attn', False))
+    if not (is_torch_npu_available() and args.task_type == 'causal_lm' and not args.padding_free
+            and getattr(args, 'attention_backend', None) != 'local' and getattr(args, 'use_flash_attn', False)):
+        return False
+    gdn_model_types = {'qwen3_next', 'qwen3_5', 'qwen3_5_moe'}
+    return getattr(args, 'model_type', None) in gdn_model_types
 
 
 def prepare_batch(args, data, vp_stage=None):

--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -361,16 +361,12 @@ def _should_use_npu_generated_attention_mask(args) -> bool:
     return bool(getattr(args, 'use_flash_attn', False))
 
 
-def _should_keep_npu_attention_mask_2d(args) -> bool:
-    return getattr(args, 'model_type', None) in _NPU_ATTENTION_MASK_2D_MODEL_TYPES
-
-
-def _prepare_npu_generated_attention_mask(args, batch) -> None:
-    keep_attention_mask_2d = _should_keep_npu_attention_mask_2d(args)
-    attention_mask = batch.get('attention_mask')
-    if keep_attention_mask_2d and 'attention_mask_2d' not in batch and attention_mask is not None:
-        batch['attention_mask_2d'] = (~attention_mask).sum(dim=(1, 2)) > 0
-    elif not keep_attention_mask_2d:
+def _prepare_npu_generated_attention_mask(batch, *, keep_attention_mask_2d: bool) -> None:
+    if keep_attention_mask_2d:
+        attention_mask = batch.get('attention_mask')
+        if 'attention_mask_2d' not in batch and attention_mask is not None:
+            batch['attention_mask_2d'] = (~attention_mask).sum(dim=(1, 2)) > 0
+    else:
         batch.pop('attention_mask_2d', None)
     batch['attention_mask'] = None
 
@@ -393,7 +389,8 @@ def prepare_batch(args, data, vp_stage=None):
     if text_position_ids is None:
         text_position_ids = batch.get('position_ids')
     if _should_use_npu_generated_attention_mask(args):
-        _prepare_npu_generated_attention_mask(args, batch)
+        _prepare_npu_generated_attention_mask(
+            batch, keep_attention_mask_2d=getattr(args, 'model_type', None) in _NPU_ATTENTION_MASK_2D_MODEL_TYPES)
     else:
         batch.pop('attention_mask_2d', None)
     if args.padding_free and text_position_ids is not None:

--- a/swift/megatron/utils/megatron_lm_utils.py
+++ b/swift/megatron/utils/megatron_lm_utils.py
@@ -734,7 +734,7 @@ def get_batch_on_this_cp_rank(args, batch: Dict[str, Any]):
         attention_mask = batch.get('attention_mask')
         if attention_mask is not None and attention_mask.ndim >= 4:
             attention_mask = split_cp_inputs(attention_mask, getattr(packed_seq_params, 'cu_seqlens_q', None), -1)
-            batch['attention_mask'] = split_cp_inputs(
-                attention_mask, getattr(packed_seq_params, 'cu_seqlens_q', None), -2)
+            batch['attention_mask'] = split_cp_inputs(attention_mask, getattr(packed_seq_params, 'cu_seqlens_q', None),
+                                                      -2)
 
     return batch

--- a/swift/megatron/utils/megatron_lm_utils.py
+++ b/swift/megatron/utils/megatron_lm_utils.py
@@ -733,7 +733,6 @@ def get_batch_on_this_cp_rank(args, batch: Dict[str, Any]):
                 batch[key] = split_cp_inputs(val, getattr(packed_seq_params, 'cu_seqlens_q', None), -1)
         attention_mask = batch.get('attention_mask')
         if is_torch_npu_available() and attention_mask is not None and attention_mask.ndim >= 4:
-            attention_mask = split_cp_inputs(attention_mask, getattr(packed_seq_params, 'cu_seqlens_q', None), -1)
             batch['attention_mask'] = split_cp_inputs(attention_mask, getattr(packed_seq_params, 'cu_seqlens_q', None),
                                                       -2)
 

--- a/swift/megatron/utils/megatron_lm_utils.py
+++ b/swift/megatron/utils/megatron_lm_utils.py
@@ -732,7 +732,7 @@ def get_batch_on_this_cp_rank(args, batch: Dict[str, Any]):
             if val is not None:
                 batch[key] = split_cp_inputs(val, getattr(packed_seq_params, 'cu_seqlens_q', None), -1)
         attention_mask = batch.get('attention_mask')
-        if attention_mask is not None and attention_mask.ndim >= 4:
+        if is_torch_npu_available() and attention_mask is not None and attention_mask.ndim >= 4:
             attention_mask = split_cp_inputs(attention_mask, getattr(packed_seq_params, 'cu_seqlens_q', None), -1)
             batch['attention_mask'] = split_cp_inputs(attention_mask, getattr(packed_seq_params, 'cu_seqlens_q', None),
                                                       -2)

--- a/swift/megatron/utils/megatron_lm_utils.py
+++ b/swift/megatron/utils/megatron_lm_utils.py
@@ -731,5 +731,10 @@ def get_batch_on_this_cp_rank(args, batch: Dict[str, Any]):
                 continue
             if val is not None:
                 batch[key] = split_cp_inputs(val, getattr(packed_seq_params, 'cu_seqlens_q', None), -1)
+        attention_mask = batch.get('attention_mask')
+        if attention_mask is not None and attention_mask.ndim >= 4:
+            attention_mask = split_cp_inputs(attention_mask, getattr(packed_seq_params, 'cu_seqlens_q', None), -1)
+            batch['attention_mask'] = split_cp_inputs(
+                attention_mask, getattr(packed_seq_params, 'cu_seqlens_q', None), -2)
 
     return batch

--- a/swift/model/chunk_gated_delta_rule.py
+++ b/swift/model/chunk_gated_delta_rule.py
@@ -4,13 +4,13 @@
 
 import torch
 import warnings
-from mindspeed.lite.ops.triton.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
-from mindspeed.lite.ops.triton.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local, chunk_fwd_o
-from mindspeed.lite.ops.triton.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
-from mindspeed.lite.ops.triton.cumsum import chunk_local_cumsum
-from mindspeed.lite.ops.triton.solve_tril import solve_tril
-from mindspeed.lite.ops.triton.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
-from mindspeed.lite.ops.triton.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
+from mindspeed.ops.triton.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
+from mindspeed.ops.triton.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local, chunk_fwd_o
+from mindspeed.ops.triton.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+from mindspeed.ops.triton.cumsum import chunk_local_cumsum
+from mindspeed.ops.triton.solve_tril import solve_tril
+from mindspeed.ops.triton.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
+from mindspeed.ops.triton.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
 from typing import Optional
 
 

--- a/swift/model/npu_patch/model.py
+++ b/swift/model/npu_patch/model.py
@@ -243,18 +243,34 @@ def npu_apply_rotary_pos_emb_qwen3_5(q, k, cos, sin, position_ids=None, unsqueez
     return q_embed, k_embed
 
 
-def _patch_transformers_flash_linear_attention_available(available: bool) -> None:
+_MISSING = object()
+_TRANSFORMERS_FLA_PROBE_MODULES = ('transformers.utils', 'transformers.utils.import_utils')
+
+
+def _patch_transformers_flash_linear_attention_available(available: bool) -> dict[str, object]:
 
     def _is_flash_linear_attention_available() -> bool:
         return available
 
-    transformers_utils = import_optional_module('transformers.utils')
-    if transformers_utils is not None:
-        setattr(transformers_utils, 'is_flash_linear_attention_available', _is_flash_linear_attention_available)
+    originals = {}
+    for module_name in _TRANSFORMERS_FLA_PROBE_MODULES:
+        module = import_optional_module(module_name)
+        if module is None:
+            continue
+        originals[module_name] = getattr(module, 'is_flash_linear_attention_available', _MISSING)
+        setattr(module, 'is_flash_linear_attention_available', _is_flash_linear_attention_available)
+    return originals
 
-    transformers_import_utils = import_optional_module('transformers.utils.import_utils')
-    if transformers_import_utils is not None:
-        setattr(transformers_import_utils, 'is_flash_linear_attention_available', _is_flash_linear_attention_available)
+
+def _restore_transformers_flash_linear_attention_available(originals: dict[str, object]) -> None:
+    for module_name, original in originals.items():
+        module = import_optional_module(module_name)
+        if module is None:
+            continue
+        if original is _MISSING:
+            delattr(module, 'is_flash_linear_attention_available')
+        else:
+            setattr(module, 'is_flash_linear_attention_available', original)
 
 
 def patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed() -> None:
@@ -515,12 +531,12 @@ def apply_patch() -> None:
 
     # Qwen3.5 GDN is patched to swift's embedded MindSpeed implementation below.
     # Skip Transformers' import-time FLA probe so FLA is not a hard dependency.
-    _patch_transformers_flash_linear_attention_available(False)
+    fla_probe_originals = _patch_transformers_flash_linear_attention_available(False)
     try:
         modeling_qwen3_5 = import_optional_module('transformers.models.qwen3_5.modeling_qwen3_5')
         modeling_qwen3_5_moe = import_optional_module('transformers.models.qwen3_5_moe.modeling_qwen3_5_moe')
     finally:
-        _patch_transformers_flash_linear_attention_available(True)
+        _restore_transformers_flash_linear_attention_available(fla_probe_originals)
     if modeling_qwen3_5 is not None:
         patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed()
 

--- a/swift/model/npu_patch/model.py
+++ b/swift/model/npu_patch/model.py
@@ -243,10 +243,10 @@ def npu_apply_rotary_pos_emb_qwen3_5(q, k, cos, sin, position_ids=None, unsqueez
     return q_embed, k_embed
 
 
-def _patch_transformers_flash_linear_attention_available() -> None:
+def _patch_transformers_flash_linear_attention_available(available: bool) -> None:
 
     def _is_flash_linear_attention_available() -> bool:
-        return True
+        return available
 
     transformers_utils = import_optional_module('transformers.utils')
     if transformers_utils is not None:
@@ -513,10 +513,15 @@ def apply_patch() -> None:
         ('qwen3_vl_moe', modeling_qwen3_vl_moe, QWEN3_VL_MOE_PATCHES, {}),
     ]
 
-    modeling_qwen3_5 = import_optional_module('transformers.models.qwen3_5.modeling_qwen3_5')
-    modeling_qwen3_5_moe = import_optional_module('transformers.models.qwen3_5_moe.modeling_qwen3_5_moe')
+    # Qwen3.5 GDN is patched to swift's embedded MindSpeed implementation below.
+    # Skip Transformers' import-time FLA probe so FLA is not a hard dependency.
+    _patch_transformers_flash_linear_attention_available(False)
+    try:
+        modeling_qwen3_5 = import_optional_module('transformers.models.qwen3_5.modeling_qwen3_5')
+        modeling_qwen3_5_moe = import_optional_module('transformers.models.qwen3_5_moe.modeling_qwen3_5_moe')
+    finally:
+        _patch_transformers_flash_linear_attention_available(True)
     if modeling_qwen3_5 is not None:
-        _patch_transformers_flash_linear_attention_available()
         patch_qwen3_5_chunk_gated_delta_rule_with_mindspeed()
 
     if modeling_qwen3_5 is not None:


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Summary

Adapt ms-swift Megatron NPU paths for MindSpeed 0.16, mainly covering Qwen3/Qwen3.5 SFT smoke compatibility, Qwen3.5 GDN import behavior, NPU generated attention mask routing, and CP attention mask splitting.

## Background

When upgrading MindSpeed/Megatron-LM from 0.15.x to 0.16, several previously working NPU Megatron smoke cases started failing:

- MindSpeed 0.16 moved the Triton GDN helper imports from `mindspeed.lite.ops.triton` to `mindspeed.ops.triton`.
- Qwen3.5 import could fail early in Transformers' FLA availability probe when FLA is absent or reports an invalid version, even though the NPU GDN path is patched to swift's embedded MindSpeed implementation.
- NPU flash/generated attention mask handling needed to distinguish standard Qwen3/Qwen3-MoE from Qwen3.5/Qwen3.5-MoE, because only Qwen3.5 GDN consumers need `attention_mask_2d`.
- CP with 4D attention mask needs the mask split on both sequence dimensions, otherwise MindSpeed 0.16 fused attention can hit mask shape errors.

## Changes

- Update Qwen3.5 chunk GDN Triton imports:
  - `mindspeed.lite.ops.triton.*` -> `mindspeed.ops.triton.*`

- Make Qwen3.5 NPU patch robust to missing/broken FLA during import:
  - Temporarily mark FLA unavailable before importing Qwen3.5/Qwen3.5-MoE Transformers modules.
  - Restore the existing patched availability behavior after import.
  - This avoids making FLA a hard import-time dependency for the NPU GDN path.

- Refine Megatron NPU attention mask handling:
  - Keep the NPU generated attention mask path gated by NPU + causal LM + non-padding-free + non-local attention + flash attention.
  - Only keep `attention_mask_2d` for `qwen3_5` and `qwen3_5_moe`.
  - Drop `attention_mask_2d` for ordinary Qwen3/Qwen3-MoE to avoid passing model-specific mask metadata into standard transformer blocks.

- Fix CP 4D attention mask slicing:
  - In CP mode, split 4D `attention_mask` along both key and query sequence dimensions.

- Remove stale duplicate helper from `BaseMegatronTrainer`:
  - Batch preparation now delegates to `swift.megatron.trainers.utils.prepare_batch()`, so the old base-class helper was no longer used.
