### PR TITLE
fix(qwen3_omni): read router_aux_loss_coef from text_config

### DIFF
--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1671,7 +1671,7 @@ def _compat_qwen3_omni_mixed_data(model, processor):
                 attention_mask,
             )
             if labels is not None:
-                loss += self.config.router_aux_loss_coef * aux_loss.to(
+                loss += self.config.text_config.router_aux_loss_coef * aux_loss.to(
                     loss.device)  # make sure to reside in the same device
 
         return Qwen3OmniMoeThinkerCausalLMOutputWithPast(


### PR DESCRIPTION
### What / Why

In the Qwen3-Omni thinker `forward` (`swift/model/models/qwen.py`), the MoE
auxiliary-loss coefficient is read from the top-level composite config:

```python
loss += self.config.router_aux_loss_coef * aux_loss.to(loss.device)
```

For the Qwen3-Omni thinker, the router hyperparameters live in the thinker's
`text_config`, not on the top-level composite config. The two sibling accesses
in the same function already go through `text_config`:

- `output_router_logits` → `self.config.text_config.output_router_logits`
- `vocab_size` → `self.config.get_text_config().vocab_size`

so `router_aux_loss_coef` was the lone inconsistent access. Reading it off the
composite config scales the aux-loss term with the wrong coefficient (and can
`AttributeError` when the attribute is absent at the top level).

### Fix

Read the coefficient from `text_config`, matching the sibling
`output_router_logits` access:

```python
loss += self.config.text_config.router_aux_loss_coef * aux_loss.to(loss.device)
```

Fixes #9757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
