### PR TITLE
fix(npu): support Qwen3.5 LoRA and MoE sleep/wake in GRPO rollout

### DIFF
--- a/examples/ascend/grpo/fsdp2/qwen3_5_4b_lora.sh
+++ b/examples/ascend/grpo/fsdp2/qwen3_5_4b_lora.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# 2 * Ascend 910B3 (64 GiB)
+# FSDP2 shards the training model across two data-parallel ranks.
+
+source /usr/local/Ascend/nnal/atb/set_env.sh || exit 1
+
+NPROC_PER_NODE=2 \
+ASCEND_RT_VISIBLE_DEVICES=0,1 \
+MASTER_PORT=29501 \
+swift rlhf \
+    --rlhf_type grpo \
+    --model Qwen/Qwen3.5-4B \
+    --check_model false \
+    --dataset 'AI-MO/NuminaMath-TIR#32' \
+    --split_dataset_ratio 0 \
+    --system 'You are a helpful math assistant. Solve the problem step by step and put your final answer within \boxed{}.' \
+    --reward_funcs accuracy \
+    --use_vllm true \
+    --vllm_mode colocate \
+    --vllm_enable_lora true \
+    --vllm_gpu_memory_utilization 0.20 \
+    --vllm_tensor_parallel_size 1 \
+    --vllm_max_model_len 1024 \
+    --max_length 256 \
+    --max_completion_length 128 \
+    --num_generations 2 \
+    --steps_per_generation 1 \
+    --tuner_type lora \
+    --target_modules all-linear \
+    --lora_rank 8 \
+    --lora_alpha 32 \
+    --torch_dtype bfloat16 \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 1 \
+    --gradient_checkpointing false \
+    --learning_rate 1e-5 \
+    --fsdp fsdp2 \
+    --max_steps 1 \
+    --logging_steps 1 \
+    --save_strategy no \
+    --eval_strategy no \
+    --dataloader_num_workers 1 \
+    --dataset_num_proc 1 \
+    --report_to none \
+    --output_dir output/qwen3_5_4b_grpo_fsdp2

--- a/examples/ascend/grpo/megatron/qwen3_5_4b_lora.sh
+++ b/examples/ascend/grpo/megatron/qwen3_5_4b_lora.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# 2 * Ascend 910B3 (64 GiB)
+# TP=PP=1, so both ranks are data-parallel training ranks.
+# generation_batch_size = global_batch_size * steps_per_generation = 4.
+# rollout prompts = generation_batch_size / num_generations = 2.
+
+source /usr/local/Ascend/nnal/atb/set_env.sh || exit 1
+
+NPROC_PER_NODE=2 \
+ASCEND_RT_VISIBLE_DEVICES=0,1 \
+MASTER_PORT=29502 \
+megatron rlhf \
+    --rlhf_type grpo \
+    --model Qwen/Qwen3.5-4B \
+    --check_model false \
+    --save_safetensors true \
+    --dataset 'AI-MO/NuminaMath-TIR#32' \
+    --split_dataset_ratio 0 \
+    --system 'You are a helpful math assistant. Solve the problem step by step and put your final answer within \boxed{}.' \
+    --reward_funcs accuracy \
+    --use_vllm true \
+    --vllm_mode colocate \
+    --vllm_gpu_memory_utilization 0.20 \
+    --vllm_tensor_parallel_size 1 \
+    --vllm_max_model_len 1024 \
+    --max_length 256 \
+    --max_completion_length 128 \
+    --num_generations 2 \
+    --steps_per_generation 1 \
+    --context_parallel_size 1 \
+    --tensor_model_parallel_size 1 \
+    --pipeline_model_parallel_size 1 \
+    --global_batch_size 4 \
+    --micro_batch_size 1 \
+    --tuner_type lora \
+    --target_modules all-linear \
+    --lora_rank 8 \
+    --lora_alpha 32 \
+    --merge_lora true \
+    --bf16 true \
+    --gradient_accumulation_fusion false \
+    --lr 1e-5 \
+    --finetune true \
+    --train_iters 1 \
+    --logging_steps 1 \
+    --save_steps 1000 \
+    --no_save_optim \
+    --no_save_rng \
+    --dataloader_num_workers 1 \
+    --dataset_num_proc 1 \
+    --attention_backend flash \
+    --padding_free false \
+    --log_completions true \
+    --output_dir output/qwen3_5_4b_grpo_megatron

--- a/swift/megatron/trainers/rollout_mixin.py
+++ b/swift/megatron/trainers/rollout_mixin.py
@@ -22,6 +22,7 @@ from dataclasses import asdict
 from megatron.core import mpu
 from megatron.core.rerun_state_machine import RerunDataIterator
 from transformers import AutoConfig
+from transformers.utils import is_torch_npu_available
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from swift.infer_engine.protocol import RequestConfig, RolloutInferRequest, RolloutOutput
@@ -376,6 +377,10 @@ class MegatronRolloutMixin(BaseRolloutTrainerMixin):
 
         if args.rlhf_type == 'gkd' and args.lmbda == 0:
             return
+
+        if is_torch_npu_available():
+            from swift.model.npu_patch.vllm_ascend import validate_vllm_ascend_megatron_lora_training
+            validate_vllm_ascend_megatron_lora_training(self.unwrapped_models, args)
 
         if not is_vllm_available():
             raise ImportError('vLLM is not available and `use_vllm` is set to True. '

--- a/swift/model/npu_patch/vllm_ascend.py
+++ b/swift/model/npu_patch/vllm_ascend.py
@@ -14,8 +14,7 @@ from __future__ import annotations
 
 import sys
 
-from swift.model.npu_patch.vllm_ascend_lora import (patch_vllm_ascend_lora_runtime,
-                                                    validate_vllm_ascend_lora_training,
+from swift.model.npu_patch.vllm_ascend_lora import (patch_vllm_ascend_lora_runtime, validate_vllm_ascend_lora_training,
                                                     validate_vllm_ascend_megatron_lora_training)
 from swift.model.npu_patch.vllm_ascend_memory import patch_vllm_ascend_memory_runtime
 from swift.model.npu_patch.vllm_ascend_moe import (patch_vllm_ascend_moe_expert_weight_loader,

--- a/swift/model/npu_patch/vllm_ascend.py
+++ b/swift/model/npu_patch/vllm_ascend.py
@@ -4,6 +4,7 @@
 Keep this file thin.  The real patches are split by responsibility:
 
 * ``vllm_ascend_moe``: MoE routing and GRPO weight-sync layout handling.
+* ``vllm_ascend_lora``: LoRA packed-projection layout compatibility.
 * ``vllm_ascend_memory``: small torch-npu/vLLM-Ascend memory API compatibility.
 Callers should import from this module so the public entrypoints stay stable,
 while reviewers can audit each patch family in its own file.  The caller is
@@ -13,6 +14,9 @@ from __future__ import annotations
 
 import sys
 
+from swift.model.npu_patch.vllm_ascend_lora import (patch_vllm_ascend_lora_runtime,
+                                                    validate_vllm_ascend_lora_training,
+                                                    validate_vllm_ascend_megatron_lora_training)
 from swift.model.npu_patch.vllm_ascend_memory import patch_vllm_ascend_memory_runtime
 from swift.model.npu_patch.vllm_ascend_moe import (patch_vllm_ascend_moe_expert_weight_loader,
                                                    patch_vllm_ascend_moe_runtime, should_skip_vllm_ascend_moe_post_load,
@@ -51,6 +55,7 @@ def patch_vllm_ascend_runtime(*, colocate: bool = False) -> None:
     compatibility patches below.
     """
     _patch_flash_attn_optional_import()
+    patch_vllm_ascend_lora_runtime()
     patch_vllm_ascend_moe_runtime()
     patch_vllm_ascend_memory_runtime()
 
@@ -60,4 +65,6 @@ __all__ = [
     'patch_vllm_ascend_runtime',
     'should_skip_vllm_ascend_moe_post_load',
     'use_vllm_ascend_moe_preprocessed_weight',
+    'validate_vllm_ascend_lora_training',
+    'validate_vllm_ascend_megatron_lora_training',
 ]

--- a/swift/model/npu_patch/vllm_ascend_lora.py
+++ b/swift/model/npu_patch/vllm_ascend_lora.py
@@ -1,0 +1,201 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""vLLM-Ascend LoRA compatibility patches."""
+from __future__ import annotations
+
+import torch
+
+from swift.utils.logger import get_logger
+
+_QWEN3_5_QKVZ_SUFFIX = '.linear_attn.in_proj_qkvz'
+logger = get_logger()
+
+
+def validate_vllm_ascend_lora_training(model, args) -> None:
+    """Reject training configurations whose expert LoRA cannot run in vLLM-Ascend."""
+    if args.tuner_type != 'lora' or not args.vllm_enable_lora or not model.model_info.is_moe_model:
+        return
+
+    tuner = getattr(model, 'base_model', None)
+    targeted_parameter_names = getattr(tuner, 'targeted_parameter_names',
+                                       getattr(args, 'target_parameters', None) or [])
+    routed_expert_parameters = sorted(
+        name for name in targeted_parameter_names if 'experts' in name.split('.'))
+    if not routed_expert_parameters:
+        return
+
+    raise ValueError(
+        'vLLM-Ascend does not support LoRA on fused routed experts, but the training model targets '
+        f'these expert parameters: {routed_expert_parameters}. With `vllm_enable_lora=true`, rollout '
+        'would omit their LoRA updates and diverge from training. Set `vllm_enable_lora=false` or '
+        'remove the routed-expert entries from `target_parameters`.')
+
+
+def validate_vllm_ascend_megatron_lora_training(models, args) -> None:
+    """Reject Megatron expert LoRA that vLLM-Ascend cannot apply during rollout."""
+    if args.tuner_type != 'lora' or not args.vllm_enable_lora or not args.model_info.is_moe_model:
+        return
+
+    routed_expert_modules = sorted({
+        name.split('.lora_', 1)[0]
+        for model in models
+        for name, parameter in model.named_parameters()
+        if parameter.requires_grad and 'experts' in name.split('.') and '.lora_' in name
+    })
+    if not routed_expert_modules:
+        return
+
+    raise ValueError(
+        'vLLM-Ascend does not support LoRA on fused routed experts, but the Megatron training model has '
+        f'trainable expert LoRA modules: {routed_expert_modules}. With `vllm_enable_lora=true`, rollout '
+        'would omit their LoRA updates and diverge from training. Set `vllm_enable_lora=false` or choose '
+        '`target_modules` that do not match routed-expert layers.')
+
+
+def _exclude_unsupported_fused_moe_lora_modules(
+    model,
+    supported_modules: list[str],
+    *,
+    fused_moe_cls=None,
+) -> list[str]:
+    """Exclude routed experts whose LoRA runtime is CUDA-only in vLLM.
+
+    vLLM adds every ``FusedMoE`` suffix to the LoRA manager's supported module
+    list. Its v0.18 wrapper builds a TritonExperts kernel during manager
+    initialization, but that kernel is unavailable on NPU. The Transformers
+    LoRA path still supports ordinary linear modules around the MoE block
+    (for example attention and shared experts), so only the fused routed
+    expert suffixes must be removed.
+    """
+    if fused_moe_cls is None:
+        from vllm.model_executor.layers.fused_moe import FusedMoE
+        fused_moe_cls = FusedMoE
+
+    fused_moe_suffixes = {
+        name.rsplit('.', 1)[-1]
+        for name, module in model.named_modules() if isinstance(module, fused_moe_cls)
+    }
+    if not fused_moe_suffixes:
+        return supported_modules
+    return [module for module in supported_modules if module not in fused_moe_suffixes]
+
+
+def _patch_vllm_ascend_fused_moe_lora_modules() -> None:
+    """Keep vLLM's CUDA-only FusedMoE LoRA wrapper out of the NPU path."""
+    try:
+        import vllm.lora.model_manager as model_manager
+        import vllm.lora.utils as lora_utils
+    except ImportError:
+        return
+
+    origin_get_supported = model_manager.get_supported_lora_modules
+    if getattr(origin_get_supported, '_swift_npu_fused_moe_lora_patched', False):
+        return
+
+    def get_supported_lora_modules(model):
+        supported_modules = origin_get_supported(model)
+        filtered_modules = _exclude_unsupported_fused_moe_lora_modules(model, supported_modules)
+        if len(filtered_modules) != len(supported_modules):
+            logger.warning_once(
+                'vLLM-Ascend does not support LoRA on fused routed experts; those modules will be skipped. '
+                'LoRA on attention and other supported linear modules remains enabled.')
+        return filtered_modules
+
+    get_supported_lora_modules._swift_origin = origin_get_supported
+    get_supported_lora_modules._swift_npu_fused_moe_lora_patched = True
+    model_manager.get_supported_lora_modules = get_supported_lora_modules
+    lora_utils.get_supported_lora_modules = get_supported_lora_modules
+
+
+def _expand_qwen3_5_qkvz_lora(
+    lora_a: list[torch.Tensor | None],
+    lora_b: list[torch.Tensor | None],
+    output_sizes: list[int],
+    *,
+    tp_size: int = 1,
+) -> tuple[list[torch.Tensor | None], list[torch.Tensor | None]]:
+    """Expand Qwen3.5's logical ``qkv + z`` LoRAs into ``q + k + v + z``.
+
+    Qwen3.5 checkpoints expose two logical modules, ``in_proj_qkv`` and
+    ``in_proj_z``, while vLLM's merged runtime layer has four physical output
+    slices. The fused qkv LoRA shares one A matrix and concatenates q/k/v in
+    its B matrix, so A is reused and B is split along its output dimension.
+    """
+    if len(lora_a) != 2 or len(lora_b) != 2 or len(output_sizes) != 4:
+        raise RuntimeError('Qwen3.5 in_proj_qkvz LoRA expects 2 logical adapters and 4 output slices, '
+                           f'got len(lora_a)={len(lora_a)}, len(lora_b)={len(lora_b)}, '
+                           f'output_sizes={output_sizes}.')
+
+    qkv_a, z_a = lora_a
+    qkv_b, z_b = lora_b
+    if (qkv_a is None) != (qkv_b is None) or (z_a is None) != (z_b is None):
+        raise RuntimeError('Qwen3.5 in_proj_qkvz LoRA A/B presence does not match.')
+
+    # vLLM creates its profiling adapter from the first two physical buffers,
+    # although the packed-module mapping contains the two logical qkv/z names.
+    # Those tensors are all-zero and have partition-local q/k shapes. Replace
+    # them with correctly shaped zero q/k/v/z tensors for warmup.
+    output_slices = [size // tp_size for size in output_sizes]
+    is_profile_adapter = (
+        qkv_a is not None and z_a is not None and qkv_b is not None and z_b is not None
+        and qkv_b.shape[0] == output_slices[0] and z_b.shape[0] == output_slices[1]
+        and not torch.count_nonzero(qkv_b).item() and not torch.count_nonzero(z_b).item())
+    if is_profile_adapter:
+        expanded_b = [qkv_b.new_zeros((size, qkv_b.shape[1])) for size in output_sizes[:3]]
+        expanded_b.append(z_b.new_zeros((output_sizes[3], z_b.shape[1])))
+        return [qkv_a, qkv_a, qkv_a, z_a], expanded_b
+
+    expanded_a: list[torch.Tensor | None]
+    expanded_b: list[torch.Tensor | None]
+    if qkv_b is None:
+        expanded_a = [None, None, None]
+        expanded_b = [None, None, None]
+    else:
+        expected_qkv_size = sum(output_sizes[:3])
+        if qkv_b.shape[0] != expected_qkv_size:
+            raise RuntimeError('Qwen3.5 in_proj_qkv LoRA B has an unexpected output dimension: '
+                               f'expected {expected_qkv_size}, got {qkv_b.shape[0]}.')
+        expanded_a = [qkv_a, qkv_a, qkv_a]
+        expanded_b = list(qkv_b.split(output_sizes[:3], dim=0))
+
+    if z_b is not None and z_b.shape[0] != output_sizes[3]:
+        raise RuntimeError('Qwen3.5 in_proj_z LoRA B has an unexpected output dimension: '
+                           f'expected {output_sizes[3]}, got {z_b.shape[0]}.')
+    expanded_a.append(z_a)
+    expanded_b.append(z_b)
+    return expanded_a, expanded_b
+
+
+def patch_vllm_ascend_lora_runtime() -> None:
+    """Patch vLLM-Ascend's merged LoRA wrapper for Qwen3.5 GDN projections."""
+    _patch_vllm_ascend_fused_moe_lora_modules()
+    try:
+        from vllm_ascend.lora.utils import AscendMergedColumnParallelLinearWithLoRA
+    except (ImportError, AttributeError):
+        return
+
+    wrapper_cls = AscendMergedColumnParallelLinearWithLoRA
+    if getattr(wrapper_cls, '_swift_qwen3_5_qkvz_lora_patched', False):
+        return
+    origin_set_lora = wrapper_cls.set_lora
+
+    def set_lora(self, index, lora_a, lora_b):
+        prefix = getattr(self.base_layer, 'prefix', '')
+        if prefix.endswith(_QWEN3_5_QKVZ_SUFFIX):
+            lora_a, lora_b = _expand_qwen3_5_qkvz_lora(
+                lora_a,
+                lora_b,
+                self.base_layer.output_sizes,
+                tp_size=self.tp_size,
+            )
+        return origin_set_lora(self, index, lora_a, lora_b)
+
+    set_lora._swift_origin = origin_set_lora
+    wrapper_cls.set_lora = set_lora
+    wrapper_cls._swift_qwen3_5_qkvz_lora_patched = True
+
+
+__all__ = [
+    'patch_vllm_ascend_lora_runtime',
+    'validate_vllm_ascend_lora_training',
+    'validate_vllm_ascend_megatron_lora_training',
+]

--- a/swift/model/npu_patch/vllm_ascend_lora.py
+++ b/swift/model/npu_patch/vllm_ascend_lora.py
@@ -18,16 +18,14 @@ def validate_vllm_ascend_lora_training(model, args) -> None:
     tuner = getattr(model, 'base_model', None)
     targeted_parameter_names = getattr(tuner, 'targeted_parameter_names',
                                        getattr(args, 'target_parameters', None) or [])
-    routed_expert_parameters = sorted(
-        name for name in targeted_parameter_names if 'experts' in name.split('.'))
+    routed_expert_parameters = sorted(name for name in targeted_parameter_names if 'experts' in name.split('.'))
     if not routed_expert_parameters:
         return
 
-    raise ValueError(
-        'vLLM-Ascend does not support LoRA on fused routed experts, but the training model targets '
-        f'these expert parameters: {routed_expert_parameters}. With `vllm_enable_lora=true`, rollout '
-        'would omit their LoRA updates and diverge from training. Set `vllm_enable_lora=false` or '
-        'remove the routed-expert entries from `target_parameters`.')
+    raise ValueError('vLLM-Ascend does not support LoRA on fused routed experts, but the training model targets '
+                     f'these expert parameters: {routed_expert_parameters}. With `vllm_enable_lora=true`, rollout '
+                     'would omit their LoRA updates and diverge from training. Set `vllm_enable_lora=false` or '
+                     'remove the routed-expert entries from `target_parameters`.')
 
 
 def validate_vllm_ascend_megatron_lora_training(models, args) -> None:
@@ -44,11 +42,10 @@ def validate_vllm_ascend_megatron_lora_training(models, args) -> None:
     if not routed_expert_modules:
         return
 
-    raise ValueError(
-        'vLLM-Ascend does not support LoRA on fused routed experts, but the Megatron training model has '
-        f'trainable expert LoRA modules: {routed_expert_modules}. With `vllm_enable_lora=true`, rollout '
-        'would omit their LoRA updates and diverge from training. Set `vllm_enable_lora=false` or choose '
-        '`target_modules` that do not match routed-expert layers.')
+    raise ValueError('vLLM-Ascend does not support LoRA on fused routed experts, but the Megatron training model has '
+                     f'trainable expert LoRA modules: {routed_expert_modules}. With `vllm_enable_lora=true`, rollout '
+                     'would omit their LoRA updates and diverge from training. Set `vllm_enable_lora=false` or choose '
+                     '`target_modules` that do not match routed-expert layers.')
 
 
 def _exclude_unsupported_fused_moe_lora_modules(

--- a/swift/model/npu_patch/vllm_ascend_moe.py
+++ b/swift/model/npu_patch/vllm_ascend_moe.py
@@ -168,8 +168,7 @@ def _patch_vllm_ascend_moe_sleep_layout(worker_cls=None) -> None:
         if restore_weights:
             saved_moe_parameters = {
                 name: param
-                for name, param in model.named_parameters()
-                if 'w13_weight' in name or 'w2_weight' in name
+                for name, param in model.named_parameters() if 'w13_weight' in name or 'w2_weight' in name
             }
 
         result = origin_wake_up(self, tags=tags)

--- a/swift/model/npu_patch/vllm_ascend_moe.py
+++ b/swift/model/npu_patch/vllm_ascend_moe.py
@@ -127,9 +127,82 @@ def _patch_vllm_ascend_device_op_nonquant_routing() -> None:
     adaptor_cls.npu_moe_init_routing = staticmethod(patched_npu_moe_init_routing)
 
 
+def _patch_vllm_ascend_moe_sleep_layout(worker_cls=None) -> None:
+    """Keep processed MoE parameters in their runtime layout after wake-up.
+
+    vLLM-Ascend 0.18 transposes unquantized ``w13_weight``/``w2_weight``
+    parameters in ``NPUWorker.wake_up``.  This prepares the parameters for a
+    checkpoint-format full-weight reload, but corrupts inference when the
+    caller only reloads a LoRA adapter: untouched routed-expert weights remain
+    in the checkpoint layout and grouped matmul observes a hidden-size
+    mismatch.
+
+    The allocator restores the original parameter storage before that
+    transpose.  Preserve and reinstall those original Parameters so sleep/wake
+    itself is layout-neutral.  SWIFT's full-weight sync already handles both
+    processed and preprocessed expert layouts explicitly.
+    """
+    if worker_cls is None:
+        try:
+            from vllm_ascend.worker.worker import NPUWorker
+        except (ImportError, AttributeError):
+            return
+        worker_cls = NPUWorker
+
+    origin_wake_up = getattr(worker_cls, 'wake_up', None)
+    if origin_wake_up is None or getattr(origin_wake_up, '_swift_moe_sleep_layout_patched', False):
+        return
+
+    try:
+        origin_source = inspect.getsource(origin_wake_up)
+    except (OSError, TypeError):
+        return
+    layout_rewrite_tokens = ('w2_weight', 'w13_weight', 'transpose(1, 2)', 'setattr(parent_module, param_name')
+    if not all(token in origin_source for token in layout_rewrite_tokens):
+        return
+
+    def wake_up(self, tags=None):
+        restore_weights = tags is None or 'weights' in tags
+        model = self.model_runner.model
+        saved_moe_parameters = {}
+        if restore_weights:
+            saved_moe_parameters = {
+                name: param
+                for name, param in model.named_parameters()
+                if 'w13_weight' in name or 'w2_weight' in name
+            }
+
+        result = origin_wake_up(self, tags=tags)
+
+        restored = 0
+        for name, original_param in saved_moe_parameters.items():
+            try:
+                current_param = model.get_parameter(name)
+            except AttributeError:
+                continue
+            expected_transposed_shape = (
+                original_param.shape[:-2] + (original_param.shape[-1], original_param.shape[-2]))
+            if current_param is original_param or current_param.shape != expected_transposed_shape:
+                continue
+            parts = name.split('.')
+            parent_module = model.get_submodule('.'.join(parts[:-1]))
+            setattr(parent_module, parts[-1], original_param)
+            restored += 1
+
+        if restored:
+            logger.warning_once(
+                f'Preserved the vLLM-Ascend runtime layout of {restored} FusedMoE parameters across sleep/wake.')
+        return result
+
+    wake_up._swift_origin = origin_wake_up
+    wake_up._swift_moe_sleep_layout_patched = True
+    worker_cls.wake_up = wake_up
+
+
 def patch_vllm_ascend_moe_runtime() -> None:
     """Apply MoE runtime patches that are independent of GRPO weight sync."""
     _patch_vllm_ascend_device_op_nonquant_routing()
+    _patch_vllm_ascend_moe_sleep_layout()
 
 
 def _is_qwen_moe_model(model) -> bool:

--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -392,6 +392,10 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
             raise ImportError('vLLM is not available and `use_vllm` is set to True. '
                               'Please install vLLM with `pip install vllm -U` to use it.')
 
+        if is_torch_npu_available():
+            from swift.model.npu_patch.vllm_ascend import validate_vllm_ascend_lora_training
+            validate_vllm_ascend_lora_training(self.model, args)
+
         if not self.vllm_version_ge_0_10_2 and getattr(self.args, 'rollout_importance_sampling_mode', None) is not None:
             raise ValueError('rollout_importance_sampling_mode is not supported in vLLM version < 0.10.2, '
                              'please update vLLM to 0.10.2 or later.')


### PR DESCRIPTION
# PR title

```text
fix(npu): support Qwen3.5 LoRA and MoE sleep/wake in GRPO rollout
```

# PR description

## PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

## Summary

This PR fixes three NPU GRPO functions in the vLLM-Ascend colocate path:

| Function | Previous behavior | Behavior after this PR |
| --- | --- | --- |
| Qwen3.5 `vllm_enable_lora` | Qwen3.5 packed QKVZ LoRA did not match the vLLM-Ascend runtime layout and failed during adapter profiling or loading | Logical `qkv + z` adapters are converted to the physical `q + k + v + z` layout |
| MoE `vllm_enable_lora` | vLLM tried to initialize its CUDA/Triton FusedMoE LoRA wrapper on NPU; skipping expert LoRA could also silently change rollout semantics | Unsupported FusedMoE wrappers are excluded, while configurations that really train routed-expert LoRA fail early |
| MoE `sleep_level` | `wake_up` transposed expert weights, but adapter-only synchronization did not reload those base weights, leaving them in the wrong layout | Processed `w13_weight` and `w2_weight` Parameters keep their runtime layout across sleep/wake |

The PR also adds portable Qwen3.5-4B GRPO examples for the FSDP2 and
Megatron backends.

## 1. Qwen3.5 LoRA rollout with `vllm_enable_lora=true`

### Previous problem

Qwen3.5 exposes the Gated DeltaNet input projection as two logical LoRA
targets:

```text
in_proj_qkv
in_proj_z
```

vLLM-Ascend represents the merged runtime layer as four physical output
slices:

```text
q
k
v
z
```

The existing merged-linear LoRA wrapper received two adapter entries but
expected four physical slices. This caused list-index or tensor-shape failures
when vLLM created its profiling dummy adapter or loaded the real adapter.

### Fix

The NPU LoRA patch now:

- detects the Qwen3.5 `linear_attn.in_proj_qkvz` runtime layer;
- reuses the QKV LoRA A matrix for q, k, and v;
- splits the concatenated QKV LoRA B matrix into q, k, and v output slices;
- appends the independent z LoRA tensors as the fourth slice;
- converts vLLM's partition-local, all-zero profiling adapter into correctly
  shaped q/k/v/z tensors before calling the original Ascend `set_lora`.

Other merged linear layers continue to use the original vLLM-Ascend
implementation.

### Result

Qwen3.5-4B can run FSDP2 GRPO colocate with:

```text
tuner_type=lora
target_modules=all-linear
vllm_enable_lora=true
```

The adapter profiling, adapter synchronization, rollout, backward, and
optimizer paths all complete.

## 2. MoE LoRA support boundary on NPU

### Previous problem

vLLM 0.18 adds every `FusedMoE` module to its supported LoRA module list.
During LoRA manager initialization it then constructs a CUDA/Triton expert
LoRA wrapper. That wrapper is not available on Ascend NPU, so an MoE model
could fail even when only attention or other normal linear modules used LoRA.

Simply skipping routed-expert LoRA is not sufficient. If the training backend
actually trains those expert adapters, rollout would continue with stale
expert weights and silently diverge from the training model.

The meaning of `target_modules=all-linear` differs between the two training
backends:

| Backend | Routed experts trained by `all-linear` | Valid with `vllm_enable_lora=true` |
| --- | --- | --- |
| FSDP2 / Transformers PEFT | No. The routed experts are stacked Parameters instead of `nn.Linear` modules | Yes, as long as routed experts are not explicitly selected through `target_parameters` |
| Megatron | Yes. `all-linear` expands to `linear_qkv`, `linear_fc1`, and `linear_fc2`; the expert `linear_fc1/linear_fc2` receive LoRA | No, because vLLM-Ascend cannot apply the routed-expert LoRA |

### Fix

This PR separates runtime compatibility from training-semantic validation:

1. The vLLM LoRA manager no longer treats NPU `FusedMoE` modules as supported
   LoRA targets. Attention, shared experts, and other supported linear modules
   remain available.
2. The FSDP2 trainer checks explicit routed-expert entries in
   `target_parameters`.
3. The Megatron trainer checks the final trainable model parameters and
   detects LoRA attached to expert modules.
4. If routed-expert LoRA is trained together with
   `vllm_enable_lora=true`, initialization raises a clear error before the
   vLLM engine starts.

The error explains that rollout would omit expert LoRA updates and provides
two supported alternatives:

```text
1. Set vllm_enable_lora=false and synchronize merged full weights.
2. Keep vllm_enable_lora=true but explicitly exclude routed experts.
```

This is a protection against silent semantic divergence. It does not add a
native NPU FusedMoE LoRA kernel.

### Result

- FSDP2 MoE models can use `all-linear + vllm_enable_lora=true` when PEFT does
  not attach LoRA to routed experts.
- FSDP2 configurations that explicitly target routed-expert Parameters fail
  early.
- Megatron MoE `all-linear + vllm_enable_lora=true` fails early because the
  routed experts are trainable.
- Megatron MoE `all-linear + vllm_enable_lora=false` keeps the original
  training semantics by synchronizing merged full weights before rollout.

## 3. MoE memory release with `sleep_level`

### Previous problem

vLLM-Ascend 0.18 restores weight storage and then transposes unquantized
`w13_weight` and `w2_weight` Parameters in `NPUWorker.wake_up`.

This is compatible with a subsequent checkpoint-format full-weight reload.
It is not compatible with adapter-only LoRA synchronization:

1. sleep releases or offloads the vLLM weights;
2. wake restores the routed-expert base weights;
3. `wake_up` replaces them with transposed Parameters;
4. LoRA synchronization only reloads adapter weights;
5. the untouched routed experts remain in checkpoint layout;
6. FusedMoE grouped matmul receives the wrong hidden/intermediate dimension.

### Fix

For the affected vLLM-Ascend implementation, the NPU patch:

- saves references to the processed `w13_weight` and `w2_weight` Parameters
  before wake-up;
- calls the original `NPUWorker.wake_up`;
- detects Parameters replaced by the known transpose;
- reinstalls the original Parameters whose storage has already been restored
  by the allocator;
- leaves KV-cache-only wake-up unchanged.

SWIFT's full-weight synchronization path continues to handle the required MoE
weight conversion explicitly.

### Result

MoE models using adapter-only synchronization retain the inference-ready
expert layout across sleep/wake and no longer fail in grouped matmul because
of transposed base expert weights.

## 4. Runnable Ascend GRPO examples

Two Qwen3.5-4B LoRA examples are added:

| Example | Backend | LoRA rollout mode |
| --- | --- | --- |
| `examples/ascend/grpo/fsdp2/qwen3_5_4b_lora.sh` | FSDP2 | `vllm_enable_lora=true`, adapter synchronization |
| `examples/ascend/grpo/megatron/qwen3_5_4b_lora.sh` | Megatron | `vllm_enable_lora=false` by default, merged full-weight synchronization |

Both examples use portable tags instead of machine-local paths:

```text
model: Qwen/Qwen3.5-4B
dataset: AI-MO/NuminaMath-TIR#32
reward: accuracy
```

The examples use two Ascend 910B3 devices, BF16, LoRA `all-linear`, vLLM
colocate mode, and a bounded one-step configuration.

## Validation

### Environment

| Component | Version |
| --- | --- |
| Device | 2 × Ascend 910B3, 64 GiB each |
| Precision | BF16 |
| PyTorch | 2.9.0 |
| torch-npu | 2.9.0.post2 |
| vLLM | 0.18.0 |
| vLLM-Ascend | 0.18.0 |
| Megatron Core | 0.16.0 |
| Mindspeed | 0.16.0 |
| mcore-bridge | 1.7.0.dev0 |

No FP8 or FP4 was used.

### Functional validation

| Function | Model/backend | Result |
| --- | --- | --- |
| Qwen3.5 packed LoRA and FSDP2 example | Qwen3.5-4B, FSDP2, `vllm_enable_lora=true` | PASS, 1/1 step, rollout and LoRA synchronization completed |
| Megatron example and merged full-weight synchronization | Qwen3.5-4B, Megatron, `vllm_enable_lora=false` | PASS, 1/1 iteration, finite loss and gradients, checkpoint and merged safetensors saved |
| `sleep_level=1` pipeline | Qwen3.5-4B, FSDP2 | PASS, 2/2 steps |
| `sleep_level=2` regression | Qwen3-4B, Qwen3.5-4B, reduced Qwen3-30B-A3B, reduced Qwen3.5-35B-A3B | PASS, 2/2 steps for all four models |
| Routed-expert semantic guard | Qwen3-30B-A3B and Qwen3.5-35B-A3B, Megatron `all-linear + vllm_enable_lora=true` | Expected failure before vLLM initialization |

Observed portable-example metrics:

- FSDP2: `global_step=1/1`, return code 0.
- Megatron: `iteration=1/1`, loss `3.84e-6`, gradient norm `0.00247566`,
  return code 0.

The zero loss in the one-step FSDP2 example was caused by all completions in
that batch receiving zero MathAccuracy reward, producing zero within-group
advantages. Rollout, LoRA synchronization, backward, and the optimizer
pipeline still completed.

## Scope and limitations

- Routed FusedMoE LoRA remains unsupported by vLLM-Ascend.
- The guard prevents unsupported expert adapters from being silently omitted;
  it is not expert-LoRA runtime support.
- The 30B and 35B checks used four-layer BF16 checkpoints. They verify the
  execution path, not the capacity of the complete models.
- The smoke tests cover short rollout/training pipelines and do not prove
  long-running stability.
- Tensor-parallel Qwen3.5 QKVZ LoRA with `vllm_tensor_parallel_size > 1` was
  not covered by these end-to-end runs.
