### PR TITLE
Fix: MiniCPM-V 4.6 training hangs on text-only samples with DeepSpeed

### DIFF
--- a/swift/template/templates/minicpm.py
+++ b/swift/template/templates/minicpm.py
@@ -9,7 +9,7 @@ from packaging import version
 from torch import nn
 from typing import Any, Dict, List, Literal, Optional
 
-from swift.utils import get_env_args, get_packed_seq_params
+from swift.utils import get_env_args, get_packed_seq_params, is_deepspeed_enabled
 from ..base import Template
 from ..constant import LLMTemplateType, MLLMTemplateType
 from ..register import TemplateMeta, register_template
@@ -673,6 +673,26 @@ class MiniCPMV4_6Template(Template):
         encoded['labels'] = labels
         encoded['loss_scale'] = loss_scale
         return encoded
+
+    def _post_encode(self, model: nn.Module, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.is_training:
+            return inputs
+
+        pixel_values = inputs.get('pixel_values')
+        pixel_values_videos = inputs.get('pixel_values_videos')
+        if pixel_values is None and pixel_values_videos is None and is_deepspeed_enabled():
+            input_ids = inputs['input_ids']
+            base_model = self.get_base_model(model)
+            inputs_embeds = base_model.get_input_embeddings()(input_ids)
+            patch_size = base_model.config.vision_config.patch_size
+            dummy_pv = torch.zeros(
+                1, 3, 4 * patch_size, 4 * patch_size, device=inputs_embeds.device, dtype=base_model.vision_tower.dtype)
+            dummy_ts = torch.tensor([[4, 4]], device=inputs_embeds.device, dtype=torch.int32)
+            vision_output = base_model.get_image_features(dummy_pv, dummy_ts, downsample_mode=self.downsample_mode)
+            image_embeds = torch.cat(vision_output.pooler_output, dim=0)
+            inputs_embeds = inputs_embeds + image_embeds.mean() * 0.
+            return {'inputs_embeds': inputs_embeds}
+        return inputs
 
     def _data_collator_mm_data(self, batch: List[Dict[str, Any]]) -> Dict[str, Any]:
         res = {}


### PR DESCRIPTION
# Fix: MiniCPM-V 4.6 training hangs on text-only samples with DeepSpeed

## Problem

When training MiniCPM-V 4.6 with DeepSpeed ZeRO, the training process hangs if the dataset contains pure-text samples (no image/video). This is because:

- For text-only samples, `MiniCPMV4_6Model.forward()` skips the vision encoder (`vision_tower` + `merger`) entirely since `pixel_values` and `pixel_values_videos` are both `None`.
- Under DeepSpeed ZeRO, parameters are sharded across GPUs and only gathered on-demand via all-gather when a computation touches them.
- When one GPU processes a text-only sample (no vision compute) while another processes an image sample (needs vision parameters), the all-gather synchronization deadlocks — one side never triggers the gather that the other side is waiting for.

## Solution

Add a `_post_encode` method to `MiniCPMV4_6Template` that detects text-only samples under DeepSpeed and runs a minimal dummy image through the full vision pipeline (`vision_tower` → `merger`). The dummy features are then zeroed out via `image_embeds.mean() * 0.` and added to the text embeddings, which:

- Forces DeepSpeed to all-gather all vision model parameters, preventing the deadlock
- Is mathematically a no-op (adds zero), so it does not affect training results

The dummy image uses the smallest valid patch grid (`target_sizes=[[4, 4]]`), which works for both 16x and 4x downsample modes, producing only 1 visual token in 16x mode — negligible compute overhead.

## Changes

- `swift/template/templates/minicpm.py`: Add `_post_encode` to `MiniCPMV4_6Template`, add `is_deepspeed_enabled` import