### PR TITLE
Support Kimi no-TE alignment path

### DIFF
--- a/swift/megatron/model/gpt_bridge.py
+++ b/swift/megatron/model/gpt_bridge.py
@@ -1,6 +1,7 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import math
 import megatron.core
+import os
 import re
 import torch
 import torch.distributed as dist
@@ -230,11 +231,49 @@ class GPTBridge:
                     del param.get_high_precision_init_val
             else:
                 if hf_scale_inv is not None:
-                    fp8_tensor = self.fp8_quantizer.make_empty(tensor.shape)
-                    fp8_tensor._rowwise_data.copy_(tensor.view(torch.uint8))
-                    self._copy_scale_inv(fp8_tensor, hf_scale_inv[i])
-                    tensor = fp8_tensor
+                    if self._use_no_te_fp8_dequant() and self._is_float8_e4m3fn_tensor(tensor):
+                        tensor = self._dequant_fp8_blockwise_to_dtype(tensor, hf_scale_inv[i], param.dtype)
+                    else:
+                        fp8_tensor = self.fp8_quantizer.make_empty(tensor.shape)
+                        fp8_tensor._rowwise_data.copy_(tensor.view(torch.uint8))
+                        self._copy_scale_inv(fp8_tensor, hf_scale_inv[i])
+                        tensor = fp8_tensor
                 param.data.copy_(tensor)
+
+    @staticmethod
+    def _use_no_te_fp8_dequant():
+        return os.environ.get('SWIFT_MEGATRON_NO_TE', '').lower() in {'1', 'true', 'yes', 'on'}
+
+    @staticmethod
+    def _is_float8_e4m3fn_tensor(tensor: torch.Tensor) -> bool:
+        float8_e4m3fn = getattr(torch, 'float8_e4m3fn', None)
+        return float8_e4m3fn is not None and tensor.dtype is float8_e4m3fn
+
+    @classmethod
+    def _dequant_fp8_blockwise_to_dtype(cls, tensor: torch.Tensor, scale_inv: torch.Tensor,
+                                        target_dtype: torch.dtype) -> torch.Tensor:
+        """Dequantize Kimi blockwise FP8 weights to a regular dense tensor.
+
+        Kimi-K2 FP8 checkpoints store float8_e4m3fn weights plus float32
+        `<weight>_scale_inv` tensors with one scale per 128x128 block.  The
+        no-TE alignment route builds ordinary BF16 MCore parameters, so avoid
+        constructing TransformerEngine Float8BlockwiseQTensor objects here.
+        """
+        block = cls.fp8_block_size
+        if tensor.ndim < 2:
+            raise ValueError(f'FP8 blockwise tensor must be at least 2D, got shape={tuple(tensor.shape)}')
+        out_dim, in_dim = tensor.shape[-2:]
+        if out_dim % block != 0 or in_dim % block != 0:
+            raise ValueError(f'FP8 blockwise tensor shape must be multiples of {block}, got {tuple(tensor.shape)}')
+        expected_scale_shape = (*tensor.shape[:-2], out_dim // block, in_dim // block)
+        if tuple(scale_inv.shape) != expected_scale_shape:
+            raise ValueError(
+                f'FP8 scale_inv shape mismatch for tensor {tuple(tensor.shape)}: '
+                f'expected {expected_scale_shape}, got {tuple(scale_inv.shape)}')
+        view_shape = (*tensor.shape[:-2], out_dim // block, block, in_dim // block, block)
+        scale_shape = (*tensor.shape[:-2], out_dim // block, 1, in_dim // block, 1)
+        dequant = tensor.float().reshape(view_shape) * scale_inv.float().reshape(scale_shape)
+        return dequant.reshape(tensor.shape).to(target_dtype)
 
     @staticmethod
     def _copy_scale_inv(tensor, scale_inv):

--- a/swift/megatron/model/register.py
+++ b/swift/megatron/model/register.py
@@ -1,11 +1,13 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import megatron.core
+import os
 from dataclasses import dataclass
 from megatron.core import mpu
 from megatron.core.enums import ModelType
-from megatron.core.models.gpt.gpt_layer_specs import (get_gpt_decoder_block_spec,
+from megatron.core.models.gpt.gpt_layer_specs import (get_gpt_decoder_block_spec, get_gpt_layer_local_spec,
                                                       get_gpt_layer_with_transformer_engine_spec,
                                                       get_gpt_mtp_block_spec)
+from megatron.core.transformer.dot_product_attention import DotProductAttention
 from packaging import version
 from torch import nn
 from typing import TYPE_CHECKING, List, Optional, Type, Union
@@ -22,6 +24,36 @@ if TYPE_CHECKING:
 
 MEGATRON_MODEL_MAPPING = {}
 logger = get_logger()
+
+
+def _disable_transformer_engine_for_alignment() -> bool:
+    """Return whether alignment-mode model construction should avoid TE specs.
+
+    Fleet does not use TransformerEngine.  Keep the default ms-swift behavior
+    unchanged, but allow repro/alignment probes to force local Megatron-Core
+    module specs through an explicit environment switch.
+    """
+
+    return os.environ.get('SWIFT_MEGATRON_NO_TE', '').lower() in {'1', 'true', 'yes', 'on'}
+
+
+class _NoTEMLADotProductAttention(DotProductAttention):
+    """Compatibility wrapper for MLA local/no-TE attention spec.
+
+    MCore MLA builders pass TE-style ``k_channels``/``v_channels`` keyword
+    arguments into the core attention module.  The local DotProductAttention in
+    this pinned Megatron-Core does not accept those kwargs.  For MLA, q/k and v
+    head dimensions may differ, so keep the TE semantics by overriding the final
+    context flatten size with ``v_channels * heads_per_partition`` while using
+    the caller-provided ``softmax_scale`` for q/k score scaling.
+    """
+
+    def __init__(self, *args, k_channels=None, v_channels=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if k_channels is not None:
+            self.hidden_size_per_attention_head = k_channels
+        if v_channels is not None:
+            self.hidden_size_per_partition = self.num_attention_heads_per_partition * v_channels
 
 
 @dataclass
@@ -74,6 +106,15 @@ class MegatronModelLoader:
         self.args = args
         self.hf_config = hf_config
         self.config = get_mcore_model_config(args, hf_config)
+        if _disable_transformer_engine_for_alignment():
+            # MCore's local WrappedTorchNorm rejects TE/Apex-style persistent
+            # layernorm.  Disable it only for explicit no-TE alignment probes.
+            self.config.persist_layer_norm = False
+            # Local no-TE MoE with grouped_gemm=True selects GroupedMLP, which
+            # requires the external grouped_gemm package.  Fleet alignment should
+            # first establish a pure local/SequentialMLP reference.
+            self.config.moe_grouped_gemm = False
+            self.args.moe_grouped_gemm = False
         self.mcore_013 = version.parse(megatron.core.__version__) >= version.parse('0.13.0rc0')
         if self.model_cls is None:
             self.model_cls = MultimodalGPTModel if self.args.is_multimodal else GPTModel
@@ -92,29 +133,55 @@ class MegatronModelLoader:
             dsa_spec.submodules.linear_kv_up_proj = linear_q_up_proj
         layer_spec.submodules.self_attention = dsa_spec
 
+    def _patch_no_te_mla_spec(self, transformer_layer_spec):
+        if not (_disable_transformer_engine_for_alignment() and self.config.multi_latent_attention):
+            return transformer_layer_spec
+        layer_specs = getattr(transformer_layer_spec, 'layer_specs', None)
+        if layer_specs is None:
+            layer_specs = [transformer_layer_spec]
+        for layer_spec in layer_specs:
+            self_attn = getattr(getattr(layer_spec, 'submodules', None), 'self_attention', None)
+            self_attn_submodules = getattr(self_attn, 'submodules', None)
+            if self_attn_submodules is not None and hasattr(self_attn_submodules, 'core_attention'):
+                self_attn_submodules.core_attention = _NoTEMLADotProductAttention
+        return transformer_layer_spec
+
     def get_transformer_layer_spec(self, vp_stage: Optional[int] = None):
         if self.config.num_moe_experts:
             kwargs = {'qk_l2_norm': self.config.qk_l2_norm, 'vp_stage': vp_stage} if self.mcore_013 else {}
             transformer_layer_spec = get_gpt_decoder_block_spec(
-                self.config, use_transformer_engine=True, normalization=self.config.normalization, **kwargs)
+                self.config,
+                use_transformer_engine=not _disable_transformer_engine_for_alignment(),
+                normalization=self.config.normalization,
+                **kwargs)
             if self.config.experimental_attention_variant == 'dsa':
                 for layer_spec in transformer_layer_spec.layer_specs:
                     self._replace_spec_dsa(layer_spec)
         else:
             transformer_layer_spec = self._get_transformer_layer_spec()
-        return transformer_layer_spec
+        return self._patch_no_te_mla_spec(transformer_layer_spec)
 
     def _get_transformer_layer_spec(self):
         config = self.config
         kwargs = {'qk_l2_norm': config.qk_l2_norm} if self.mcore_013 else {}
-        transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
-            config.num_moe_experts,
-            self.args.moe_grouped_gemm,
-            config.qk_layernorm,
-            config.multi_latent_attention,
-            **kwargs,
-        )
-        return transformer_layer_spec
+        if _disable_transformer_engine_for_alignment():
+            transformer_layer_spec = get_gpt_layer_local_spec(
+                config.num_moe_experts,
+                self.args.moe_grouped_gemm,
+                config.qk_layernorm,
+                config.multi_latent_attention,
+                normalization=config.normalization,
+                **kwargs,
+            )
+        else:
+            transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
+                config.num_moe_experts,
+                self.args.moe_grouped_gemm,
+                config.qk_layernorm,
+                config.multi_latent_attention,
+                **kwargs,
+            )
+        return self._patch_no_te_mla_spec(transformer_layer_spec)
 
     def get_mtp_block_spec(self, transformer_layer_spec, vp_stage: Optional[int] = None):
         if hasattr(transformer_layer_spec, 'layer_specs') and len(transformer_layer_spec.layer_specs) == 0:
@@ -126,7 +193,10 @@ class MegatronModelLoader:
             transformer_layer_spec_for_mtp = transformer_layer_spec
         kwargs = {'vp_stage': vp_stage} if self.mcore_013 else {}
         return get_gpt_mtp_block_spec(
-            self.config, transformer_layer_spec_for_mtp, use_transformer_engine=True, **kwargs)
+            self.config,
+            transformer_layer_spec_for_mtp,
+            use_transformer_engine=not _disable_transformer_engine_for_alignment(),
+            **kwargs)
 
     def _set_shared_expert_gate(self, transformer_layer_spec):
         mcore_016 = version.parse(megatron.core.__version__) >= version.parse('0.16.0rc0')

--- a/swift/megatron/utils/megatron_lm_utils.py
+++ b/swift/megatron/utils/megatron_lm_utils.py
@@ -36,6 +36,71 @@ logger = get_logger()
 mcore_013 = version.parse(megatron.core.__version__) >= version.parse('0.13.0rc0')
 
 
+def _alignment_no_te_checkpoint_compat_enabled() -> bool:
+    """Whether to load a TE-style checkpoint into explicit no-TE specs.
+
+    This is a narrow repro/alignment bridge for Kimi-style checkpoints: the
+    model is constructed with local/no-TE modules, while some existing MCore
+    checkpoints were saved from TE fused norm-linear specs.  Keep default
+    behavior unchanged unless the explicit no-TE alignment switch is enabled.
+    """
+
+    return os.environ.get('SWIFT_MEGATRON_NO_TE', '').lower() in {'1', 'true', 'yes', 'on'}
+
+
+def _get_checkpoint_metadata_keys(checkpoint_dir: str) -> set[str]:
+    try:
+        from torch.distributed.checkpoint import FileSystemReader
+        reader = FileSystemReader(checkpoint_dir)
+        metadata = reader.read_metadata()
+        return set(metadata.state_dict_metadata.keys())
+    except Exception as e:
+        logger.warning(f'Unable to read dist-checkpoint metadata for no-TE compatibility mapping: {e!r}')
+        return set()
+
+
+def _patch_no_te_alignment_checkpoint_keys(state_dict_model, checkpoint_dir: str):
+    """Map no-TE standalone norm parameters to TE fused norm-linear keys.
+
+    Megatron-Core's local/no-TE specs expose q/kv/post-attention norms as
+    standalone parameters, while TE specs save the same tensors as
+    ``*.layer_norm_weight`` inside fused Linear modules.  Dist checkpointing
+    separates the Python dict key (the loaded model key) from the sharded
+    tensor's checkpoint source key (``v.key``), so we can load the TE-saved
+    tensor into the no-TE parameter without changing model module names.
+
+    Expert MLP tensors already carry packed TE checkpoint source keys and
+    expert-axis offsets in their ShardedTensor/ShardedTensorFactory objects;
+    this helper intentionally only patches the missing fused-norm cases.
+    """
+
+    if not _alignment_no_te_checkpoint_compat_enabled():
+        return
+    checkpoint_keys = _get_checkpoint_metadata_keys(checkpoint_dir)
+    if not checkpoint_keys:
+        return
+
+    patched = []
+    for key, value in state_dict_model.items():
+        source_key = None
+        if key.endswith('.self_attention.q_layernorm.weight'):
+            source_key = key.replace('.self_attention.q_layernorm.weight',
+                                     '.self_attention.linear_q_up_proj.layer_norm_weight')
+        elif key.endswith('.self_attention.kv_layernorm.weight'):
+            source_key = key.replace('.self_attention.kv_layernorm.weight',
+                                     '.self_attention.linear_kv_up_proj.layer_norm_weight')
+        elif key.endswith('.pre_mlp_layernorm.weight'):
+            source_key = key.replace('.pre_mlp_layernorm.weight', '.mlp.linear_fc1.layer_norm_weight')
+
+        if source_key and source_key in checkpoint_keys and hasattr(value, 'key'):
+            value.key = source_key
+            patched.append((key, source_key))
+
+    if patched:
+        logger.info('Applied no-TE alignment checkpoint key remap: %s',
+                    ', '.join(f'{target}<-{source}' for target, source in patched))
+
+
 @contextmanager
 def _patch_megatron_timeout(distributed_timeout_minutes):
     from megatron.core import parallel_state
@@ -456,6 +521,7 @@ def load_mcore_checkpoint(args,
     _filter_adapter_state_dict(sharded_state_dict, is_peft_format, adapter_name=adapter_name)
     model_keys = [k for k in sharded_state_dict.keys() if k.startswith('model')]  # compat vpp
     for k in model_keys:
+        _patch_no_te_alignment_checkpoint_keys(sharded_state_dict[k], checkpoint_dir)
         patch_merge_fn(sharded_state_dict[k])
     load_strategy = get_default_load_sharded_strategy(checkpoint_dir)
     load_strategy = FullyParallelLoadStrategyWrapper(load_strategy,


### PR DESCRIPTION
## Summary
- add SWIFT_MEGATRON_NO_TE gated local/no-TE Megatron-Core layer specs for Kimi alignment
- add MLA DotProductAttention compatibility for local no-TE specs
- remap TE-saved fused norm checkpoint keys when loading no-TE specs
- dequantize Kimi FP8 weight_scale_inv tensors into regular BF16 params under SWIFT_MEGATRON_NO_TE

## Validation
- python -m py_compile swift/megatron/model/gpt_bridge.py swift/megatron/model/register.py swift/megatron/utils/megatron_lm_utils.py
- sampled full Kimi-K2-Instruct FP8 weight_scale_inv branch smoke: exact BF16 dequant match
- reduced 2-layer Kimi SFT no-TE forward loss comparisons reached 20-step and 100-step BITWISE_PASS in the repro workspace

## Scope
Default TransformerEngine behavior is unchanged. New behavior is gated by SWIFT_MEGATRON_NO_TE for Kimi alignment/repro workflows.