### PR TITLE
Adjust the order to avoid errors

### DIFF
--- a/swift/rlhf_trainers/utils.py
+++ b/swift/rlhf_trainers/utils.py
@@ -579,10 +579,10 @@ def profiling_context(trainer, name: str):
     elif hasattr(trainer, 'is_main_process'):
         is_main_process = trainer.is_main_process
 
-    if 'wandb' in trainer.args.report_to and wandb.run is not None and is_main_process:
+    if 'wandb' in trainer.args.report_to and is_main_process and wandb.run is not None:
         wandb.log(profiling_metrics, commit=False)
 
-    if 'swanlab' in trainer.args.report_to and swanlab_get_run() is not None and is_main_process:
+    if 'swanlab' in trainer.args.report_to and is_main_process and swanlab_get_run() is not None:
         swanlab.log(profiling_metrics)
 
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Adjusted the order of conditions within the `profiling_context` in `rlhf_trainers/utils.py` to prevent errors during multi-process training.

## Experiment results

Paste your experiment result here(if needed).
