### PR TITLE
[megatron] Fix MXFP8 sequence-length padding under sequence parallel

### DIFF
--- a/swift/megatron/utils/utils.py
+++ b/swift/megatron/utils/utils.py
@@ -217,6 +217,11 @@ def get_padding_to(args):
     fp4_format = getattr(args, 'fp4_format', None) or getattr(args, 'fp4', None)
     if args.fp8_recipe == 'blockwise':
         padding_to = (padding_to or 1) * 128
+    elif args.fp8_recipe == 'mxfp8':
+        # MXFP8 uses a block size of 32. Under sequence parallel, the sequence is
+        # split across TP ranks, so each per-rank shard (seq_len / TP) must itself
+        # be divisible by 32. Pad the total length to TP * 32 to guarantee this.
+        padding_to = (padding_to or 1) * 32
     elif fp8_format is not None or fp4_format is not None:
         padding_to = (padding_to or 1) * 16
     if args.attention_backend == 'fused':


### PR DESCRIPTION
## What
Add a dedicated `mxfp8` branch in `get_padding_to()` that pads the packed
sequence length to `TP * 32`.

## Why
MXFP8 uses a block size of 32, so any dimension it quantizes must be divisible
by 32. With sequence parallel, the packed sequence is split across TP ranks, so
each per-rank shard (`seq_len / TP`) must itself be divisible by 32 — i.e. the
total padded length must be a multiple of `TP * 32`.

Currently `mxfp8` falls into the generic FP8 branch (`TP * 16`). A per-rank
shard can then be a multiple of 16 but not 32, which trips an assertion inside
the TransformerEngine quantizer:

```
RuntimeError: ... quantizer.cpp create_tensor: Assertion failed:
flat_first_dim % MXFP8_BLOCK_SIZE == 0 && flat_last_dim % MXFP8_BLOCK_SIZE == 0.
MXFP8 requires tensor dims that are divisible by 32 (got shape=(7984, 3072))
```
e.g. padded total `31936` (= 64×499), TP=4 → shard `7984`, `7984 % 32 = 16`.

## Repro conditions
All of: `--fp8_recipe mxfp8` + `--packing` / `--padding_free` + `--sequence_parallel`
with TP > 1.

## Fix
`blockwise` is already handled separately (×128); `mxfp8` needs ×32 for the same
block-alignment reason. After the change `padding_to` becomes `TP*32`, the
per-rank shard is a multiple of 32, and training proceeds normally.
