### PR TITLE
fix: support Qwen3.5 MoE models in linear attention sequence parallel…

### DIFF
--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1220,10 +1220,7 @@ def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
     **kwargs,
 ) -> torch.Tensor:
     _ensure_linear_attention_kernels(mod)
-    apply_mask_to_padding_states = getattr(mod, '_apply_mask_to_padding_states', None)
-    if apply_mask_to_padding_states is None:
-        modeling_module = import_module(mod.__class__.__module__)
-        apply_mask_to_padding_states = getattr(modeling_module, 'apply_mask_to_padding_states')
+    apply_mask_to_padding_states = mod.__class__._apply_mask_to_padding_states
 
     local_attention_mask = attention_mask
     if torch.is_tensor(attention_mask) and attention_mask.dim() == 2:
@@ -1338,7 +1335,7 @@ def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
 
 
 def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
-    gated_delta_net_classes = []
+    gated_delta_net_specs = []
     class_specs = (
         ('transformers.models.qwen3_5.modeling_qwen3_5', 'Qwen3_5GatedDeltaNet'),
         ('transformers.models.qwen3_5_moe.modeling_qwen3_5_moe', 'Qwen3_5MoeGatedDeltaNet'),
@@ -1347,15 +1344,16 @@ def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
         try:
             modeling_module = import_module(module_name)
             gated_delta_net_cls = getattr(modeling_module, class_name)
-            gated_delta_net_cls._apply_mask_to_padding_states = getattr(modeling_module, 'apply_mask_to_padding_states')
-            gated_delta_net_classes.append(gated_delta_net_cls)
+            apply_mask_to_padding_states = getattr(modeling_module, 'apply_mask_to_padding_states')
+            gated_delta_net_specs.append((gated_delta_net_cls, apply_mask_to_padding_states))
         except Exception:
             pass
 
-    def patch_gated_delta_net(gated_delta_net_cls):
+    def patch_gated_delta_net(gated_delta_net_cls, apply_mask_to_padding_states):
         if getattr(gated_delta_net_cls, '_ms_swift_sp_linear_patched', False):
             return
 
+        gated_delta_net_cls._apply_mask_to_padding_states = apply_mask_to_padding_states
         origin_forward = gated_delta_net_cls.forward
         parameters = inspect.signature(origin_forward).parameters
 
@@ -1397,8 +1395,8 @@ def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
         gated_delta_net_cls.forward = sp_linear_forward
         gated_delta_net_cls._ms_swift_sp_linear_patched = True
 
-    for gated_delta_net_cls in gated_delta_net_classes:
-        patch_gated_delta_net(gated_delta_net_cls)
+    for gated_delta_net_cls, apply_mask_to_padding_states in gated_delta_net_specs:
+        patch_gated_delta_net(gated_delta_net_cls, apply_mask_to_padding_states)
 
 
 class Qwen3_5MoeLoader(Qwen3VLLoader):

--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -4,6 +4,7 @@ import inspect
 import os
 import torch
 import torch.nn.functional as F
+from importlib import import_module
 from packaging import version
 from PIL import Image
 from transformers import (AutoConfig, AutoModel, AutoTokenizer, BitsAndBytesConfig, PretrainedConfig, PreTrainedModel,
@@ -1219,7 +1220,8 @@ def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
     **kwargs,
 ) -> torch.Tensor:
     _ensure_linear_attention_kernels(mod)
-    from transformers.models.qwen3_5.modeling_qwen3_5 import apply_mask_to_padding_states
+    modeling_module = import_module(mod.__class__.__module__)
+    apply_mask_to_padding_states = getattr(modeling_module, 'apply_mask_to_padding_states')
 
     local_attention_mask = attention_mask
     if torch.is_tensor(attention_mask) and attention_mask.dim() == 2:
@@ -1334,54 +1336,65 @@ def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
 
 
 def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
-    try:
-        from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedDeltaNet
-    except Exception:
-        return
+    gated_delta_net_classes = []
+    class_specs = (
+        ('transformers.models.qwen3_5.modeling_qwen3_5', 'Qwen3_5GatedDeltaNet'),
+        ('transformers.models.qwen3_5_moe.modeling_qwen3_5_moe', 'Qwen3_5MoeGatedDeltaNet'),
+    )
+    for module_name, class_name in class_specs:
+        try:
+            modeling_module = import_module(module_name)
+            gated_delta_net_classes.append(getattr(modeling_module, class_name))
+        except Exception:
+            pass
 
-    if getattr(Qwen3_5GatedDeltaNet, '_ms_swift_sp_linear_patched', False):
-        return
+    def patch_gated_delta_net(gated_delta_net_cls):
+        if getattr(gated_delta_net_cls, '_ms_swift_sp_linear_patched', False):
+            return
 
-    origin_forward = Qwen3_5GatedDeltaNet.forward
-    parameters = inspect.signature(origin_forward).parameters
+        origin_forward = gated_delta_net_cls.forward
+        parameters = inspect.signature(origin_forward).parameters
 
-    def sp_linear_forward(
-        mod,
-        hidden_states: torch.Tensor,
-        cache_params=None,
-        cache_position=None,
-        attention_mask: Optional[torch.Tensor] = None,
-        **kwargs,
-    ):
-        if not sequence_parallel.enabled() and 'cu_seq_lens_q' not in kwargs:
-            kwargs = {}
-            if 'cache_position' in parameters:
-                kwargs['cache_position'] = cache_position
-            return origin_forward(
-                mod, hidden_states, cache_params=cache_params, attention_mask=attention_mask, **kwargs)
-
-        if int(sequence_parallel.rp_world_size or 1) > 1:
-            requested_sp_size = int(sequence_parallel.world_size or 1)
-            suggested_sp_size = int(sequence_parallel.sp_world_size or 1)
-            raise NotImplementedError(
-                'Qwen3.5 linear attention sequence parallel does not support derived ring attention '
-                f'(sequence_parallel_size={requested_sp_size}, '
-                f'sp_world_size={sequence_parallel.sp_world_size}, '
-                f'rp_world_size={sequence_parallel.rp_world_size}). '
-                f'Please reduce --sequence_parallel_size to {suggested_sp_size} so that rp_world_size becomes 1.')
-
-        # padding_free/packing or sp will all go through here
-        return _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
+        def sp_linear_forward(
             mod,
-            hidden_states,
-            cache_params=cache_params,
-            cache_position=cache_position,
-            attention_mask=attention_mask,
+            hidden_states: torch.Tensor,
+            cache_params=None,
+            cache_position=None,
+            attention_mask: Optional[torch.Tensor] = None,
             **kwargs,
-        )
+        ):
+            if not sequence_parallel.enabled() and 'cu_seq_lens_q' not in kwargs:
+                kwargs = {}
+                if 'cache_position' in parameters:
+                    kwargs['cache_position'] = cache_position
+                return origin_forward(
+                    mod, hidden_states, cache_params=cache_params, attention_mask=attention_mask, **kwargs)
 
-    Qwen3_5GatedDeltaNet.forward = sp_linear_forward
-    Qwen3_5GatedDeltaNet._ms_swift_sp_linear_patched = True
+            if int(sequence_parallel.rp_world_size or 1) > 1:
+                requested_sp_size = int(sequence_parallel.world_size or 1)
+                suggested_sp_size = int(sequence_parallel.sp_world_size or 1)
+                raise NotImplementedError(
+                    'Qwen3.5 linear attention sequence parallel does not support derived ring attention '
+                    f'(sequence_parallel_size={requested_sp_size}, '
+                    f'sp_world_size={sequence_parallel.sp_world_size}, '
+                    f'rp_world_size={sequence_parallel.rp_world_size}). '
+                    f'Please reduce --sequence_parallel_size to {suggested_sp_size} so that rp_world_size becomes 1.')
+
+            # padding_free/packing or sp will all go through here
+            return _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
+                mod,
+                hidden_states,
+                cache_params=cache_params,
+                cache_position=cache_position,
+                attention_mask=attention_mask,
+                **kwargs,
+            )
+
+        gated_delta_net_cls.forward = sp_linear_forward
+        gated_delta_net_cls._ms_swift_sp_linear_patched = True
+
+    for gated_delta_net_cls in gated_delta_net_classes:
+        patch_gated_delta_net(gated_delta_net_cls)
 
 
 class Qwen3_5MoeLoader(Qwen3VLLoader):

--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1220,8 +1220,10 @@ def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
     **kwargs,
 ) -> torch.Tensor:
     _ensure_linear_attention_kernels(mod)
-    modeling_module = import_module(mod.__class__.__module__)
-    apply_mask_to_padding_states = getattr(modeling_module, 'apply_mask_to_padding_states')
+    apply_mask_to_padding_states = getattr(mod, '_apply_mask_to_padding_states', None)
+    if apply_mask_to_padding_states is None:
+        modeling_module = import_module(mod.__class__.__module__)
+        apply_mask_to_padding_states = getattr(modeling_module, 'apply_mask_to_padding_states')
 
     local_attention_mask = attention_mask
     if torch.is_tensor(attention_mask) and attention_mask.dim() == 2:
@@ -1344,7 +1346,9 @@ def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
     for module_name, class_name in class_specs:
         try:
             modeling_module = import_module(module_name)
-            gated_delta_net_classes.append(getattr(modeling_module, class_name))
+            gated_delta_net_cls = getattr(modeling_module, class_name)
+            gated_delta_net_cls._apply_mask_to_padding_states = getattr(modeling_module, 'apply_mask_to_padding_states')
+            gated_delta_net_classes.append(gated_delta_net_cls)
         except Exception:
             pass
 

--- a/swift/sequence_parallel/sequence_parallel.py
+++ b/swift/sequence_parallel/sequence_parallel.py
@@ -1,4 +1,5 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
+import inspect
 import math
 import torch
 import torch.distributed as dist
@@ -11,6 +12,49 @@ from typing import Optional
 from swift.utils import HfConfigFactory, get_cu_seqlens_from_position_ids, get_device, get_dist_setting
 from .ulysses import DistributedAttention
 from .zigzag_ring_attn import zigzag_ring_flash_attn_varlen_func
+
+
+def has_signature_parameter(fn, parameter: str) -> bool:
+    try:
+        return parameter in inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+def call_with_supported_kwargs(fn, *args, **kwargs):
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return fn(*args, **kwargs)
+    parameters = signature.parameters
+    if not any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()):
+        kwargs = {key: value for key, value in kwargs.items() if key in parameters}
+    return fn(*args, **kwargs)
+
+
+def _call_create_causal_mask(fn, config, input_embeds, attention_mask, cache_position_or_past_key_values, *args,
+                             **kwargs):
+    if has_signature_parameter(fn, 'cache_position'):
+        return call_with_supported_kwargs(
+            fn,
+            config,
+            input_embeds,
+            attention_mask,
+            cache_position_or_past_key_values,
+            *args,
+            **kwargs,
+        )
+    if cache_position_or_past_key_values is None and 'past_key_values' in kwargs:
+        return call_with_supported_kwargs(fn, config, input_embeds, attention_mask, *args, **kwargs)
+    return call_with_supported_kwargs(
+        fn,
+        config,
+        input_embeds,
+        attention_mask,
+        cache_position_or_past_key_values,
+        *args,
+        **kwargs,
+    )
 
 
 class SequenceParallel:
@@ -75,17 +119,27 @@ class SequenceParallel:
                 'sdpa_origin'] = masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa']
             masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa'] = sdpa_mask
 
-            def create_causal_mask(config, input_embeds, attention_mask, cache_position, *args, **kwargs):
+            def create_causal_mask(config,
+                                   input_embeds,
+                                   attention_mask,
+                                   cache_position_or_past_key_values=None,
+                                   *args,
+                                   **kwargs):
                 if self.world_size == 1:
-                    return masking_utils.origin_create_causal_mask(config, input_embeds, attention_mask, cache_position,
-                                                                   *args, **kwargs)
+                    return _call_create_causal_mask(masking_utils.origin_create_causal_mask, config, input_embeds,
+                                                    attention_mask, cache_position_or_past_key_values, *args, **kwargs)
                 input_embeds = torch.ones(
                     (input_embeds.shape[0], input_embeds.shape[1] * self.sp_world_size, input_embeds.shape[2]),
                     dtype=input_embeds.dtype,
                     device=input_embeds.device)
-                cache_position = torch.arange(0, input_embeds.shape[1], device=input_embeds.device)
-                return masking_utils.origin_create_causal_mask(config, input_embeds, attention_mask, cache_position,
-                                                               *args, **kwargs)
+                if has_signature_parameter(masking_utils.origin_create_causal_mask, 'cache_position'):
+                    cache_position_or_past_key_values = torch.arange(
+                        0,
+                        input_embeds.shape[1],
+                        device=input_embeds.device,
+                    )
+                return _call_create_causal_mask(masking_utils.origin_create_causal_mask, config, input_embeds,
+                                                attention_mask, cache_position_or_past_key_values, *args, **kwargs)
 
             masking_utils.origin_create_causal_mask = masking_utils.create_causal_mask
             masking_utils.create_causal_mask = create_causal_mask

--- a/swift/sequence_parallel/sequence_parallel.py
+++ b/swift/sequence_parallel/sequence_parallel.py
@@ -3,7 +3,7 @@ import inspect
 import math
 import torch
 import torch.distributed as dist
-from functools import partial
+from functools import lru_cache, partial
 from torch.distributed import init_device_mesh
 from transformers import PreTrainedTokenizer
 from types import SimpleNamespace
@@ -14,19 +14,23 @@ from .ulysses import DistributedAttention
 from .zigzag_ring_attn import zigzag_ring_flash_attn_varlen_func
 
 
-def has_signature_parameter(fn, parameter: str) -> bool:
+@lru_cache(maxsize=None)
+def get_signature_parameters(fn):
     try:
-        return parameter in inspect.signature(fn).parameters
+        return inspect.signature(fn).parameters
     except (TypeError, ValueError):
-        return False
+        return None
+
+
+def has_signature_parameter(fn, parameter: str) -> bool:
+    parameters = get_signature_parameters(fn)
+    return parameters is not None and parameter in parameters
 
 
 def call_with_supported_kwargs(fn, *args, **kwargs):
-    try:
-        signature = inspect.signature(fn)
-    except (TypeError, ValueError):
+    parameters = get_signature_parameters(fn)
+    if parameters is None:
         return fn(*args, **kwargs)
-    parameters = signature.parameters
     if not any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()):
         kwargs = {key: value for key, value in kwargs.items() if key in parameters}
     return fn(*args, **kwargs)


### PR DESCRIPTION

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## PR information

This PR fixes Qwen3.5/Qwen3.6 MoE sequence parallel training with linear attention.

Previously, the Qwen3.5 linear attention SP patch only covered `Qwen3_5GatedDeltaNet`, while MoE models use `Qwen3_5MoeGatedDeltaNet`. As a result, Qwen3.5/Qwen3.6 MoE models could skip the ms-swift SP/padding-free linear attention path.

This change refactors the patching logic to dynamically import and patch both supported GatedDeltaNet implementations:

- `transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5GatedDeltaNet`
- `transformers.models.qwen3_5_moe.modeling_qwen3_5_moe.Qwen3_5MoeGatedDeltaNet`

The shared SP forward now resolves `apply_mask_to_padding_states` from the actual module of the patched class, so dense and MoE variants use their corresponding transformers helper.

This PR also improves `create_causal_mask` compatibility across transformers versions by routing calls through a signature-aware helper. This handles variants that use `cache_position`, `past_key_values`, or different supported keyword arguments.

User impact:

- Enables Qwen3.5/Qwen3.6 MoE transformers training to use the existing SP/padding-free linear attention path.
- Keeps the existing dense Qwen3.5 behavior unchanged.
- Improves compatibility with different transformers causal mask signatures.

## Experiment results

CUDA_VISIBLE_DEVICES=0,1,2,3
NPROC_PER_NODE=4 \
swift sft \
    --model Qwen/Qwen3.6-35B-A3B \
    --dataset 'swift/self-cognition' \
    --load_from_cache_file true \
    --tuner_type lora \
    --torch_dtype bfloat16 \
    --per_device_train_batch_size 2 \
    --target_modules all-linear \
    --gradient_accumulation_steps 8 \
    --save_total_limit 2 \
    --save_only_model true \
    --save_steps 50 \
    --max_length 65535 \
    --warmup_ratio 0.05 \
    --attn_impl flash_attn \
    --logging_steps 1 \
    --use_logits_to_keep false \
    --sequence_parallel_size 2 \
    --padding_free true

Train:   5%|███▏                                                              | 1/21 [01:07<22:32, 67.65s/it]{'loss': '3.041', 'grad_norm': '4.151', 'learning_rate': '5e-05', 'token_acc': '0.4439', 'epoch': '0.1481', 'global_step/max_steps': '1/21', 'elapsed_time': '1m 8s', 'remaining_time': '22m 33s', 'memory(GiB)': '69.55', 'train_speed(s/it)': '67.67'}
{'loss': '2.884', 'grad_norm': '4.532', 'learning_rate': '0.0001', 'token_acc': '0.5076', 'epoch': '0.2963', 'global_step/max_steps': '2/21', 'elapsed_time': '1m 19s', 'remaining_time': '12m 28s', 'memory(GiB)': '69.64', 'train_speed(s/it)': '39.37'}
{'loss': '3.043', 'grad_norm': '3.466', 'learning_rate': '9.932e-05', 'token_acc': '0.4432', 'epoch': '0.4444', 'global_step/max_steps': '3/21', 'elapsed_time': '1m 31s', 'remaining_time': '9m 5s', 'memory(GiB)': '69.64', 'train_speed(s/it)': '30.27'}


if  num_key_value_heads==2 and  sequence_parallel_size==4
it will throw an exception like below(as gdn is not supporting cp now)
<img width="914" height="169" alt="8fa2ed562fb6586c0b7503d6476296e3" src="https://github.com/user-attachments/assets/78823570-cfec-49a0-9196-7b1e99738306" />
