### PR TITLE
Feat: add qwen3_5-Moe GRPO megatron training scripts for Ascend NPU

### DIFF
--- a/examples/ascend/train/qwen3_5/qwen3_5_full_grpo_megatron.sh
+++ b/examples/ascend/train/qwen3_5/qwen3_5_full_grpo_megatron.sh
@@ -1,0 +1,58 @@
+export PYTHONPATH=$PYTHONPATH:<your_local_megatron_lm_path>
+export MEGATRON_LM_PATH=<your_local_megatron_lm_path>
+export VLLM_ASCEND_ENABLE_NZ=0
+export USE_MCORE_GDN=1
+#export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 \
+NPROC_PER_NODE=16 \
+megatron rlhf \
+    --rlhf_type grpo \
+    --model Qwen/Qwen3.5-35B-A3B \
+    --save_safetensors true \
+    --context_parallel_size 1 \
+    --tensor_model_parallel_size 4 \
+    --expert_model_parallel_size 8 \
+    --pipeline_model_parallel_size 2 \
+    --dataset AI-MO/NuminaMath-TIR#1000 \
+    --num_train_epochs 1 \
+    --global_batch_size 16 \
+    --micro_batch_size 1 \
+    --steps_per_generation 1 \
+    --num_generations 4 \
+    --reward_funcs accuracy \
+    --use_vllm true \
+    --vllm_mode colocate \
+    --vllm_gpu_memory_utilization 0.35 \
+    --vllm_tensor_parallel_size 4 \
+    --vllm_max_model_len 16384 \
+    --max_length 8192 \
+    --max_completion_length 8192\
+    --tuner_type full \
+    --lr 5e-5 \
+    --bf16 true \
+    --beta 0.00 \
+    --importance_sampling_level sequence \
+    --gradient_accumulation_fusion false \
+    --epsilon 3e-4 \
+    --epsilon_high 4e-4 \
+    --dynamic_sample false \
+    --overlong_filter true \
+    --loss_type grpo \
+    --sleep_level 2 \
+    --offload_model true \
+    --offload_bridge false \
+    --offload_optimizer true \
+    --optimizer_cpu_offload true \
+    --logging_steps 1 \
+    --recompute_granularity selective \
+    --finetune \
+    --dataloader_num_workers 8 \
+    --dataset_num_proc 8 \
+    --no_save_optim \
+    --no_save_rng \
+    --attention_backend flash \
+    --temperature 1.0 \
+    --padding_free true \
+    --sequence_parallel true \
+    --log_completions true \
+    --report_to tensorboard

--- a/examples/ascend/train/qwen3_5/qwen3_5_lora_grpo_megatron.sh
+++ b/examples/ascend/train/qwen3_5/qwen3_5_lora_grpo_megatron.sh
@@ -1,49 +1,58 @@
 export PYTHONPATH=$PYTHONPATH:<your_local_megatron_lm_path>
 export MEGATRON_LM_PATH=<your_local_megatron_lm_path>
 export VLLM_ASCEND_ENABLE_NZ=0
-export TASK_QUEUE_ENABLE=0
+export USE_MCORE_GDN=1
+#export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
 NPROC_PER_NODE=8 \
-accelerate launch --config_file "./examples/ascend/train/qwen3_5/fsdp2.json" \
-    swift/cli/rlhf.py \
-        --rlhf_type grpo \
-        --model Qwen/Qwen3.5-35B-A3B \
-        --model_type qwen3_5_moe \
-        --reward_funcs accuracy \
-        --use_vllm true \
-        --vllm_mode colocate \
-        --vllm_gpu_memory_utilization 0.4 \
-        --vllm_enforce_eager false \
-        --vllm_tensor_parallel_size 4 \
-        --vllm_max_model_len 16384 \
-        --tuner_type lora \
-        --lora_rank 8 \
-        --lora_alpha 32 \
-        --torch_dtype bfloat16 \
-        --dataset AI-MO/NuminaMath-TIR#1000 \
-        --max_length 1024 \
-        --max_completion_length 8192 \
-        --overlong_filter true \
-        --num_train_epochs 1 \
-        --per_device_train_batch_size 1 \
-        --learning_rate 1e-6 \
-        --gradient_accumulation_steps 1 \
-        --save_strategy 'steps' \
-        --eval_strategy 'steps' \
-        --eval_steps 1000 \
-        --save_steps 1000 \
-        --save_total_limit 10 \
-        --logging_steps 1 \
-        --warmup_ratio 0.01 \
-        --dataloader_num_workers 4 \
-        --num_generations 4 \
-        --temperature 1.0 \
-        --log_completions true \
-        --sleep_level 2 \
-        --offload_model true \
-        --offload_optimizer true \
-        --gradient_checkpointing false \
-        --report_to tensorboard \
-        --num_iterations 1 \
-        --beta 0.001 \
-        --move_model_batches 40
+megatron rlhf \
+    --rlhf_type grpo \
+    --model Qwen/Qwen3.5-35B-A3B \
+    --save_safetensors true \
+    --merge_lora false \
+    --context_parallel_size 1 \
+    --tensor_model_parallel_size 2 \
+    --expert_model_parallel_size 4 \
+    --pipeline_model_parallel_size 2 \
+    --dataset AI-MO/NuminaMath-TIR#1000 \
+    --num_train_epochs 1 \
+    --global_batch_size 8 \
+    --micro_batch_size 1 \
+    --steps_per_generation 1 \
+    --num_generations 4 \
+    --reward_funcs accuracy \
+    --use_vllm true \
+    --vllm_mode colocate \
+    --vllm_gpu_memory_utilization 0.6 \
+    --vllm_tensor_parallel_size 4 \
+    --vllm_max_model_len 16384 \
+    --max_length 8192 \
+    --max_completion_length 8192 \
+    --tuner_type lora \
+    --lr 5e-5 \
+    --bf16 true \
+    --beta 0.00 \
+    --importance_sampling_level sequence \
+    --gradient_accumulation_fusion false \
+    --epsilon 3e-4 \
+    --epsilon_high 4e-4 \
+    --dynamic_sample false \
+    --overlong_filter true \
+    --loss_type grpo \
+    --sleep_level 2 \
+    --offload_model true \
+    --offload_bridge false \
+    --offload_optimizer true \
+    --logging_steps 1 \
+    --recompute_granularity selective \
+    --finetune \
+    --dataloader_num_workers 8 \
+    --dataset_num_proc 8 \
+    --no_save_optim \
+    --no_save_rng \
+    --attention_backend flash \
+    --temperature 1.0 \
+    --padding_free true \
+    --sequence_parallel true \
+    --log_completions true \
+    --report_to tensorboard

--- a/examples/ascend/train/qwen3_5/qwen3_5_lora_grpo_megatron.sh
+++ b/examples/ascend/train/qwen3_5/qwen3_5_lora_grpo_megatron.sh
@@ -1,0 +1,49 @@
+export PYTHONPATH=$PYTHONPATH:<your_local_megatron_lm_path>
+export MEGATRON_LM_PATH=<your_local_megatron_lm_path>
+export VLLM_ASCEND_ENABLE_NZ=0
+export TASK_QUEUE_ENABLE=0
+ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+NPROC_PER_NODE=8 \
+accelerate launch --config_file "./examples/ascend/train/qwen3_5/fsdp2.json" \
+    swift/cli/rlhf.py \
+        --rlhf_type grpo \
+        --model Qwen/Qwen3.5-35B-A3B \
+        --model_type qwen3_5_moe \
+        --reward_funcs accuracy \
+        --use_vllm true \
+        --vllm_mode colocate \
+        --vllm_gpu_memory_utilization 0.4 \
+        --vllm_enforce_eager false \
+        --vllm_tensor_parallel_size 4 \
+        --vllm_max_model_len 16384 \
+        --tuner_type lora \
+        --lora_rank 8 \
+        --lora_alpha 32 \
+        --torch_dtype bfloat16 \
+        --dataset AI-MO/NuminaMath-TIR#1000 \
+        --max_length 1024 \
+        --max_completion_length 8192 \
+        --overlong_filter true \
+        --num_train_epochs 1 \
+        --per_device_train_batch_size 1 \
+        --learning_rate 1e-6 \
+        --gradient_accumulation_steps 1 \
+        --save_strategy 'steps' \
+        --eval_strategy 'steps' \
+        --eval_steps 1000 \
+        --save_steps 1000 \
+        --save_total_limit 10 \
+        --logging_steps 1 \
+        --warmup_ratio 0.01 \
+        --dataloader_num_workers 4 \
+        --num_generations 4 \
+        --temperature 1.0 \
+        --log_completions true \
+        --sleep_level 2 \
+        --offload_model true \
+        --offload_optimizer true \
+        --gradient_checkpointing false \
+        --report_to tensorboard \
+        --num_iterations 1 \
+        --beta 0.001 \
+        --move_model_batches 40


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Full-tuning and LoRA GRPO megatron training scripts for Qwen3.5 MoE on Ascend NPU, including recommended parallelism, offload, and vLLM-colocate settings.

