### PR TITLE
fix(tuners/lora): re-apply lora_dtype after peft _cast_adapter_dtype (#9694)

### DIFF
--- a/swift/tuners/peft.py
+++ b/swift/tuners/peft.py
@@ -362,6 +362,25 @@ def hot_patch_peft_module():
     LoraModel.__init_origin__ = LoraModel.__init__
     LoraModel.__init__ = __new_init__
 
+    # Re-apply lora_dtype after peft's `_cast_adapter_dtype` (issue #9694).
+    # `PeftModel.__init__` calls `LoraModel._cast_adapter_dtype(autocast_adapter_dtype=True)`
+    # *after* `__new_init__` has already converted the adapter to `lora_dtype`; that call
+    # upcasts float16/bfloat16 adapters back to float32, silently discarding `lora_dtype`.
+    # Re-run the conversion afterwards so the requested `lora_dtype` takes effect.
+    if hasattr(LoraModel, '_cast_adapter_dtype'):
+        LoraModel._cast_adapter_dtype_origin = LoraModel._cast_adapter_dtype
+
+        def _cast_adapter_dtype(self, adapter_name: str, autocast_adapter_dtype: bool = True):
+            self._cast_adapter_dtype_origin(
+                adapter_name=adapter_name, autocast_adapter_dtype=autocast_adapter_dtype)
+            active_config = self.peft_config.get(adapter_name)
+            if active_config is not None and getattr(active_config, 'lora_dtype', None):
+                for name, module in self.model.named_modules():
+                    if isinstance(module, LoraLayer):
+                        _convert_dtype(module, adapter_name, active_config.lora_dtype)
+
+        LoraModel._cast_adapter_dtype = _cast_adapter_dtype
+
     # Support LoRA+
     PeftModel.create_optimizer_param_groups = create_optimizer_param_groups
     PeftModel.load_adapter_origin = PeftModel.load_adapter


### PR DESCRIPTION
## What this fixes

Fixes #9694.

`--lora_dtype bfloat16` (or `float16`) has no effect when using the peft backend: LoRA adapter weights are always saved as `float32`.

### Root cause

`swift/tuners/peft.py` monkey-patches `LoraModel.__init__` (`__new_init__`), which converts the adapter to `lora_dtype` right after peft builds it. But peft's `PeftModel.__init__` then calls `LoraModel._cast_adapter_dtype(autocast_adapter_dtype=True)` **after** `LoraModel.__init__` returns, and that helper upcasts `float16`/`bfloat16` adapter params back to `float32`:

```
PeftModel.__init__
 ├─ LoraModel.__init__ (= swift __new_init__)
 │    ├─ inject_adapter        → float32   (peft default)
 │    └─ _convert_dtype        → bfloat16  ✅ (swift)
 └─ base_model._cast_adapter_dtype(autocast_adapter_dtype=True)
                                → float32  ❌ overrides swift
```

So swift's conversion runs too early and is silently discarded.

### Fix

Patch `LoraModel._cast_adapter_dtype` so that, after peft's cast, swift re-applies `lora_dtype`. This runs at the correct point (after peft's upcast) and is a no-op for the default `lora_dtype=None`, so existing fp32-adapter behavior is unchanged.

### Verification (CPU, no training, from the issue repro)

```python
import torch
from swift.tuners.peft import LoraConfig as SwiftLoraConfig
from peft import get_peft_model

class MiniModel(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.linear = torch.nn.Linear(32, 64, bias=False)
    def forward(self, x): return self.linear(x)

pm = get_peft_model(MiniModel(),
                    SwiftLoraConfig(r=8, lora_alpha=16, target_modules=["linear"], lora_dtype="bfloat16"),
                    autocast_adapter_dtype=True)  # swift's default
for n, p in pm.named_parameters():
    if "lora" in n:
        print(n, p.dtype)
# before: torch.float32 (bug)
# after:  torch.bfloat16 ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
