### PR TITLE
Avoid overwriting AutoTP-related settings when using DeepSpeed ​​configuration files.

### DIFF
--- a/swift/arguments/sft_args.py
+++ b/swift/arguments/sft_args.py
@@ -275,8 +275,8 @@ class SftArguments(SwanlabArguments, TunerArguments, BaseArguments, Seq2SeqTrain
             if self.deepspeed_autotp_size is not None:
                 assert self.deepspeed is not None, (
                     'To use `deepspeed_autotp_size`, you need to additionally set the `--deepspeed` argument.')
-                self.deepspeed['tensor_parallel']['autotp_size'] = self.deepspeed_autotp_size
-                self.deepspeed['zero_optimization']['gather_16bit_weights_on_model_save'] = True
+                self.deepspeed.setdefault('tensor_parallel', {})['autotp_size'] = self.deepspeed_autotp_size
+                self.deepspeed.setdefault('zero_optimization', {})['gather_16bit_weights_on_model_save'] = True
             if 'deepspeed_elastic' in set(getattr(self, 'callbacks', []) or []):
                 prepare_deepspeed_elastic_config(self)
             logger.info(f'Using deepspeed: {self.deepspeed}')

--- a/swift/arguments/sft_args.py
+++ b/swift/arguments/sft_args.py
@@ -275,7 +275,7 @@ class SftArguments(SwanlabArguments, TunerArguments, BaseArguments, Seq2SeqTrain
             if self.deepspeed_autotp_size is not None:
                 assert self.deepspeed is not None, (
                     'To use `deepspeed_autotp_size`, you need to additionally set the `--deepspeed` argument.')
-                self.deepspeed['tensor_parallel'] = {'autotp_size': self.deepspeed_autotp_size}
+                self.deepspeed['tensor_parallel']['autotp_size'] = self.deepspeed_autotp_size
                 self.deepspeed['zero_optimization']['gather_16bit_weights_on_model_save'] = True
             if 'deepspeed_elastic' in set(getattr(self, 'callbacks', []) or []):
                 prepare_deepspeed_elastic_config(self)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Avoid overwriting AutoTP-related settings when using DeepSpeed ​​configuration files.
For example, if `partition_config` is configured in the config file, it will be overridden if the `--deepspeed_autotp_size` argument is passed in the training script.

## Experiment results

Paste your experiment result here(if needed).
