### PR TITLE
fix(rlhf): mask teacher logprobs before KL

### DIFF
--- a/swift/rl_core/advantage.py
+++ b/swift/rl_core/advantage.py
@@ -222,8 +222,10 @@ def compute_teacher_kl_per_token(
         ``[B, T]`` per-token teacher KL (masked outside the response).
     """
     d = teacher_per_token_logps - policy_per_token_logps
+    # Mask before exp so padding sentinel values cannot overflow and produce inf * 0.
+    d = d.masked_fill(~completion_mask.bool(), 0.0)
     per_token = torch.exp(d) - d - 1
-    return per_token * completion_mask
+    return per_token
 
 
 def compute_teacher_logratio(
@@ -245,7 +247,7 @@ def compute_teacher_logratio(
         ``[B, T]`` per-token signed log-ratio (masked outside the response).
     """
     d = teacher_per_token_logps - policy_per_token_logps
-    return d * completion_mask
+    return d.masked_fill(~completion_mask.bool(), 0.0)
 
 
 def expand_advantage_to_per_token(

--- a/tests/utils/test_teacher_advantage.py
+++ b/tests/utils/test_teacher_advantage.py
@@ -1,0 +1,39 @@
+"""Tests for masking teacher log-probability signals outside completion tokens."""
+
+import torch
+import unittest
+
+from swift.rl_core.advantage import compute_teacher_kl_per_token, compute_teacher_logratio
+
+
+class TestTeacherAdvantageMasking(unittest.TestCase):
+
+    def test_teacher_kl_masks_padding_before_exp(self):
+        teacher_logps = torch.tensor([[-2.0, 0.0, -3.0, 0.0]])
+        policy_logps = torch.tensor([[-3.0, -1e10, -1.0, -1e10]])
+        completion_mask = torch.tensor([[1, 0, 1, 0]], dtype=torch.bool)
+
+        result = compute_teacher_kl_per_token(teacher_logps, policy_logps, completion_mask)
+        active_delta = torch.tensor([1.0, -2.0])
+        expected_active = torch.exp(active_delta) - active_delta - 1
+
+        self.assertTrue(torch.isfinite(result).all())
+        torch.testing.assert_close(result[completion_mask], expected_active)
+        torch.testing.assert_close(result[~completion_mask], torch.zeros(2))
+
+    def test_teacher_helpers_ignore_nonfinite_padding(self):
+        teacher_logps = torch.tensor([[-2.0, float('nan'), 0.0]])
+        policy_logps = torch.tensor([[-3.0, float('inf'), -1e10]])
+        completion_mask = torch.tensor([[1, 0, 0]], dtype=torch.bool)
+
+        teacher_kl = compute_teacher_kl_per_token(teacher_logps, policy_logps, completion_mask)
+        logratio = compute_teacher_logratio(teacher_logps, policy_logps, completion_mask)
+
+        self.assertTrue(torch.isfinite(teacher_kl).all())
+        self.assertTrue(torch.isfinite(logratio).all())
+        torch.testing.assert_close(teacher_kl, torch.tensor([[torch.e - 2.0, 0.0, 0.0]]))
+        torch.testing.assert_close(logratio, torch.tensor([[1.0, 0.0, 0.0]]))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix NaN values in the OPD-RL `teacher_kl` monitoring metric when using padded batches.

Teacher API log probabilities use `0` outside completion tokens, while padding-free student log probabilities may use
`-1e10`. The K3 estimator previously applied the completion mask after exponentiation:

```python
d = teacher_logps - student_logps
k3 = (torch.exp(d) - d - 1) * completion_mask
```

At padding positions, this could produce:

```text
d = 0 - (-1e10) = 1e10
exp(d) = inf
inf * 0 = NaN
```

A single padding NaN then caused the aggregated `teacher_kl` metric to become NaN, even though all active
completion-token log probabilities were finite.

This PR masks the log-probability difference before applying the K3 estimator. The same safe masking is applied to the
signed teacher log-ratio so non-finite padding cannot contaminate OPD advantages.

The fix is implemented in the shared RL advantage helper, so it applies consistently to both Megatron and HF RLHF
trainers without duplicating logic in their training loops. Active completion-token calculations are unchanged.

Regression tests cover:

- The `-1e10` padding case that caused `inf * 0`.
- `NaN` and `Inf` values outside the completion mask.
- Preservation of the expected K3 and signed log-ratio values on active tokens.

## Experiment results

A minimal reproduction produced:

```text
delta = [[1.0, 1e10, -2.0, 1e10]]
k3 = [[0.7182817, NaN, 1.1353352, NaN]]
sum = NaN
```

After the fix, both regression tests pass:

```text
test_teacher_helpers_ignore_nonfinite_padding ... ok
test_teacher_kl_masks_padding_before_exp ... ok

Ran 2 tests
OK
```

Additional verification:

```text
Python compilation: passed
git diff --check: passed
```
