### PR TITLE
[bugfix] fix streaming packing with truncation_strategy=split

### DIFF
--- a/swift/dataset/packing.py
+++ b/swift/dataset/packing.py
@@ -204,7 +204,10 @@ class IterablePackingDataset(IterableDataset):
             if isinstance(data, dict):
                 data = [data]
             for chunk in data:
-                last_res.append((chunk, len(chunk['input_ids'])))
+                # Defensive: skip empty/malformed chunks (e.g. missing 'input_ids')
+                # to avoid KeyError/TypeError, mirroring RowPreprocessor's skip-bad-data behaviour.
+                if chunk and 'input_ids' in chunk:
+                    last_res.append((chunk, len(chunk['input_ids'])))
         return last_res
 
     @staticmethod

--- a/swift/dataset/packing.py
+++ b/swift/dataset/packing.py
@@ -194,9 +194,17 @@ class IterablePackingDataset(IterableDataset):
             i, data = self._out_queue.get()
             if not data:
                 continue
-            res[i] = (data, len(data['input_ids']))
-        res = [data for data in res if data]
-        last_res += res
+            res[i] = data
+        # `template.encode` returns a single dict, except for `truncation_strategy='split'`
+        # where an over-long sample is split into a list of chunks. Flatten each sample
+        # (in input order, preserved via `res[i]`) into one bin-packing item per chunk.
+        for data in res:
+            if not data:
+                continue
+            if isinstance(data, dict):
+                data = [data]
+            for chunk in data:
+                last_res.append((chunk, len(chunk['input_ids'])))
         return last_res
 
     @staticmethod

--- a/tests/train/test_packing.py
+++ b/tests/train/test_packing.py
@@ -75,6 +75,25 @@ def test_streaming_packing_split():
     assert sum(sum(item[1] for item in b) for b in bins) == 100 + 1024 + 904
 
 
+def test_streaming_packing_split_skips_malformed_chunks():
+    """Empty chunks or chunks missing ``'input_ids'`` are skipped defensively, keeping only
+    valid chunks for bin-packing (mirrors RowPreprocessor's skip-bad-data behaviour)."""
+    import queue
+    import types
+
+    from swift.dataset.packing import IterablePackingDataset
+
+    obj = types.SimpleNamespace(_out_queue=queue.Queue())
+    good = {'input_ids': list(range(50)), 'labels': [-100] * 50}
+    empty_chunk = {}  # empty -> skipped
+    no_input_ids = {'labels': [-100]}  # missing 'input_ids' -> skipped
+
+    obj._out_queue.put((0, [good, empty_chunk, no_input_ids]))
+
+    res = IterablePackingDataset._fetch_data_out_queue(obj, [], 1)
+    assert res == [(good, 50)]
+
+
 def test_mllm_streaming():
     from swift import InferArguments, SftArguments, infer_main, sft_main
     result = sft_main(

--- a/tests/train/test_packing.py
+++ b/tests/train/test_packing.py
@@ -43,6 +43,38 @@ def test_streaming():
     infer_main(InferArguments(adapters=last_model_checkpoint, load_data_args=True, merge_lora=True))
 
 
+def test_streaming_packing_split():
+    """IterablePackingDataset must flatten ``truncation_strategy='split'``'s list-of-chunks
+    return from ``template.encode``. Regression test for
+    https://github.com/modelscope/ms-swift/issues/8285 : streaming + packing + split crashed
+    with ``TypeError: list indices must be integers or slices, not str`` because
+    ``_fetch_data_out_queue`` assumed ``encode`` always returns a dict."""
+    import queue
+    import types
+
+    from swift.dataset.packing import IterablePackingDataset, calculate_matched_group
+
+    # _fetch_data_out_queue only touches self._out_queue; bypass __init__ (which spawns mp workers).
+    obj = types.SimpleNamespace(_out_queue=queue.Queue())
+
+    normal = {'input_ids': list(range(100)), 'labels': [-100] * 100}  # dict: delete/left/right
+    chunk_a = {'input_ids': list(range(1024)), 'labels': [-100] * 1024}  # split chunk 1
+    chunk_b = {'input_ids': list(range(904)), 'labels': [-100] * 904}  # split chunk 2
+
+    obj._out_queue.put((0, normal))  # i=0: single dict (non-split)
+    obj._out_queue.put((1, [chunk_a, chunk_b]))  # i=1: split -> list of chunks
+    obj._out_queue.put((2, {}))  # i=2: failed encode (MaxLengthError) -> skipped
+
+    res = IterablePackingDataset._fetch_data_out_queue(obj, [], 3)
+
+    # Flattened to one (chunk, length) item per chunk; failed sample skipped; input order preserved.
+    assert res == [(normal, 100), (chunk_a, 1024), (chunk_b, 904)]
+
+    # Flattened chunks feed bin-packing without error; total tokens are conserved across bins.
+    bins, _ = calculate_matched_group(res, 1024, is_finished=True)
+    assert sum(sum(item[1] for item in b) for b in bins) == 100 + 1024 + 904
+
+
 def test_mllm_streaming():
     from swift import InferArguments, SftArguments, infer_main, sft_main
     result = sft_main(


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information
Fixes #8285.

`IterablePackingDataset._fetch_data_out_queue` assumed `template.encode` always returns a single dict. With `truncation_strategy='split'`, an over-long sample is split into a **list** of chunks (`template/base.py:_encode_truncated` returns `batched`, and `encode` returns that list when more than one chunk is produced). `_fetch_data_out_queue` then ran `len(data['input_ids'])` on the list, raising:

```
TypeError: list indices must be integers or slices, not str
```

This only triggers for `streaming=true + packing=true + truncation_strategy=split` (a common long-document streaming pretraining setup). The non-streaming path is unaffected: `EncodePreprocessor` materializes split chunks into separate dataset rows before `PackingDataset` wraps them, so it only ever sees single-dict rows.

**Fix**: flatten the list into one bin-packing item per chunk, mirroring the existing pattern in `RowPreprocessor.batched_preprocess` (`if isinstance(row, dict): row = [row]`). Input order is preserved via `res[i]` (required for the `sequential` packing strategy). No behaviour change for the dict path (`delete`/`left`/`right`): each successful sample still produces exactly one `(chunk, length)` item in the same order as before, and failed/empty encodes are still skipped.

## Experiment results
- Added unit test `tests/train/test_packing.py::test_streaming_packing_split` covering the dict (delete/left/right), split-list, and failed-encode (empty dict) cases; asserts correct flattening, input-order preservation, and that flattened chunks feed `calculate_matched_group` without error (tokens conserved).
- `pre-commit run --files swift/dataset/packing.py tests/train/test_packing.py` passes (flake8 / isort / yapf / trailing-whitespace / double-quote-string-fixer ...).
- Local test run:

```
$ python3 -m pytest tests/train/test_packing.py::test_streaming_packing_split -x -q
.
1 passed in 3.29s
```