### PR TITLE
Fix async GRPO _prefetch crash: convert raw rows via to_samples()

### DIFF
--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -1623,6 +1623,7 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
         inputs = next(iter(dataloader))
         if self.template.truncation_strategy == 'raise':
             inputs = self.resample_encode_failed_inputs(inputs)
+        inputs = self.to_samples(inputs)
         inputs = self._preprocess_inputs(inputs)
         all_inputs = gather_object(inputs)
         if self.state.global_step != self._last_loaded_step:


### PR DESCRIPTION
### What

`RolloutTrainerMixin._prefetch` (the async rollout path, used with `--async_generate true` / `--vllm_mode server`) passes the raw dataloader batch straight into `_preprocess_inputs` → `_add_prompt_id_to_inputs`, which accesses `.messages` on each item:

```python
all_messages = gather_object([s.messages for s in samples])
```

When dataset rows are collated as plain dicts, this raises:

```
AttributeError: 'dict' object has no attribute 'messages'
```

The crash happens at `on_train_begin` (prefetch), before step 0.

### Why

The synchronous rollout path `_rollout_samples` first converts raw rows to sample objects via `self.to_samples(inputs)` before preprocessing. The async `_prefetch` path is missing that conversion, so it feeds dicts into code that expects sample objects.

### Fix

Call `self.to_samples(inputs)` in `_prefetch` before `_preprocess_inputs`, mirroring `_rollout_samples`.

### Reproduce

GRPO with `--vllm_mode server --async_generate true` on a dataset that carries extra (non-standard) columns, so rows are collated as dicts.

### Verification

After the change, async GRPO trains normally (steps run + checkpoint saved) with rollout/train overlap across GPUs. Verified on ms-swift 4.4.1 and current `main` (Qwen3.5 4B, LoRA, vLLM server rollout).
