### PR TITLE
fix(template): guard MiniCPM-V/mPLUG-Owl3 video sampling against 0-fps metadata

### DIFF
--- a/swift/template/vision_utils.py
+++ b/swift/template/vision_utils.py
@@ -286,7 +286,7 @@ def load_video_minicpmv_mplug_owl3(video: Union[str, bytes], max_num_frames):
 
     video_io = load_file(video)
     vr = VideoReader(video_io, ctx=cpu(0))
-    sample_fps = round(vr.get_avg_fps() / 1)  # FPS
+    sample_fps = max(1, round(vr.get_avg_fps() / 1))  # FPS; clamp so a 0-fps video does not make range() step 0
     frame_idx = [i for i in range(0, len(vr), sample_fps)]
 
     if len(frame_idx) > max_num_frames:

--- a/tests/general/test_template.py
+++ b/tests/general/test_template.py
@@ -101,9 +101,46 @@ def test_save_pil_image_dimension_collision():
         assert saved_b.size == (width_b, height_b)
 
 
+def test_load_video_minicpmv_handles_zero_fps():
+    import numpy as np
+    import sys
+    import types
+    from unittest import mock
+
+    from swift.template import vision_utils
+
+    n_frames = 8
+
+    class _FakeVideoReader:
+
+        def __len__(self):
+            return n_frames
+
+        def get_avg_fps(self):
+            # decord returns 0.0 when the container carries no / broken fps metadata.
+            return 0.0
+
+        def get_batch(self, idx):
+            arr = np.zeros((len(list(idx)), 4, 4, 3), dtype='uint8')
+            return types.SimpleNamespace(asnumpy=lambda: arr)
+
+    fake_decord = types.SimpleNamespace(
+        VideoReader=lambda *args, **kwargs: _FakeVideoReader(),
+        cpu=lambda *args, **kwargs: None,
+    )
+
+    with mock.patch.dict(sys.modules, {'decord': fake_decord}), \
+            mock.patch.object(vision_utils, 'load_file', lambda video: video):
+        # A 0-fps video used to raise "range() arg 3 must not be zero" here.
+        frames = vision_utils.load_video_minicpmv_mplug_owl3(b'video-bytes', max_num_frames=4)
+
+    assert len(frames) == 4
+
+
 if __name__ == '__main__':
     test_template()
     test_mllm()
     test_llm_dataset_map()
     test_mllm_dataset_map()
     test_save_pil_image_dimension_collision()
+    test_load_video_minicpmv_handles_zero_fps()


### PR DESCRIPTION
## What

`load_video_minicpmv_mplug_owl3` picks frames with

```python
sample_fps = round(vr.get_avg_fps() / 1)  # FPS
frame_idx = [i for i in range(0, len(vr), sample_fps)]
```

decord's `get_avg_fps()` returns `0.0` when the container has no / broken fps metadata (and a very low sub-1 fps rounds to 0 as well), so `sample_fps` becomes `0` and `range(0, len(vr), 0)` raises `ValueError: range() arg 3 must not be zero` before a single frame is read. The `MiniCPM-V` and `mPLUG-Owl3` templates call this for any user-supplied video (`swift/template/templates/minicpm.py`, `swift/template/templates/mplug.py`), and there is no upstream fps check, so an ordinary video with missing fps metadata crashes encoding. The same file already treats `fps == 0` as a real case elsewhere (`_video_get_metadata_local` uses `fps if fps > 0 else 0`).

## Fix

Clamp `sample_fps` to at least 1 so a 0-fps video falls back to sampling every frame, which the existing `max_num_frames` `uniform_sample` then downsamples. Normal videos (`fps >= 1`) are unaffected.

## Verification

decord/torch are not installable in my environment, so I reproduced the exact sampling logic standalone:

| avg fps | before | after |
| --- | --- | --- |
| 25.0 | 4 frames | 4 frames |
| 1.0 | 4 frames | 4 frames |
| 0.4 | `ValueError: range() arg 3 must not be zero` | 4 frames |
| 0.0 | `ValueError: range() arg 3 must not be zero` | 4 frames |

The added `test_load_video_minicpmv_handles_zero_fps` mocks a decord `VideoReader` whose `get_avg_fps()` returns `0.0` and asserts `load_video_minicpmv_mplug_owl3` returns frames instead of raising (fails before this change, passes after). It needs no real video or GPU.
