### PR TITLE
fix: Qwen3-TTS project input text embedding

### DIFF
--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1793,7 +1793,8 @@ def _patch_qwen3_tts_forward(model):
         input_codec_ids = input_ids[:, :, 1]
 
         # Build text and codec embeddings
-        input_text_embedding = self.talker.model.text_embedding(input_text_ids) * text_embedding_mask
+        input_text_embedding = self.talker.text_projection(
+            self.talker.model.text_embedding(input_text_ids)) * text_embedding_mask
         input_codec_embedding = self.talker.model.codec_embedding(input_codec_ids) * codec_embedding_mask
         # Inject speaker embedding at position 6
         input_codec_embedding[:, 6, :] = speaker_embedding


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Running this Qwen3-TTS [example](https://github.com/modelscope/ms-swift/blob/main/examples/models/qwen3_tts/train.sh) with the alternative model `Qwen/Qwen3-TTS-12Hz-0.6B-Base` leads to this error.

```
  File "/root/autodl-tmp/ms-swift/swift/model/models/qwen.py", line 1802, in tts_forward
    input_embeddings = input_text_embedding + input_codec_embedding
                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
RuntimeError: The size of tensor a (2048) must match the size of tensor b (1024) at non-singleton dimension 2
```

The root cause is the missing text embedding projection, and the official implementation [sft_12hz.py](https://github.com/QwenLM/Qwen3-TTS/blob/022e286b98fbec7e1e916cb940cdf532cd9f488e/finetuning/sft_12hz.py#L89) has the same issue. There are several PRs in the Qwen3-TTS repository attempting to patch it: https://github.com/QwenLM/Qwen3-TTS/pull/336 and https://github.com/QwenLM/Qwen3-TTS/pull/278.

## Experiment results

Both `Qwen/Qwen3-TTS-12Hz-1.7B-Base` and `Qwen/Qwen3-TTS-12Hz-0.6B-Base` run without any problems.