### PR TITLE
fix(examples/grpo): build rollout_infos before _close_and_remove in sudoku scheduler (#9745)

### DIFF
--- a/examples/train/grpo/plugin/openenv/sudoku_scheduler.py
+++ b/examples/train/grpo/plugin/openenv/sudoku_scheduler.py
@@ -274,18 +274,20 @@ class SudokuScheduler(OpenEnvScheduler):
         action_text = response_choice.message.content
         action_dict = self.parse_action(action_text)
         if action_dict is None:
-            # Parse failed: end trajectory with penalty instead of polluting env
+            # Parse failed: end trajectory with penalty instead of polluting env.
+            # Snapshot rollout_infos *before* _close_and_remove, which pops
+            # self._total_rewards[uuid] / self._step_rewards[uuid] (see the
+            # base OpenEnvScheduler._close_and_remove). Building the dict after
+            # cleanup raised KeyError on total_reward and lost step_rewards.
             self._total_rewards[uuid] = self._total_rewards.get(uuid, 0.0) - 1.0
             self._step_rewards.setdefault(uuid, []).append(-1.0)
-            await self._close_and_remove(uuid)
-            return {
-                'done': True,
-                'rollout_infos': {
-                    'total_reward': self._total_rewards[uuid],
-                    'step_rewards': list(self._step_rewards.get(uuid, [])),
-                    'gym_done': True,
-                }
+            rollout_infos = {
+                'total_reward': self._total_rewards[uuid],
+                'step_rewards': list(self._step_rewards.get(uuid, [])),
+                'gym_done': True,
             }
+            await self._close_and_remove(uuid)
+            return {'done': True, 'rollout_infos': rollout_infos}
         move = action_dict.get('message', '')
 
         # Step environment


### PR DESCRIPTION
## What

Fixes the first defect reported in #9745: in the OpenEnv Sudoku GRPO example, the parse-failure branch of `SudokuScheduler.on_turn_end` builds its `rollout_infos` dict **after** calling `_close_and_remove(uuid)`.

`OpenEnvScheduler._close_and_remove` (in `swift/rollout/multi_turn.py`) pops `self._total_rewards[uuid]` and `self._step_rewards[uuid]`. So when the model emits an unparseable action:

```python
self._total_rewards[uuid] = self._total_rewards.get(uuid, 0.0) - 1.0
self._step_rewards.setdefault(uuid, []).append(-1.0)
await self._close_and_remove(uuid)          # pops _total_rewards[uuid] / _step_rewards[uuid]
return {
    'done': True,
    'rollout_infos': {
        'total_reward': self._total_rewards[uuid],        # KeyError
        'step_rewards': list(self._step_rewards.get(uuid, [])),  # always []
        ...
```

`self._total_rewards[uuid]` raises `KeyError` (and `step_rewards` silently comes back empty). Since unparseable model output is common early in GRPO training, this crashes rollouts.

## Fix

Snapshot `rollout_infos` **before** cleanup — mirroring the already-correct terminal path at the end of `on_turn_end` (which builds `rollout_infos` first, then calls `_close_and_remove`). Minimal, behavior-preserving for the happy path.

## Note on the second reported issue

#9745 also reports an OpenEnv **session leak** when a trajectory stops because it hit `--max_turns` (or `finish_reason == 'length'`) rather than the env returning `done=True`. That one is a framework-level gap: `MultiTurnScheduler.run()` returns as soon as `should_stop` is set and never invokes a post-trajectory cleanup hook, so `on_turn_end` (the example's only entry point) has no way to release the env on a trainer-forced stop. Fixing it properly means adding a trajectory-end hook to the base scheduler and having `GYMScheduler`/`OpenEnvScheduler` close any surviving env — a change with broader blast radius across all schedulers, so I've left it out of this minimal fix and defer to maintainers on the preferred shape. Happy to follow up with that if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
