### PR TITLE
fix: Qwen3-TTS incorrect loss handling

### DIFF
--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1810,20 +1810,25 @@ def _patch_qwen3_tts_forward(model):
             input_embeddings = input_embeddings + codec_i_embedding
 
         outputs = self.talker(
-            inputs_embeds=input_embeddings[:, :-1, :],
-            attention_mask=attention_mask[:, :-1],
+            inputs_embeds=input_embeddings,
+            attention_mask=attention_mask,
+            labels=codec_0_labels,
             output_hidden_states=True,
         )
 
         # Compute sub_talker_loss from hidden states at codec positions
-        hidden_states = outputs.hidden_states[0][-1]
-        talker_hidden_states = hidden_states[codec_mask[:, :-1]]
+        hidden_states = outputs.hidden_states[0][-1][:, :-1, :]
+        talker_hidden_states = hidden_states[codec_mask[:, 1:]]
         talker_codec_ids = codec_ids[codec_mask]
 
-        _, sub_talker_loss = self.talker.forward_sub_talker_finetune(talker_codec_ids, talker_hidden_states)
+        sub_talker_logits, _ = self.talker.forward_sub_talker_finetune(talker_codec_ids, talker_hidden_states)
+        sub_talker_loss = F.cross_entropy(
+            sub_talker_logits.reshape(-1, sub_talker_logits.shape[-1]).float(),
+            talker_codec_ids[:, 1:].reshape(-1).to(sub_talker_logits.device),
+        )
 
-        # Attach sub_talker_loss to outputs for the custom loss function
-        outputs.sub_talker_loss = sub_talker_loss
+        outputs['loss'] = outputs.loss + 0.3 * sub_talker_loss
+
         return outputs
 
     model.forward = MethodType(tts_forward, model)

--- a/swift/template/templates/qwen.py
+++ b/swift/template/templates/qwen.py
@@ -1233,18 +1233,6 @@ class Qwen3TTSTemplate(Template):
             inputs.pop('ref_mels')
             inputs['speaker_embedding'] = speaker_embedding
         outputs = model(**inputs)
-        logits = outputs.logits
-        shift_labels = inputs['codec_0_labels'][:, 1:].contiguous()
-        talker_loss = F.cross_entropy(
-            logits.reshape(-1, logits.shape[-1]).float(),
-            shift_labels.reshape(-1).to(logits.device),
-            ignore_index=-100,
-        )
-        sub_talker_loss = getattr(outputs, 'sub_talker_loss', None)
-        if sub_talker_loss is not None:
-            outputs['loss'] = talker_loss + 0.3 * sub_talker_loss
-        else:
-            outputs['loss'] = talker_loss
         return outputs
 
     def save_callback(self, model, output_dir):


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

总共包含了两个修复和一处代码简化。

## sub_talker_loss 没有被传下去

**现象**：Loss 极低（从 1 开始下降），但是完全无法克隆声音：[no_sub_talker_loss.mp3](https://github.com/user-attachments/files/30061054/no_sub_talker_loss.mp3)。


原代码把 [sub_talker_loss](https://github.com/modelscope/ms-swift/blob/225b1a0eb455aca3d54fc4d9e34a5a146b154ae9/swift/model/models/qwen.py#L1826) 作为动态属性挂在 `ModelOutput` 上，再由 [compute_sft_loss](https://github.com/modelscope/ms-swift/blob/225b1a0eb455aca3d54fc4d9e34a5a146b154ae9/swift/template/templates/qwen.py#L1243) 用 `getattr` 读取：

```python
outputs.sub_talker_loss = sub_talker_loss   # 动态属性
# compute_sft_loss:
sub_talker_loss = getattr(outputs, 'sub_talker_loss', None)   # → None
```

动态属性被 `@can_return_tuple` / 模型封装在跨边界时剥离，`getattr` 恒为 `None`，又被静默兜底成纯 talker loss，code_predictor 整个训练零梯度。

**修复**：把损失合并移进 `tts_forward` 内部。

## 标签 shift 错位

**现象**：在修复了上一条后，Loss 极高（sub_talker_loss 大约是 11），输出噪音，模型崩溃：[double_shift.mp3](https://github.com/user-attachments/files/30061118/double_shift.mp3)。


上游代码中 `forward_sub_talker_finetune` 内部调用 [code_predictor.forward_finetune](https://github.com/QwenLM/Qwen3-TTS/blob/022e286b98fbec7e1e916cb940cdf532cd9f488e/qwen_tts/core/models/modeling_qwen3_tts.py#L1628)，传入的的 `labels` 是已经预移位一位过的 `codec_ids[:, 1:]`，`forward_finetune` 中的实现会调用 `ForCausalLMLoss` 再次 shift，导致双重 shift 的情况。

**修复**：参考 https://github.com/QwenLM/Qwen3-TTS/pull/278 ，但直接取 `sub_talker_logits` 手动计算 Loss。

## 移除手动计算 talker_loss

依然参考 https://github.com/QwenLM/Qwen3-TTS/pull/278 ，并不需要手动计算 [talker_loss](https://github.com/modelscope/ms-swift/blob/225b1a0eb455aca3d54fc4d9e34a5a146b154ae9/swift/template/templates/qwen.py#L1238)。

## Experiment results

Paste your experiment result here(if needed).

```bash
SPEAKER_NAME='cyrene' \
CUDA_VISIBLE_DEVICES=0 \
nohup swift sft \
    --model Qwen/Qwen3-TTS-12Hz-0.6B-Base \
    --dataset '/root/autodl-tmp/audio/train/0/Chinese(PRC).jsonl' \
    --split_dataset_ratio 0.0 \
    --load_from_cache_file true \
    --tuner_type full \
    --torch_dtype bfloat16 \
    --num_train_epochs 4 \
    --per_device_train_batch_size 8 \
    --gradient_accumulation_steps 2 \
    --learning_rate 2.29e-5 \
    --weight_decay 0.01 \
    --adam_beta2 0.999 \
    --lr_scheduler_type cosine_with_min_lr \
    --lr_scheduler_kwargs '{"min_lr": 9.94e-6}' \
    --attn_impl 'flash_attention_2' \
    --save_steps 33550336 \
    --max_length 4096 \
    --output_dir /root/autodl-tmp/output/tts \
    --warmup_ratio 0.05 \
    --dataset_num_proc 1 \
    --dataloader_num_workers 4 \
    --save_only_model \
    > "$(date +%s).log" 2>&1 &
```

成功复刻昔涟：[it_works.mp3](https://github.com/user-attachments/files/30061323/it_works.mp3)。

并且额外尝试了 [examples/models/qwen3_tts/train.sh](https://github.com/modelscope/ms-swift/blob/225b1a0eb455aca3d54fc4d9e34a5a146b154ae9/examples/models/qwen3_tts/train.sh)，能听得出来是芙宁娜：[furina.mp3](https://github.com/user-attachments/files/30062092/furina.mp3)。
