### PR TITLE
Fix TRL optional dependency checks with Transformers 5

### DIFF
--- a/swift/rlhf_trainers/grpo_trainer.py
+++ b/swift/rlhf_trainers/grpo_trainer.py
@@ -16,13 +16,8 @@ except ImportError:
     pass
 
 # https://github.com/modelscope/ms-swift/pull/8280
-try:
-    import trl.import_utils as _trl_import_utils
-    _orig = _trl_import_utils.is_vllm_ascend_available
-    if not isinstance(_orig(), bool):
-        _trl_import_utils.is_vllm_ascend_available = lambda: bool(_orig()[0])
-except Exception:
-    pass
+from swift.utils.import_utils import patch_trl_package_check
+patch_trl_package_check()
 # fmt: on
 
 import concurrent.futures

--- a/swift/rlhf_trainers/grpo_trainer.py
+++ b/swift/rlhf_trainers/grpo_trainer.py
@@ -15,9 +15,6 @@ try:
 except ImportError:
     pass
 
-# https://github.com/modelscope/ms-swift/pull/8280
-from swift.utils.import_utils import patch_trl_package_check
-patch_trl_package_check()
 # fmt: on
 
 import concurrent.futures

--- a/swift/utils/import_utils.py
+++ b/swift/utils/import_utils.py
@@ -61,6 +61,23 @@ def is_trl_available() -> bool:
     return importlib.util.find_spec('trl') is not None
 
 
+def patch_trl_package_check() -> None:
+    """Fix optional dependency checks in TRL <= 0.28 with Transformers 5."""
+    import trl.import_utils as trl_import_utils
+
+    package_check = trl_import_utils._is_package_available
+    if not isinstance(package_check('trl'), tuple):
+        return
+
+    def compatible_package_check(package, return_version=False):
+        result = package_check(package, return_version=return_version)
+        if not return_version and isinstance(result, tuple):
+            return result[0]
+        return result
+
+    trl_import_utils._is_package_available = compatible_package_check
+
+
 class _LazyModule(ModuleType):
     """
     Module class that surfaces all objects but only performs associated imports when the objects are requested.

--- a/swift/utils/import_utils.py
+++ b/swift/utils/import_utils.py
@@ -62,7 +62,12 @@ def is_trl_available() -> bool:
 
 
 def patch_trl_package_check() -> None:
-    """Fix optional dependency checks in TRL <= 0.28 with Transformers 5."""
+    """Normalize Transformers 5 package checks used by TRL <= 0.28.
+
+    Old TRL code expects a bool from default calls. Transformers 5 returns a tuple for every package, so probing the
+    installed ``trl`` package detects that behavior without depending on any optional package. Version queries keep
+    their original tuple result.
+    """
     try:
         import trl.import_utils as trl_import_utils
     except ImportError:

--- a/swift/utils/import_utils.py
+++ b/swift/utils/import_utils.py
@@ -63,10 +63,13 @@ def is_trl_available() -> bool:
 
 def patch_trl_package_check() -> None:
     """Fix optional dependency checks in TRL <= 0.28 with Transformers 5."""
-    import trl.import_utils as trl_import_utils
+    try:
+        import trl.import_utils as trl_import_utils
+    except ImportError:
+        return
 
-    package_check = trl_import_utils._is_package_available
-    if not isinstance(package_check('trl'), tuple):
+    package_check = getattr(trl_import_utils, '_is_package_available', None)
+    if package_check is None or not isinstance(package_check('trl'), tuple):
         return
 
     def compatible_package_check(package, return_version=False):

--- a/swift/utils/import_utils.py
+++ b/swift/utils/import_utils.py
@@ -66,7 +66,12 @@ def is_trl_available() -> bool:
 
 
 def patch_trl_package_check() -> None:
-    """Fix optional dependency checks in TRL <= 0.28 with Transformers 5."""
+    """Normalize Transformers 5 package checks used by TRL <= 0.28.
+
+    Old TRL code expects a bool from default calls. Transformers 5 returns a tuple for every package, so probing the
+    installed ``trl`` package detects that behavior without depending on any optional package. Version queries keep
+    their original tuple result.
+    """
     try:
         import trl.import_utils as trl_import_utils
     except ImportError:

--- a/swift/utils/import_utils.py
+++ b/swift/utils/import_utils.py
@@ -65,6 +65,23 @@ def is_trl_available() -> bool:
     return importlib.util.find_spec('trl') is not None
 
 
+def patch_trl_package_check() -> None:
+    """Fix optional dependency checks in TRL <= 0.28 with Transformers 5."""
+    import trl.import_utils as trl_import_utils
+
+    package_check = trl_import_utils._is_package_available
+    if not isinstance(package_check('trl'), tuple):
+        return
+
+    def compatible_package_check(package, return_version=False):
+        result = package_check(package, return_version=return_version)
+        if not return_version and isinstance(result, tuple):
+            return result[0]
+        return result
+
+    trl_import_utils._is_package_available = compatible_package_check
+
+
 class _LazyModule(ModuleType):
     """
     Module class that surfaces all objects but only performs associated imports when the objects are requested.

--- a/swift/utils/import_utils.py
+++ b/swift/utils/import_utils.py
@@ -90,6 +90,9 @@ def patch_trl_package_check() -> None:
     trl_import_utils._is_package_available = compatible_package_check
 
 
+patch_trl_package_check()
+
+
 class _LazyModule(ModuleType):
     """
     Module class that surfaces all objects but only performs associated imports when the objects are requested.

--- a/swift/utils/import_utils.py
+++ b/swift/utils/import_utils.py
@@ -67,10 +67,13 @@ def is_trl_available() -> bool:
 
 def patch_trl_package_check() -> None:
     """Fix optional dependency checks in TRL <= 0.28 with Transformers 5."""
-    import trl.import_utils as trl_import_utils
+    try:
+        import trl.import_utils as trl_import_utils
+    except ImportError:
+        return
 
-    package_check = trl_import_utils._is_package_available
-    if not isinstance(package_check('trl'), tuple):
+    package_check = getattr(trl_import_utils, '_is_package_available', None)
+    if package_check is None or not isinstance(package_check('trl'), tuple):
         return
 
     def compatible_package_check(package, return_version=False):

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,0 +1,38 @@
+import trl.import_utils as trl_import_utils
+import unittest
+from unittest.mock import patch
+
+from swift.utils.import_utils import patch_trl_package_check
+
+
+class TestImportUtils(unittest.TestCase):
+
+    def test_patch_trl_package_check(self):
+
+        def package_check(package, return_version=False):
+            if return_version:
+                return True, '1.0.0'
+            return package not in {'vllm_ascend', 'weave'}, None
+
+        with patch.object(trl_import_utils, '_is_package_available', package_check):
+            patch_trl_package_check()
+
+            self.assertIs(trl_import_utils.is_vllm_ascend_available(), False)
+            self.assertIs(trl_import_utils.is_weave_available(), False)
+            self.assertEqual(trl_import_utils._is_package_available('vllm', return_version=True), (True, '1.0.0'))
+
+    def test_patch_trl_package_check_is_noop_for_bool_return(self):
+
+        def package_check(package, return_version=False):
+            if return_version:
+                return True, '1.0.0'
+            return True
+
+        with patch.object(trl_import_utils, '_is_package_available', package_check):
+            patch_trl_package_check()
+
+            self.assertIs(trl_import_utils._is_package_available, package_check)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,11 +1,30 @@
-import trl.import_utils as trl_import_utils
+import sys
 import unittest
+from types import ModuleType
 from unittest.mock import patch
 
 from swift.utils.import_utils import patch_trl_package_check
 
 
 class TestImportUtils(unittest.TestCase):
+
+    @staticmethod
+    def make_trl_modules(package_check):
+        trl = ModuleType('trl')
+        trl.__path__ = []
+        trl_import_utils = ModuleType('trl.import_utils')
+        trl_import_utils._is_package_available = package_check
+
+        def is_vllm_ascend_available():
+            return trl_import_utils._is_package_available('vllm_ascend')
+
+        def is_weave_available():
+            return trl_import_utils._is_package_available('weave')
+
+        trl_import_utils.is_vllm_ascend_available = is_vllm_ascend_available
+        trl_import_utils.is_weave_available = is_weave_available
+        trl.import_utils = trl_import_utils
+        return {'trl': trl, 'trl.import_utils': trl_import_utils}
 
     def test_patch_trl_package_check(self):
 
@@ -14,7 +33,9 @@ class TestImportUtils(unittest.TestCase):
                 return True, '1.0.0'
             return package not in {'vllm_ascend', 'weave'}, None
 
-        with patch.object(trl_import_utils, '_is_package_available', package_check):
+        modules = self.make_trl_modules(package_check)
+        trl_import_utils = modules['trl.import_utils']
+        with patch.dict(sys.modules, modules):
             patch_trl_package_check()
 
             self.assertIs(trl_import_utils.is_vllm_ascend_available(), False)
@@ -28,10 +49,22 @@ class TestImportUtils(unittest.TestCase):
                 return True, '1.0.0'
             return True
 
-        with patch.object(trl_import_utils, '_is_package_available', package_check):
+        modules = self.make_trl_modules(package_check)
+        trl_import_utils = modules['trl.import_utils']
+        with patch.dict(sys.modules, modules):
             patch_trl_package_check()
 
             self.assertIs(trl_import_utils._is_package_available, package_check)
+
+    def test_patch_trl_package_check_is_noop_without_trl(self):
+        with patch.dict(sys.modules, {'trl': None, 'trl.import_utils': None}):
+            patch_trl_package_check()
+
+    def test_patch_trl_package_check_is_noop_without_package_check(self):
+        modules = self.make_trl_modules(lambda package: True)
+        del modules['trl.import_utils']._is_package_available
+        with patch.dict(sys.modules, modules):
+            patch_trl_package_check()
 
 
 if __name__ == '__main__':

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -37,9 +37,12 @@ class TestImportUtils(unittest.TestCase):
         trl_import_utils = modules['trl.import_utils']
         with patch.dict(sys.modules, modules):
             patch_trl_package_check()
+            patched_package_check = trl_import_utils._is_package_available
+            patch_trl_package_check()
 
             self.assertIs(trl_import_utils.is_vllm_ascend_available(), False)
             self.assertIs(trl_import_utils.is_weave_available(), False)
+            self.assertIs(trl_import_utils._is_package_available, patched_package_check)
             self.assertEqual(trl_import_utils._is_package_available('vllm', return_version=True), (True, '1.0.0'))
 
     def test_patch_trl_package_check_is_noop_for_bool_return(self):

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,5 +1,7 @@
+import importlib.util
 import sys
 import unittest
+from pathlib import Path
 from types import ModuleType
 from unittest.mock import patch
 
@@ -44,6 +46,22 @@ class TestImportUtils(unittest.TestCase):
             self.assertIs(trl_import_utils.is_weave_available(), False)
             self.assertIs(trl_import_utils._is_package_available, patched_package_check)
             self.assertEqual(trl_import_utils._is_package_available('vllm', return_version=True), (True, '1.0.0'))
+
+    def test_patch_trl_package_check_runs_on_import(self):
+
+        def package_check(package, return_version=False):
+            if return_version:
+                return True, '1.0.0'
+            return package != 'weave', None
+
+        modules = self.make_trl_modules(package_check)
+        module_path = Path(__file__).parents[2] / 'swift/utils/import_utils.py'
+        spec = importlib.util.spec_from_file_location('_isolated_swift_import_utils', module_path)
+        isolated_import_utils = importlib.util.module_from_spec(spec)
+        with patch.dict(sys.modules, modules):
+            spec.loader.exec_module(isolated_import_utils)
+
+            self.assertIs(modules['trl.import_utils'].is_weave_available(), False)
 
     def test_patch_trl_package_check_is_noop_for_bool_return(self):
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This fixes GRPO imports with TRL 0.28 and Transformers 5.

Transformers 5 returns a tuple from `_is_package_available`. TRL 0.28 expects a bool. A missing optional package is therefore treated as installed.

#8280 fixed this for `vllm_ascend` only. The same issue still affects `weave` and other TRL optional dependencies. This PR fixes the shared package check and keeps version queries unchanged.

## Experiment results

- Added tests for missing `weave` and `vllm_ascend`.
- Added tests for missing TRL and newer TRL behavior.
- Verified that `return_version=True` still returns the version tuple.
- Verified that newer bool-return behavior is unchanged.
- Verified `GRPOTrainer` imports with TRL 0.28.0 and Transformers 5.3.0.
- Ran Qwen3.5-4B LoRA GRPO past step 500 with the same fix.
