### PR TITLE
docs: fix GRPO pseudocode answer

### DIFF
--- a/docs/source/Instruction/GRPO/GetStarted/GRPO.md
+++ b/docs/source/Instruction/GRPO/GetStarted/GRPO.md
@@ -37,10 +37,10 @@ completions = rollout_function(
 )
 """
 completions = [
-    (completion 1) "The larger number is 9.11...",
-    (completion 2) "9.9 is bigger than...",
+    (completion 1) "The larger number is 9.9...",
+    (completion 2) "9.11 is bigger than...",
     ...
-    (completion 8) "After calculation, 9.11..."
+    (completion 8) "After calculation, 9.9..."
 ]
 """
 
@@ -48,7 +48,7 @@ completions = [
 # Evaluate generated completions using reward model
 rewards = reward_function(
     completions=completions,
-    ground_truth="9.11"  # Expected correct answer
+    ground_truth="9.9"  # Expected correct answer
 )
 """
 rewards = [

--- a/docs/source_en/Instruction/GRPO/GetStarted/GRPO.md
+++ b/docs/source_en/Instruction/GRPO/GetStarted/GRPO.md
@@ -36,10 +36,10 @@ completions = rollout_function(
 )
 """
 completions = [
-    (completion 1) "The larger number is 9.11...",
-    (completion 2) "9.9 is bigger than...",
+    (completion 1) "The larger number is 9.9...",
+    (completion 2) "9.11 is bigger than...",
     ...
-    (completion 8) "After calculation, 9.11..."
+    (completion 8) "After calculation, 9.9..."
 ]
 """
 
@@ -47,7 +47,7 @@ completions = [
 # Evaluate generated completions using reward model
 rewards = reward_function(
     completions=completions,
-    ground_truth="9.11"  # Expected correct answer
+    ground_truth="9.9"  # Expected correct answer
 )
 """
 rewards = [


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR fixes the GRPO pseudocode example in the documentation.

The previous example asks which number is bigger between `9.11` and `9.9`, but marks `9.11` as the expected correct answer. Since `9.9` is larger, this PR updates both the English and Chinese GRPO docs to use `9.9` as the ground truth and adjusts the sample completions accordingly.

Fixes #9596.

## Experiment results

Documentation-only change. Verified the updated pseudocode is internally consistent in both English and Chinese docs.