### PR TITLE
[BugFix] Fix IPC issue of async mode on AMD platform (ROCm)

### DIFF
--- a/swift/pipelines/infer/rollout.py
+++ b/swift/pipelines/infer/rollout.py
@@ -47,6 +47,7 @@ from swift.rlhf_trainers.utils import (VLLM_LORA_INT_ID, VLLM_LORA_NAME, VLLM_LO
                                        patch_vllm_moe_model_weight_loader, vllm_supports_lora_load_inplace)
 from swift.rollout import RolloutScheduler, multi_turns
 from swift.utils import (gc_collect, get_logger, get_seed, ipc_collect, is_vllm_ascend_available,
+                         is_torch_rocm, get_physical_device_count,
                          is_vllm_metax_available, synchronize)
 from ..base import SwiftPipeline
 
@@ -613,6 +614,32 @@ def _set_visible_devices_for_dp_rank(data_parallel_rank: int, tensor_parallel_si
     start = data_parallel_rank * tensor_parallel_size
     end = start + tensor_parallel_size
     selected = all_devices[start:end]
+
+    # ROCm: do NOT shrink the visibility mask to ``selected``. Restricting
+    # CUDA_VISIBLE_DEVICES (e.g. to "6,7") makes vLLM renumber those GPUs locally
+    # as cuda:0,1, so the device ids the rollout uses/reports diverge from the
+    # trainer's global numbering, and the cross-process RCCL weight-sync fails on
+    # ROCm with "invalid device ordinal" (the trainer can't resolve the rollout's
+    # GPUs). Instead keep EVERY physical GPU visible and only reorder the mask so
+    # the selected devices come first: vLLM still lands on the intended physical
+    # GPUs (cuda:0..tp-1 -> selected), while RCCL can resolve all peers (incl. the
+    # trainer's GPUs) by PCI bus id, so train<->rollout communication works.
+    if env_var == 'CUDA_VISIBLE_DEVICES' and is_torch_rocm():
+        total = get_physical_device_count()
+        sel_ints = []
+        for x in selected:
+            try:
+                sel_ints.append(int(x))
+            except ValueError:
+                sel_ints = []
+                break
+        if sel_ints and all(0 <= i < total for i in sel_ints):
+            rest = [i for i in range(total) if i not in sel_ints]
+            reordered = ','.join(str(i) for i in (sel_ints + rest))
+            os.environ['CUDA_VISIBLE_DEVICES'] = reordered
+            os.environ['HIP_VISIBLE_DEVICES'] = reordered
+            return
+
     os.environ[env_var] = ','.join(selected)
 
 

--- a/swift/pipelines/infer/rollout.py
+++ b/swift/pipelines/infer/rollout.py
@@ -46,9 +46,8 @@ from swift.rlhf_trainers.utils import (VLLM_LORA_INT_ID, VLLM_LORA_NAME, VLLM_LO
                                        finish_vllm_weight_reload, patch_vllm_load_adapter,
                                        patch_vllm_moe_model_weight_loader, vllm_supports_lora_load_inplace)
 from swift.rollout import RolloutScheduler, multi_turns
-from swift.utils import (gc_collect, get_logger, get_seed, ipc_collect, is_vllm_ascend_available,
-                         is_torch_rocm, get_physical_device_count,
-                         is_vllm_metax_available, synchronize)
+from swift.utils import (gc_collect, get_logger, get_physical_device_count, get_seed, ipc_collect, is_torch_rocm,
+                         is_vllm_ascend_available, is_vllm_metax_available, synchronize)
 from ..base import SwiftPipeline
 
 try:

--- a/swift/utils/__init__.py
+++ b/swift/utils/__init__.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
                               get_generative_reranker_logits, get_last_valid_indices, get_max_reserved_memory,
                               get_torch_device, init_process_group, ipc_collect, nanstd, safe_ddp_context,
                               set_default_ddp_config, set_device, synchronize, time_synchronize, to_device,
-                              to_float_dtype)
+			      get_physical_device_count, is_torch_rocm, to_float_dtype)
     from .transformers_utils import (activate_parameters, disable_deepspeed_zero3, find_all_linears, find_embedding,
                                      find_layers, find_norm, find_sub_module, freeze_parameters,
                                      get_cu_seqlens_from_position_ids, get_model_parameter_info,
@@ -61,7 +61,7 @@ else:
             'get_current_device', 'get_device', 'get_device_count', 'get_generative_reranker_logits',
             'get_last_valid_indices', 'get_max_reserved_memory', 'get_torch_device', 'init_process_group',
             'ipc_collect', 'safe_ddp_context', 'set_default_ddp_config', 'set_device', 'synchronize',
-            'time_synchronize', 'to_device', 'to_float_dtype', 'nanstd'
+            'time_synchronize', 'to_device', 'to_float_dtype', 'nanstd', 'get_physical_device_count', 'is_torch_rocm'
         ],
         'transformers_utils': [
             'activate_parameters', 'disable_deepspeed_zero3', 'find_all_linears', 'find_embedding', 'find_layers',

--- a/swift/utils/__init__.py
+++ b/swift/utils/__init__.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
                               get_generative_reranker_logits, get_last_valid_indices, get_max_reserved_memory,
                               get_torch_device, init_process_group, ipc_collect, nanstd, safe_ddp_context,
                               set_default_ddp_config, set_device, synchronize, time_synchronize, to_device,
-			      get_physical_device_count, is_torch_rocm, to_float_dtype)
+			                  get_physical_device_count, is_torch_rocm, to_float_dtype)
     from .transformers_utils import (activate_parameters, disable_deepspeed_zero3, find_all_linears, find_embedding,
                                      find_layers, find_norm, find_sub_module, freeze_parameters,
                                      get_cu_seqlens_from_position_ids, get_model_parameter_info,

--- a/swift/utils/__init__.py
+++ b/swift/utils/__init__.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
     from .torch_utils import (Serializer, check_shared_disk, disable_safe_ddp_context_use_barrier, empty_cache,
                               gc_collect, get_current_device, get_device, get_device_count,
                               get_generative_reranker_logits, get_last_valid_indices, get_max_reserved_memory,
-                              get_torch_device, init_process_group, ipc_collect, nanstd, safe_ddp_context,
-                              set_default_ddp_config, set_device, synchronize, time_synchronize, to_device,
-			                  get_physical_device_count, is_torch_rocm, to_float_dtype)
+                              get_physical_device_count, get_torch_device, init_process_group, ipc_collect,
+                              is_torch_rocm, nanstd, safe_ddp_context, set_default_ddp_config, set_device, synchronize,
+                              time_synchronize, to_device, to_float_dtype)
     from .transformers_utils import (activate_parameters, disable_deepspeed_zero3, find_all_linears, find_embedding,
                                      find_layers, find_norm, find_sub_module, freeze_parameters,
                                      get_cu_seqlens_from_position_ids, get_model_parameter_info,

--- a/swift/utils/torch_utils.py
+++ b/swift/utils/torch_utils.py
@@ -174,6 +174,75 @@ def get_device_count() -> int:
         return 0
 
 
+def is_torch_rocm() -> bool:
+    """True on an AMD ROCm/HIP torch build.
+
+    PyTorch on ROCm exposes devices through the ``torch.cuda.*`` API (hipify), so
+    ``is_torch_cuda_available()`` is True on ROCm too; the distinguishing signal is
+    a non-None ``torch.version.hip``.
+    """
+    return is_torch_cuda_available() and getattr(torch.version, 'hip', None) is not None
+
+
+def get_physical_device_count() -> int:
+    """Number of physical accelerators, ignoring ``*_VISIBLE_DEVICES`` masks.
+
+    Unlike :func:`get_device_count` (which honors CUDA/HIP_VISIBLE_DEVICES via the
+    runtime), this queries the driver/topology layer, so a process that inherited a
+    restricted mask can still discover the full device set. It still respects the
+    container's device exposure (``--gpus`` / ``NVIDIA_VISIBLE_DEVICES`` / passed
+    ``/dev/dri`` + ``/dev/kfd``). Falls back to the mask-dependent runtime count if
+    the driver query is unavailable.
+    """
+    import glob
+
+    if is_torch_rocm():
+        # ROCm: the kfd topology lists one node per device; GPU nodes have
+        # ``simd_count > 0`` (CPU/host nodes have 0). Reading sysfs neither
+        # initializes HIP nor is affected by the visibility mask.
+        count = 0
+        for prop in glob.glob('/sys/class/kfd/kfd/topology/nodes/*/properties'):
+            try:
+                with open(prop) as f:
+                    for line in f:
+                        if line.startswith('simd_count'):
+                            if int(line.split()[1]) > 0:
+                                count += 1
+                            break
+            except Exception:
+                continue
+        if count > 0:
+            return count
+    elif is_torch_cuda_available():
+        # NVIDIA: NVML/procfs/nvidia-smi enumerate at the driver level and are not
+        # filtered by CUDA_VISIBLE_DEVICES (only by container-level exposure).
+        try:
+            import pynvml
+            pynvml.nvmlInit()
+            try:
+                count = pynvml.nvmlDeviceGetCount()
+            finally:
+                pynvml.nvmlShutdown()
+            if count > 0:
+                return count
+        except Exception:
+            pass
+        count = len(glob.glob('/proc/driver/nvidia/gpus/*'))
+        if count > 0:
+            return count
+        try:
+            import subprocess
+            out = subprocess.check_output(['nvidia-smi', '--query-gpu=index', '--format=csv,noheader'],
+                                          stderr=subprocess.DEVNULL)
+            count = len([line for line in out.decode().splitlines() if line.strip()])
+            if count > 0:
+                return count
+        except Exception:
+            pass
+
+    return get_device_count()
+
+
 def empty_cache():
     if is_torch_npu_available():
         torch.npu.empty_cache()

--- a/swift/utils/torch_utils.py
+++ b/swift/utils/torch_utils.py
@@ -233,7 +233,8 @@ def get_physical_device_count() -> int:
         try:
             import subprocess
             out = subprocess.check_output(['nvidia-smi', '--query-gpu=index', '--format=csv,noheader'],
-                                          stderr=subprocess.DEVNULL, timeout=5)
+                                          stderr=subprocess.DEVNULL,
+                                          timeout=5)
             count = len([line for line in out.decode().splitlines() if line.strip()])
             if count > 0:
                 return count

--- a/swift/utils/torch_utils.py
+++ b/swift/utils/torch_utils.py
@@ -233,7 +233,7 @@ def get_physical_device_count() -> int:
         try:
             import subprocess
             out = subprocess.check_output(['nvidia-smi', '--query-gpu=index', '--format=csv,noheader'],
-                                          stderr=subprocess.DEVNULL)
+                                          stderr=subprocess.DEVNULL, timeout=5)
             count = len([line for line in out.decode().splitlines() if line.strip()])
             if count > 0:
                 return count


### PR DESCRIPTION
Fixes cross-process RCCL weight synchronization failing on AMD ROCm when the vLLM rollout server and the trainer run as separate processes on disjoint GPUs (server/disaggregated `vllm_mode=server`, optionally in separate containers). On such setups the weight sync died with `HIP error: invalid device ordinal`.

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

### Motivation / Root cause
For DP placement, `_set_visible_devices_for_dp_rank` restricts `CUDA_VISIBLE_DEVICES` to the rollout's device slice (e.g. `3,4,6,7`). On ROCm this makes vLLM renumber those GPUs **locally** (`3,4,6,7 -> cuda:0,1,2,3`), so the device ids the rollout uses/reports diverge from the trainer's **global** numbering. When the trainer and rollout build a cross-process RCCL communicator (`init_communicator` / `update_flattened_params`), RCCL can no longer resolve the peer GPUs and aborts with `invalid device ordinal`. This does not happen on CUDA because `cudaIpcOpenMemHandle` resolves peers at the driver level even when they are outside the importing process's `CUDA_VISIBLE_DEVICES`; ROCm (`hipIpcOpenMemHandle`) requires the peer GPU to be visible/consistently numbered.

### Changes
- `swift/pipelines/infer/rollout.py` — `_set_visible_devices_for_dp_rank`: on ROCm, do **not** shrink the visibility mask. Keep every physical GPU visible and only **reorder** the mask so the selected devices come first  (`3,4,6,7 -> 3,4,6,7,0,1,2,5`). vLLM still lands on the intended physical GPUs, while RCCL resolves all peers (including the trainer's GPUs) by PCI bus id. Non-ROCm / NPU paths are unchanged.
- `swift/utils/torch_utils.py` — add two helpers:
  - `is_torch_rocm()`: detects an AMD ROCm/HIP torch build (`is_torch_cuda_available()` + non-None `torch.version.hip`).
  - `get_physical_device_count()`: physical accelerator count that **ignores** `*_VISIBLE_DEVICES` masks (needed because a process may inherit a restricted mask). ROCm reads the kfd topology (`/sys/class/kfd/.../properties`, `simd_count > 0`); NVIDIA tries NVML → `/proc/driver/nvidia/gpus/*` → `nvidia-smi`; falls back to the mask-dependent `get_device_count()`.
- `swift/utils/__init__.py` — export the two new helpers.

### Behavior & compatibility
- Only affects ROCm rollout device assignment; CUDA/NPU behavior is unchanged.
- Works for `vllm_data_parallel_size > 1`: each DP replica reorders with its own
  slice first, so replicas land on distinct physical GPUs while all stay visible
  (each rollout worker process has its own `os.environ`, so the differing masks
  do not interfere).


## Experiment results

Verified on an 8×MI308 (gfx942) node, ROCm 7.x, with Megatron GRPO (`vllm_mode=server`) and the vLLM rollout in a separate container (`--network host --ipc host`):
- rollout `CUDA_VISIBLE_DEVICES=3,4,6,7`, `tp=2`, `dp=2` → both replicas land on physical 3,4 and 6,7 with all 8 GPUs visible;
- trainer `CUDA_VISIBLE_DEVICES=0,1,2,5`;
- `init_communicator` / `update_flattened_params` / `/infer` all succeed, no `invalid device ordinal` error, and training runs with coherent rollouts. Before the change the same setup failed at `init_communicator` with `invalid device ordinal`.
