### PR TITLE
fix(ci): refresh wandb in the CUDA test container setup

### DIFF
--- a/.dev_scripts/ci_container_test.sh
+++ b/.dev_scripts/ci_container_test.sh
@@ -220,6 +220,10 @@ if [ "$MODELSCOPE_SDK_DEBUG" == "True" ]; then
             fi
         fi
         pip install -r requirements/framework.txt -U -i https://mirrors.aliyun.com/pypi/simple/
+        # The CI image bakes an old wandb whose protobuf codegen does not
+        # survive the protobuf 7.x pulled in above, so `import wandb` dies
+        # with "cannot import name ... from wandb_telemetry_pb2". Refresh it.
+        pip install -U wandb -i https://mirrors.aliyun.com/pypi/simple/
         pip install decord einops -U -i https://mirrors.aliyun.com/pypi/simple/
         pip uninstall autoawq -y
         pip install optimum


### PR DESCRIPTION
The unittest job has been red on every PR since around July 14. #9744 reported it, and run 29903129982 on the latest main-facing PR shows the same failure: three test modules die at import with

```
ImportError: cannot import name 'Imports' from 'wandb.proto.wandb_telemetry_pb2'
```

The chain: the CI image bakes an old wandb, and the CUDA setup's `pip install -r requirements/framework.txt -U` pulls protobuf 7.35.1 in over it. The baked wandb's generated protobuf code does not work on protobuf 7.x, so `import wandb` inside `swift/rlhf_trainers/utils.py` blows up and takes `test_ray_gkd`, `test_multi_teacher` and `test_assemble_teacher_topk_logprobs` down with it. Those modules import the utils module for unrelated helpers; wandb is incidental.

Reproduced the mechanism locally: wandb 0.18.7 imports fine with protobuf 5.29.6, fails with `cannot import name 'Deprecated' from wandb.proto.wandb_telemetry_pb2` once protobuf 7.35.1 is forced in, and wandb 0.28.1 imports cleanly with protobuf 7.35.1. So refreshing wandb in the setup script is enough. NPU CI is green and untouched.

Fixes #9744.
