### PR TITLE
Fix MindSpeed GDN import on Ascend 950

### DIFF
--- a/swift/megatron/__init__.py
+++ b/swift/megatron/__init__.py
@@ -4,13 +4,8 @@ try:
     from transformers.utils import is_torch_npu_available
 
     if is_torch_npu_available():
-        import torch_npu
-        device_name = torch_npu.npu.get_device_name()
-        if 'Ascend910_95' in device_name or 'Ascend950' in device_name:
-            import fla.utils
-            # MindSpeed still imports this flag after it was removed from upstream FLA.
-            if not hasattr(fla.utils, 'USE_CUDA_GRAPH'):
-                fla.utils.USE_CUDA_GRAPH = False
+        from swift.model.npu_patch.mindspeed import prepare_mindspeed_gdn_import
+        prepare_mindspeed_gdn_import()
         # Enable Megatron on Ascend NPU
         import mindspeed.megatron_adaptor  # F401
     from .init import init_megatron_env

--- a/swift/megatron/__init__.py
+++ b/swift/megatron/__init__.py
@@ -4,6 +4,13 @@ try:
     from transformers.utils import is_torch_npu_available
 
     if is_torch_npu_available():
+        import torch_npu
+        device_name = torch_npu.npu.get_device_name()
+        if 'Ascend910_95' in device_name or 'Ascend950' in device_name:
+            import fla.utils
+            # MindSpeed still imports this flag after it was removed from upstream FLA.
+            if not hasattr(fla.utils, 'USE_CUDA_GRAPH'):
+                fla.utils.USE_CUDA_GRAPH = False
         # Enable Megatron on Ascend NPU
         import mindspeed.megatron_adaptor  # F401
     from .init import init_megatron_env

--- a/swift/model/npu_patch/mindspeed.py
+++ b/swift/model/npu_patch/mindspeed.py
@@ -46,6 +46,18 @@ def _apply_gdn_patch(MindSpeedPatchesManager, patch, implementation) -> None:
 def _patch_mindspeed_fla_gdn_implementation(MindSpeedPatchesManager) -> None:
     patch = MindSpeedPatchesManager.patches_info.get(_FLA_GDN_PATCH_TARGET)
 
+    import torch_npu
+    device_name = torch_npu.npu.get_device_name()
+    if 'Ascend910_95' in device_name or 'Ascend950' in device_name:
+        from mindspeed.core.ssm.chunk_gated_delta_rule import chunk_gated_delta_rule as mindspeed_gdn
+        _apply_gdn_patch(MindSpeedPatchesManager, patch, mindspeed_gdn)
+        logger.info(
+            'Using MindSpeed chunk_gated_delta_rule for Megatron GDN on Ascend arch35: module=%s, source=%s.',
+            mindspeed_gdn.__module__,
+            inspect.getsourcefile(inspect.unwrap(mindspeed_gdn)),
+        )
+        return
+
     fla_error = None
     if (patch is not None and patch.orig_func is not None and patch.orig_func.__module__.startswith('fla.')):
         # MindSpeed propagates its replacement into already imported submodules,
@@ -82,7 +94,7 @@ def _patch_mindspeed_fla_gdn_implementation(MindSpeedPatchesManager) -> None:
 
 
 def patch_mindspeed_fla_gdn_implementation() -> None:
-    """Best-effort preference for upstream FLA while preserving the current GDN implementation."""
+    """Use MindSpeed GDN on Ascend arch35 and prefer upstream FLA elsewhere."""
     from mindspeed.patch_utils import MindSpeedPatchesManager
 
     try:

--- a/swift/model/npu_patch/mindspeed.py
+++ b/swift/model/npu_patch/mindspeed.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import sys
+from types import ModuleType
 from typing import Any
 
 from swift.utils.logger import get_logger
@@ -12,6 +13,44 @@ logger = get_logger()
 
 _ORIGINAL_MINDSPEED_TE_CP_CLASS = None
 _FLA_GDN_PATCH_TARGET = 'fla.ops.gated_delta_rule.chunk_gated_delta_rule'
+
+
+def prepare_mindspeed_gdn_import() -> None:
+    try:
+        import fla.utils
+    except ModuleNotFoundError as e:
+        if e.name not in {'fla', 'fla.utils'}:
+            raise
+        gdn_module = ModuleType('mindspeed.core.ssm.chunk_gated_delta_rule')
+
+        def torch_chunk_gated_delta_rule(
+                q, k, v, g, beta, scale=None, initial_state=None, output_final_state=False,
+                use_qk_l2norm_in_kernel=False, cu_seqlens=None, chunk_size=64, head_first=False, **kwargs):
+            if cu_seqlens is not None:
+                raise ValueError('Torch GDN fallback does not support cu_seqlens.')
+            from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import torch_chunk_gated_delta_rule as torch_gdn
+            return torch_gdn(
+                q,
+                k,
+                v,
+                g=g,
+                beta=beta,
+                chunk_size=chunk_size,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )
+
+        gdn_module.chunk_gated_delta_rule = torch_chunk_gated_delta_rule
+        gdn_module._ms_swift_torch_fallback = True
+        sys.modules[gdn_module.__name__] = gdn_module
+    else:
+        import torch_npu
+        device_name = torch_npu.npu.get_device_name()
+        # MindSpeed still imports this flag after it was removed from upstream FLA.
+        if not hasattr(fla.utils, 'USE_CUDA_GRAPH'):
+            if 'Ascend910_95' in device_name or 'Ascend950' in device_name:
+                fla.utils.USE_CUDA_GRAPH = False
 
 
 def _apply_gdn_patch(MindSpeedPatchesManager, patch, implementation) -> None:
@@ -45,6 +84,13 @@ def _apply_gdn_patch(MindSpeedPatchesManager, patch, implementation) -> None:
 
 def _patch_mindspeed_fla_gdn_implementation(MindSpeedPatchesManager) -> None:
     patch = MindSpeedPatchesManager.patches_info.get(_FLA_GDN_PATCH_TARGET)
+
+    mindspeed_gdn_module = sys.modules.get('mindspeed.core.ssm.chunk_gated_delta_rule')
+    if getattr(mindspeed_gdn_module, '_ms_swift_torch_fallback', False):
+        torch_gdn = mindspeed_gdn_module.chunk_gated_delta_rule
+        _apply_gdn_patch(MindSpeedPatchesManager, patch, torch_gdn)
+        logger.info('Using torch chunk_gated_delta_rule for Megatron GDN because FLA is unavailable.')
+        return
 
     import torch_npu
     device_name = torch_npu.npu.get_device_name()
@@ -94,7 +140,7 @@ def _patch_mindspeed_fla_gdn_implementation(MindSpeedPatchesManager) -> None:
 
 
 def patch_mindspeed_fla_gdn_implementation() -> None:
-    """Use MindSpeed GDN on Ascend arch35 and prefer upstream FLA elsewhere."""
+    """Use torch GDN without FLA, MindSpeed GDN on arch35, and upstream FLA elsewhere."""
     from mindspeed.patch_utils import MindSpeedPatchesManager
 
     try:

--- a/swift/model/npu_patch/mindspeed.py
+++ b/swift/model/npu_patch/mindspeed.py
@@ -65,9 +65,19 @@ def prepare_mindspeed_gdn_import() -> None:
             raise
         gdn_module = ModuleType('mindspeed.core.ssm.chunk_gated_delta_rule')
 
-        def torch_chunk_gated_delta_rule(
-                q, k, v, g, beta, scale=None, initial_state=None, output_final_state=False,
-                use_qk_l2norm_in_kernel=False, cu_seqlens=None, chunk_size=64, head_first=False, **kwargs):
+        def torch_chunk_gated_delta_rule(q,
+                                         k,
+                                         v,
+                                         g,
+                                         beta,
+                                         scale=None,
+                                         initial_state=None,
+                                         output_final_state=False,
+                                         use_qk_l2norm_in_kernel=False,
+                                         cu_seqlens=None,
+                                         chunk_size=64,
+                                         head_first=False,
+                                         **kwargs):
             if cu_seqlens is not None:
                 raise ValueError('Torch GDN fallback does not support cu_seqlens.')
             from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import torch_chunk_gated_delta_rule as torch_gdn
@@ -143,8 +153,7 @@ def _patch_mindspeed_fla_gdn_implementation(MindSpeedPatchesManager) -> None:
             _ORIGINAL_MINDSPEED_GDN = mindspeed_gdn
         _apply_gdn_patch(MindSpeedPatchesManager, patch, _mindspeed_gdn_with_safe_varlen)
         logger.info(
-            'Using MindSpeed chunk_gated_delta_rule with safe varlen fallback for Megatron GDN on Ascend arch35.'
-        )
+            'Using MindSpeed chunk_gated_delta_rule with safe varlen fallback for Megatron GDN on Ascend arch35.')
         return
 
     fla_error = None

--- a/swift/model/npu_patch/mindspeed.py
+++ b/swift/model/npu_patch/mindspeed.py
@@ -12,7 +12,49 @@ from swift.utils.logger import get_logger
 logger = get_logger()
 
 _ORIGINAL_MINDSPEED_TE_CP_CLASS = None
+_ORIGINAL_MINDSPEED_GDN = None
 _FLA_GDN_PATCH_TARGET = 'fla.ops.gated_delta_rule.chunk_gated_delta_rule'
+
+
+def _mindspeed_gdn_with_safe_varlen(q,
+                                    k,
+                                    v,
+                                    g,
+                                    beta,
+                                    scale=None,
+                                    initial_state=None,
+                                    output_final_state=False,
+                                    use_qk_l2norm_in_kernel=False,
+                                    cu_seqlens=None,
+                                    chunk_size=64,
+                                    head_first=False):
+    kwargs = {
+        'scale': scale,
+        'output_final_state': output_final_state,
+        'use_qk_l2norm_in_kernel': use_qk_l2norm_in_kernel,
+        'chunk_size': chunk_size,
+        'head_first': head_first,
+    }
+    if cu_seqlens is None:
+        return _ORIGINAL_MINDSPEED_GDN(q, k, v, g, beta, initial_state=initial_state, **kwargs)
+
+    # MindSpeed's arch35 varlen backward uses the local sequence length as the packed gate stride.
+    # Keep the same implementation but run each sequence independently to avoid the invalid indexing.
+    import torch
+    sequence_dim = 2 if head_first else 1
+    offsets = cu_seqlens.detach().cpu().tolist()
+    outputs, final_states = [], []
+    for i, (start, end) in enumerate(zip(offsets, offsets[1:])):
+        length = end - start
+        inputs = [x.narrow(sequence_dim, start, length) for x in (q, k, v, g, beta)]
+        state = None if initial_state is None else initial_state[i:i + 1]
+        output, final_state = _ORIGINAL_MINDSPEED_GDN(*inputs, initial_state=state, **kwargs)
+        outputs.append(output)
+        if output_final_state:
+            final_states.append(final_state)
+    output = torch.cat(outputs, dim=sequence_dim)
+    final_state = torch.cat(final_states) if output_final_state else None
+    return output, final_state
 
 
 def prepare_mindspeed_gdn_import() -> None:
@@ -96,11 +138,12 @@ def _patch_mindspeed_fla_gdn_implementation(MindSpeedPatchesManager) -> None:
     device_name = torch_npu.npu.get_device_name()
     if 'Ascend910_95' in device_name or 'Ascend950' in device_name:
         from mindspeed.core.ssm.chunk_gated_delta_rule import chunk_gated_delta_rule as mindspeed_gdn
-        _apply_gdn_patch(MindSpeedPatchesManager, patch, mindspeed_gdn)
+        global _ORIGINAL_MINDSPEED_GDN
+        if _ORIGINAL_MINDSPEED_GDN is None:
+            _ORIGINAL_MINDSPEED_GDN = mindspeed_gdn
+        _apply_gdn_patch(MindSpeedPatchesManager, patch, _mindspeed_gdn_with_safe_varlen)
         logger.info(
-            'Using MindSpeed chunk_gated_delta_rule for Megatron GDN on Ascend arch35: module=%s, source=%s.',
-            mindspeed_gdn.__module__,
-            inspect.getsourcefile(inspect.unwrap(mindspeed_gdn)),
+            'Using MindSpeed chunk_gated_delta_rule with safe varlen fallback for Megatron GDN on Ascend arch35.'
         )
         return
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix Megatron GDN initialization and implementation selection for Ascend 950 / arch35 environments.

## Changes
- Initialize the MindSpeed GDN import compatibility layer before importing `mindspeed.megatron_adaptor`.
- When FLA is unavailable, register a Torch-based `chunk_gated_delta_rule` fallback so MindSpeed imports can proceed.
- On Ascend 910_95 and Ascend 950 devices, prefer MindSpeed's native GDN implementation.
- Restore the `fla.utils.USE_CUDA_GRAPH` compatibility flag required by MindSpeed when it is absent in newer FLA versions.
- Preserve upstream FLA GDN behavior for other supported environments.

## Why not use FLA on Ascend 950?

FLA does not yet provide native Ascend 950 support for the Gated Delta Net (GDN) implementation. Therefore, on Ascend 950 / arch35 devices, this PR explicitly selects MindSpeed's native `chunk_gated_delta_rule` implementation instead of the upstream FLA implementation.

When FLA is not installed, a Torch-based GDN fallback is registered to keep MindSpeed imports and Megatron initialization working.

## Experiment results

Please add the relevant Megatron training/inference validation results on Ascend 950 if available.