### PR TITLE
perf: vectorize _select_dataset for cached-dataset loading

### DIFF
--- a/swift/pipelines/utils.py
+++ b/swift/pipelines/utils.py
@@ -52,14 +52,16 @@ def _select_dataset(args, dataset):
         # Compatible with ms-swift 3.x cache_dataset
         dataset = dataset.rename_column('length', 'lengths')
     max_length = args.max_length
-    if args.truncation_strategy == 'delete':
+    new_dataset = dataset
+    if args.truncation_strategy == 'delete' and max_length is not None:
         lengths = dataset['lengths']
-        idxs = [
-            i for i, length in enumerate(lengths) if (max(length) if isinstance(length, list) else length) <= max_length
-        ]
-        new_dataset = dataset.select(idxs)
-    else:
-        new_dataset = dataset
+        if lengths and isinstance(lengths[0], list):
+            arr = np.fromiter((max(length) for length in lengths), dtype=np.int64, count=len(lengths))
+        else:
+            arr = np.asarray(lengths, dtype=np.int64)
+        keep = arr <= max_length
+        if not bool(keep.all()):
+            new_dataset = dataset.select(np.flatnonzero(keep))
     if len(new_dataset) < len(dataset):
         logger.info(f'Dataset filtered, origin length: {len(dataset)}, filtered dataset length: {len(new_dataset)}')
     return new_dataset


### PR DESCRIPTION
## What

`_select_dataset` (swift/pipelines/utils.py) runs on every `--cached_dataset` load, on every rank. The current implementation:

1. walks the whole `lengths` column in a Python list comprehension, and
2. **always** calls `dataset.select()` with one index per kept row — even when no row is over-length, which is the common case for caches produced by `swift export --to_cached_dataset true` (over-length rows are already deleted at export time). `select()` then writes a full indices mapping for nothing.

For large caches (ours is ~750k rows) this adds avoidable Python-loop time and an unnecessary indices-mapping write to every training start.

## Change

- numpy comparison over the column instead of the Python loop (np is already imported in this module)
- `select()` skipped entirely when nothing is dropped
- fixes a latent `TypeError` when `truncation_strategy='delete'` is combined with `max_length=None` (previously `int <= None`)

Behavior is otherwise identical: same kept-row set, same order, same log line.

## Verification

Compared against the original implementation on synthetic datasets (200k rows, both int-typed and list-typed `lengths` columns, ~0.1% over-length): kept-row sets are element-wise identical in both cases; zero-drop case returns the dataset unchanged.