### PR TITLE
fix: flush asynchronous JSONL logs on training end

### DIFF
--- a/swift/megatron/callbacks/print.py
+++ b/swift/megatron/callbacks/print.py
@@ -32,6 +32,7 @@ class PrintCallback(MegatronCallback):
         self.jsonl_writer = JsonlWriter(logging_path, enable_async=True, write_on_rank='last')
 
     def on_train_end(self):
+        self.jsonl_writer.close()
         self.training_bar.close()
         self.training_bar = None
 

--- a/swift/utils/io_utils.py
+++ b/swift/utils/io_utils.py
@@ -52,11 +52,20 @@ class JsonlWriter:
         self.enable_async = enable_async
         self._queue = Queue()
         self._thread = None
+        self._closed = False
+        self._worker_exception = None
 
     def _append_worker(self):
         while True:
             item = self._queue.get()
-            self._append(**item)
+            try:
+                if item is None:
+                    return
+                self._append(**item)
+            except Exception as e:
+                self._worker_exception = e
+            finally:
+                self._queue.task_done()
 
     def _append(self, obj: Union[Dict, List[Dict]], gather_obj: bool = False):
         if isinstance(obj, (list, tuple)) and all(isinstance(item, dict) for item in obj):
@@ -73,6 +82,8 @@ class JsonlWriter:
         self._write_buffer(''.join(obj_list))
 
     def append(self, obj: Union[Dict, List[Dict]], gather_obj: bool = False):
+        if self._closed:
+            raise RuntimeError('Cannot append to a closed JsonlWriter')
         if self.enable_async:
             if self._thread is None:
                 self._thread = Thread(target=self._append_worker, daemon=True)
@@ -80,6 +91,24 @@ class JsonlWriter:
             self._queue.put({'obj': obj, 'gather_obj': gather_obj})
         else:
             self._append(obj, gather_obj=gather_obj)
+
+    def flush(self):
+        if not self.enable_async:
+            return
+        self._queue.join()
+        if self._worker_exception is not None:
+            raise self._worker_exception
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        if self.enable_async and self._thread is not None:
+            self._queue.put(None)
+            self._queue.join()
+            self._thread.join()
+            if self._worker_exception is not None:
+                raise self._worker_exception
 
     def _write_buffer(self, text: str):
         if not text:

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 import unittest
 
-from swift.utils import append_to_jsonl, get_logger, read_from_jsonl, write_to_jsonl
+from swift.utils import JsonlWriter, append_to_jsonl, get_logger, read_from_jsonl, write_to_jsonl
 
 logger = get_logger()
 
@@ -36,6 +36,18 @@ class TestIOUtils(unittest.TestCase):
             append_to_jsonl(fpath, obj)
         new_obj_list = read_from_jsonl(fpath)
         self.assertTrue(new_obj_list == obj_list)
+
+    def test_async_jsonl_close(self):
+        fpath = os.path.join(self.tmp_dir, 'async.jsonl')
+        obj_list = [{'value': i} for i in range(100)]
+        writer = JsonlWriter(fpath, enable_async=True)
+        for obj in obj_list:
+            writer.append(obj)
+        writer.close()
+
+        self.assertEqual(read_from_jsonl(fpath), obj_list)
+        with self.assertRaises(RuntimeError):
+            writer.append({'value': 100})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What does this PR do?

- Add `flush()` and `close()` lifecycle methods to `JsonlWriter`.
- Wait for pending asynchronous writes before shutting down the writer thread.
- Propagate asynchronous write exceptions back to the caller.
- Close the Megatron logging writer when training ends.
- Add a regression test covering asynchronous writer shutdown.

## Motivation

Megatron writes `logging.jsonl` through a daemon thread. The writer was not flushed or closed when training finished, so the process could exit before pending log entries were written, resulting in incomplete logging files.

## Tests

- Added `test_async_jsonl_close` to verify that all queued records are persisted before `close()` returns.
- Verified that appending after the writer is closed raises `RuntimeError`.
- Passed Python compilation and `git diff --check`.