### PR TITLE
[docs] fix wrong opsd teacher server script

### DIFF
--- a/examples/megatron/rlhf/gkd/teacher_server.sh
+++ b/examples/megatron/rlhf/gkd/teacher_server.sh
@@ -44,11 +44,10 @@ megatron rlhf \
     --max_completion_length $max_completion_length \
     --attention_backend flash \
     --use_vllm true \
-    --vllm_mode colocate \
-    --vllm_gpu_memory_utilization 0.5 \
-    --vllm_tensor_parallel_size 1 \
-    --vllm_max_model_len $max_total_length \
-    --sleep_level 1 \
+    --vllm_mode server \
+    --vllm_server_host 127.0.0.1 \
+    --vllm_server_port 8000 \
+    --vllm_server_timeout 600 \
     --finetune \
     --no_save_optim \
     --no_save_rng \

--- a/examples/train/rlhf/gkd/teacher_server.sh
+++ b/examples/train/rlhf/gkd/teacher_server.sh
@@ -25,11 +25,10 @@ swift rlhf \
     --teacher_model_server http://localhost:8000 \
     --gkd_logits_topk $top_k \
     --use_vllm true \
-    --vllm_mode colocate \
-    --vllm_gpu_memory_utilization 0.5 \
-    --vllm_tensor_parallel_size 1 \
-    --vllm_max_model_len $max_total_length \
-    --sleep_level 0 \
+    --vllm_mode server \
+    --vllm_server_host 127.0.0.1 \
+    --vllm_server_port 8000 \
+    --vllm_server_timeout 600 \
     --dataset 'modelscope/gsm8k' \
     --lmbda 1 \
     --beta 0.5 \


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix incorrect GKD teacher server example scripts.

This PR updates the GKD `teacher_server.sh` examples to use vLLM server mode instead of colocate mode when a teacher model server is expected to be started separately. The scripts now configure `vllm_server_host`, `vllm_server_port`, and `vllm_server_timeout` consistently with the documented teacher server setup.

Updated files:
- `examples/train/rlhf/gkd/teacher_server.sh`
- `examples/megatron/rlhf/gkd/teacher_server.sh`

## Experiment results

Not needed. This PR only updates example scripts.