### PR TITLE
feat(megatron): expose optimizer_cuda_graph for the optimizer

### DIFF
--- a/docs/source/Megatron-SWIFT/Command-line-parameters.md
+++ b/docs/source/Megatron-SWIFT/Command-line-parameters.md
@@ -38,6 +38,7 @@
 - 🔥optimizer_cpu_offload: 将优化器状态卸载到 CPU，例如设置：`--use_precision_aware_optimizer true --optimizer_cpu_offload true --optimizer_offload_fraction 0.7`。默认为False。
   - 该参数可以显著降低显存占用（但增加内存占用）。若global_batch_size较大，则对训练速度的影响不大。
 - 🔥optimizer_offload_fraction: 卸载到 CPU 的优化器状态所占比例。默认为1.。
+- optimizer_cuda_graph: 是否为优化器步骤启用 CUDA 计算图，传递给 Megatron 的 `--optimizer-cuda-graph`。默认为False。
 - use_precision_aware_optimizer: 使用 TransformerEngine 中的精度感知优化器，该优化器允许将主参数和优化器状态设置为较低精度，例如 fp16 和 fp8。
 - main_grads_dtype: 启用 use_precision_aware_optimizer 时主梯度的 dtype。可选为'fp32', 'bf16'。默认为'fp32'。
 - main_params_dtype: 启用 use_precision_aware_optimizer 时主参数的 dtype。可选为'fp32', 'fp16'。默认为'fp32'。

--- a/docs/source_en/Megatron-SWIFT/Command-line-parameters.md
+++ b/docs/source_en/Megatron-SWIFT/Command-line-parameters.md
@@ -40,6 +40,7 @@
 - 🔥optimizer_cpu_offload: Offloads optimizer states to the CPU. For example, set: `--use_precision_aware_optimizer true --optimizer_cpu_offload true --optimizer_offload_fraction 0.7`. Defaults to `False`.
   - This parameter can significantly reduce GPU memory usage (at the cost of increased CPU memory consumption). When the `global_batch_size` is large, its impact on training speed is minimal.
 - 🔥optimizer_offload_fraction: The fraction of the optimizer state to offload to CPU. Default is `1.0`.
+- optimizer_cuda_graph: Whether to enable CUDA graph for the optimizer step, forwarded to Megatron's `--optimizer-cuda-graph`. Default is `False`.
 - use_precision_aware_optimizer: Use the precision-aware optimizer in TransformerEngine, which allows setting the main parameters and optimizer states to lower precision, such as fp16 and fp8.
 - main_grads_dtype: The dtype of main gradients when use_precision_aware_optimizer is enabled. Options are 'fp32' and 'bf16'. Default is 'fp32'.
 - main_params_dtype: The dtype of main parameters when use_precision_aware_optimizer is enabled. Options are 'fp32' and 'fp16'. Default is 'fp32'.

--- a/swift/megatron/arguments/megatron_args.py
+++ b/swift/megatron/arguments/megatron_args.py
@@ -500,6 +500,7 @@ class MegatronArguments(RLHFMegatronArgumentsMixin, MegatronTunerMixin):
     optimizer: Literal['adam', 'sgd', 'muon', 'dist_muon'] = 'adam'
     optimizer_cpu_offload: bool = False
     optimizer_offload_fraction: float = 1.
+    optimizer_cuda_graph: bool = False
     use_precision_aware_optimizer: bool = False
     main_grads_dtype: Literal['fp32', 'bf16'] = 'fp32'
     main_params_dtype: Literal['fp32', 'fp16'] = 'fp32'


### PR DESCRIPTION
## What

Megatron-SWIFT's `MegatronArguments` exposes several optimizer-level toggles (`optimizer_cpu_offload`, `optimizer_offload_fraction`, `use_precision_aware_optimizer`, …) but is **missing `optimizer_cuda_graph`**, which Megatron-Core supports:

- Megatron CLI: `--optimizer-cuda-graph` (`megatron/training/arguments.py`, `action='store_true'`)
- Megatron config: `OptimizerConfig.optimizer_cuda_graph: bool = False` (`megatron/core/optimizer/optimizer_config.py`) — *"If true, enables CUDA graph for optimizer step."*

`optimizer_cuda_graph` CUDA-graphs the optimizer step, reducing per-step CPU launch overhead. Without it exposed, recipes that want the CUDA-graphed optimizer step cannot enable it through Megatron-SWIFT.

## Change

- Add `optimizer_cuda_graph: bool = False` to `MegatronArguments`, alongside the other `optimizer_*` toggles (matching Megatron's `OptimizerConfig` field name and default).
- Document it in the zh/en command-line-parameters docs.

No forwarding code is needed: `swift/megatron/trainers/base.py` builds the Megatron `OptimizerConfig` from `MegatronArguments` via a field-name-keyed comprehension over `dataclasses.fields(config_cls)` (`{f.name: getattr(args, f.name) for f in dataclasses.fields(config_cls) if hasattr(args, f.name) ...}`), so exposing a field whose name matches `OptimizerConfig.optimizer_cuda_graph` is sufficient for it to be forwarded — exactly like the existing optimizer toggles.

## Notes

Typed as `bool` (default `False`) to mirror Megatron's own CLI (`store_true`) and `OptimizerConfig` field default. Verified against current `main`: the field is absent in Megatron-SWIFT (`grep -r optimizer_cuda_graph` → 0 refs) while present in Megatron-Core, and the ms-swift attribute name matches Megatron's `OptimizerConfig` field name exactly (so the forwarding comprehension picks it up with no additional code).
