### PR TITLE
feat: add NPU installation extra

### DIFF
--- a/.dev_scripts/ci_container_test.sh
+++ b/.dev_scripts/ci_container_test.sh
@@ -201,8 +201,8 @@ if [ "$MODELSCOPE_SDK_DEBUG" == "True" ]; then
         uv pip install .
         echo "NPU CI skips auto_gptq because it is a CUDA/GPTQ optional dependency."
         uv pip install bitsandbytes deepspeed -U
-        if [ -f requirements/npu.txt ]; then
-            uv pip install -r requirements/npu.txt
+        if [ -f requirements/npu_ci.txt ]; then
+            uv pip install -r requirements/npu_ci.txt
         fi
         ensure_npu_runtime
         report_npu_runtime

--- a/docs/source/BestPractices/NPU-support.md
+++ b/docs/source/BestPractices/NPU-support.md
@@ -174,15 +174,22 @@ source /usr/local/Ascend/ascend-toolkit/set_env.sh
 
 # 设置 pip 全局镜像（可选，加速下载）
 pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/
-pip install ms-swift -U
+
+# 安装 ms-swift NPU extra（二选一）
+# aarch64 Ascend
+pip install "ms-swift[npu]"
+
+# x86_64 机器建议使用 PyTorch CPU wheels，避免安装 CUDA 相关 nvidia-* 依赖
+# pip install "ms-swift[npu]" --extra-index-url https://download.pytorch.org/whl/cpu
 
 # 使用源码安装
 git clone https://github.com/modelscope/ms-swift.git
 cd ms-swift
-pip install -e .
+pip install -e ".[npu]"
 
-# 安装 torch_npu
-pip install torch_npu==2.9.0 decorator
+# x86_64 源码安装同样建议指定 PyTorch CPU wheels
+# pip install -e ".[npu]" --extra-index-url https://download.pytorch.org/whl/cpu
+
 # 如果你想要使用 deepspeed（控制显存占用，训练速度会有一定下降）
 pip install deepspeed
 

--- a/docs/source_en/BestPractices/NPU-support.md
+++ b/docs/source_en/BestPractices/NPU-support.md
@@ -176,15 +176,22 @@ source /usr/local/Ascend/ascend-toolkit/set_env.sh
 
 # Set the global pip mirror (optional, speeds up downloads)
 pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/
-pip install ms-swift -U
+
+# Install the ms-swift NPU extra (choose one)
+# aarch64 Ascend
+pip install "ms-swift[npu]"
+
+# On x86_64, use PyTorch CPU wheels to avoid CUDA-related nvidia-* dependencies
+# pip install "ms-swift[npu]" --extra-index-url https://download.pytorch.org/whl/cpu
 
 # Install from source
 git clone https://github.com/modelscope/ms-swift.git
 cd ms-swift
-pip install -e .
+pip install -e ".[npu]"
 
-# Install torch_npu
-pip install torch_npu==2.9.0 decorator
+# On x86_64 source installs, use PyTorch CPU wheels as well
+# pip install -e ".[npu]" --extra-index-url https://download.pytorch.org/whl/cpu
+
 # If you want to use deepspeed (to reduce memory usage, with some speed overhead)
 pip install deepspeed
 

--- a/requirements/npu.txt
+++ b/requirements/npu.txt
@@ -1,8 +1,8 @@
 decorator
 torch==2.9.0+cpu; platform_machine == "x86_64"
-torchaudio==2.9.0+cpu; platform_machine == "x86_64"
-torchvision==0.24.0+cpu; platform_machine == "x86_64"
 torch==2.9.0; platform_machine == "aarch64"
-torchaudio==2.9.0; platform_machine == "aarch64"
-torchvision==0.24.0; platform_machine == "aarch64"
 torch-npu==2.9.0.post2
+torchaudio==2.9.0+cpu; platform_machine == "x86_64"
+torchaudio==2.9.0; platform_machine == "aarch64"
+torchvision==0.24.0+cpu; platform_machine == "x86_64"
+torchvision==0.24.0; platform_machine == "aarch64"

--- a/requirements/npu.txt
+++ b/requirements/npu.txt
@@ -1,3 +1,8 @@
 decorator
-torchaudio==2.7.1
-torchvision==0.22.1
+torch==2.9.0+cpu; platform_machine == "x86_64"
+torchaudio==2.9.0+cpu; platform_machine == "x86_64"
+torchvision==0.24.0+cpu; platform_machine == "x86_64"
+torch==2.9.0; platform_machine == "aarch64"
+torchaudio==2.9.0; platform_machine == "aarch64"
+torchvision==0.24.0; platform_machine == "aarch64"
+torch-npu==2.9.0.post2

--- a/requirements/npu_ci.txt
+++ b/requirements/npu_ci.txt
@@ -1,0 +1,3 @@
+decorator
+torchaudio==2.7.1
+torchvision==0.22.1

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ if __name__ == '__main__':
     all_requires = []
     extra_requires['megatron'], _ = parse_requirements('requirements/megatron.txt')
     extra_requires['eval'], _ = parse_requirements('requirements/eval.txt')
+    extra_requires['npu'], _ = parse_requirements('requirements/npu.txt')
     extra_requires['swanlab'], _ = parse_requirements('requirements/swanlab.txt')
     extra_requires['ray'], _ = parse_requirements('requirements/ray.txt')
     all_requires.extend(install_requires)


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR adds an `npu` install extra for `ms-swift`, so users can install NPU-related dependencies directly via pip extras, e.g. `pip install "ms-swift[npu]"` or `pip install -e ".[npu]"`.

## What’s changed
- Add `npu` extra in `setup.py`, mapped to `requirements/npu.txt`
- Update `requirements/npu.txt` to include NPU-related dependencies with platform-specific Torch packages:
  - `x86_64`: CPU wheels for `torch`, `torchaudio`, `torchvision`
  - `aarch64`: standard wheels for `torch`, `torchaudio`, `torchvision`
  - `torch-npu==2.9.0.post2`
- Add `requirements/npu_ci.txt` for CI-only dependency installation
- Update NPU CI script to install from `requirements/npu_ci.txt` instead of `requirements/npu.txt`
- Update both Chinese and English NPU documentation to recommend:
  - `pip install "ms-swift[npu]"`
  - `pip install -e ".[npu]"`
  - optional CPU wheel index usage on `x86_64` to avoid CUDA-related `nvidia-*` dependencies

## Why
Previously, NPU environment setup required users to install dependencies manually. This change provides a more standard and convenient installation path, while also separating runtime installation requirements from CI requirements.

## Notes
- `requirements/npu.txt` is now intended for user-facing NPU installation
- `requirements/npu_ci.txt` keeps CI dependency installation lightweight and compatible with the existing NPU CI workflow
- Documentation is updated in both `docs/source/BestPractices/NPU-support.md` and `docs/source_en/BestPractices/NPU-support.md`

## Impact
- Improves usability of NPU environment setup
- Makes NPU installation more consistent with other optional extras
- Reduces accidental installation of CUDA-related dependencies on `x86_64` machines
