### PR TITLE
fix(dataset): skip empty rejected_messages instead of crashing

### DIFF
--- a/swift/dataset/preprocessor/core.py
+++ b/swift/dataset/preprocessor/core.py
@@ -513,8 +513,8 @@ class MessagesPreprocessor(RowPreprocessor):
 
     def preprocess(self, row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         if 'rejected_messages' in row:
-            row['rejected_messages'] = MessagesPreprocessor.preprocess(
-                self, {'messages': row['rejected_messages']})['messages']
+            rejected = MessagesPreprocessor.preprocess(self, {'messages': row['rejected_messages']})
+            row['rejected_messages'] = rejected['messages'] if rejected else None
         messages = row['messages']
         if self.inner_key is not None:
             messages = messages[self.inner_key]

--- a/tests/general/test_data_preprocess.py
+++ b/tests/general/test_data_preprocess.py
@@ -1,6 +1,6 @@
 import unittest
 
-from swift.dataset import EncodePreprocessor, PackingDataset, load_dataset
+from swift.dataset import EncodePreprocessor, MessagesPreprocessor, PackingDataset, load_dataset
 from swift.model import get_processor
 from swift.template import get_template
 
@@ -145,6 +145,62 @@ class TestDataPreprocess(unittest.TestCase):
         self.assertGreater(len(packed), 0)
         self.assertIn('input_ids', packed[0])
         self.assertIn('labels', packed[0])
+
+
+class TestRejectedMessagesPreprocess(unittest.TestCase):
+    """MessagesPreprocessor handling of rejected_messages (no model required)."""
+
+    def test_empty_rejected_messages_does_not_crash(self):
+        """A DPO row whose rejected_messages repair to empty must not crash.
+
+        The recursive preprocess() call returns None when rejected_messages is
+        empty (the same graceful-skip path used for the main messages list), so
+        subscripting it with ['messages'] raised TypeError and aborted the whole
+        dataset map. Downstream already treats rejected_messages is None as
+        'no rejected', so the row should fall back to None instead.
+        """
+        row = {
+            'messages': [
+                {
+                    'role': 'user',
+                    'content': 'Q'
+                },
+                {
+                    'role': 'assistant',
+                    'content': 'good'
+                },
+            ],
+            'rejected_messages': [],
+        }
+        result = MessagesPreprocessor().preprocess(row)
+        self.assertIsNotNone(result)
+        self.assertIsNone(result['rejected_messages'])
+
+    def test_valid_rejected_messages_preserved(self):
+        row = {
+            'messages': [
+                {
+                    'role': 'user',
+                    'content': 'Q'
+                },
+                {
+                    'role': 'assistant',
+                    'content': 'good'
+                },
+            ],
+            'rejected_messages': [
+                {
+                    'role': 'user',
+                    'content': 'Q'
+                },
+                {
+                    'role': 'assistant',
+                    'content': 'bad'
+                },
+            ],
+        }
+        result = MessagesPreprocessor().preprocess(row)
+        self.assertEqual(result['rejected_messages'][-1]['content'], 'bad')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information

`MessagesPreprocessor.preprocess` crashes with `TypeError: 'NoneType' object is not subscriptable` when a DPO row carries a `rejected_messages` field that ends up empty.

The recursive call reuses `preprocess` to normalize `rejected_messages`:

```python
row['rejected_messages'] = MessagesPreprocessor.preprocess(
    self, {'messages': row['rejected_messages']})['messages']
```

But `preprocess` returns `None` whenever the message list is empty (or a bare string) after `repair_messages` — that's the same graceful-skip path the main `messages` list relies on. So the unconditional `['messages']` subscript blows up on `None`, and because preprocessing runs inside `dataset.map`, a single such row aborts the whole dataset load instead of being dropped.

This is reachable with ordinary community DPO data: a row whose `rejected` column maps to an empty list, or repairs down to nothing.

Fix: keep the recursive result and fall back to `None` when it's empty, mirroring how the rest of the pipeline skips bad rows. Downstream already treats `rejected_messages is None` as "no rejected" (`template_inputs.py` gates on `inputs.get('rejected_messages') is not None`), so this needs no further handling.

Added two regression tests in `tests/general/test_data_preprocess.py` (no model required): an empty `rejected_messages` now yields `None` instead of crashing, and a valid one is still preserved. The first test fails on `main` and passes with this change.

Note: this touches the same statement as my open #9611 (which adds `system` propagation to the recursive call). The two changes are orthogonal — this one only guards the `None` subscript — and combine cleanly; whichever lands first leaves a trivial rebase for the other.
