### PR TITLE
Fix: torch_dtype argument not passed to inference engine in swift sample

### DIFF
--- a/swift/pipelines/sampling/vanilla_sampler.py
+++ b/swift/pipelines/sampling/vanilla_sampler.py
@@ -38,7 +38,8 @@ class VanillaSampler(Sampler):
         self.infer_engine = None
         if _Engine:
             self.infer_engine = _Engine(
-                self.args.model, model_type=self.args.model_type, template=self.template, **self.args.engine_kwargs)
+                self.args.model, model_type=self.args.model_type, template=self.template, 
+                torch_dtype=self.args.torch_dtype, **self.args.engine_kwargs)
             self.infer_engine.strict = False
 
     @RayHelper.function(group='sampler')

--- a/swift/pipelines/sampling/vanilla_sampler.py
+++ b/swift/pipelines/sampling/vanilla_sampler.py
@@ -38,8 +38,11 @@ class VanillaSampler(Sampler):
         self.infer_engine = None
         if _Engine:
             self.infer_engine = _Engine(
-                self.args.model, model_type=self.args.model_type, template=self.template,
-                torch_dtype=self.args.torch_dtype, **self.args.engine_kwargs)
+                self.args.model,
+                model_type=self.args.model_type,
+                template=self.template,
+                torch_dtype=self.args.torch_dtype,
+                **self.args.engine_kwargs)
             self.infer_engine.strict = False
 
     @RayHelper.function(group='sampler')

--- a/swift/pipelines/sampling/vanilla_sampler.py
+++ b/swift/pipelines/sampling/vanilla_sampler.py
@@ -38,7 +38,7 @@ class VanillaSampler(Sampler):
         self.infer_engine = None
         if _Engine:
             self.infer_engine = _Engine(
-                self.args.model, model_type=self.args.model_type, template=self.template, 
+                self.args.model, model_type=self.args.model_type, template=self.template,
                 torch_dtype=self.args.torch_dtype, **self.args.engine_kwargs)
             self.infer_engine.strict = False
 


### PR DESCRIPTION
# PR type
- [ X] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Problem
When running `swift sample --torch_dtype bfloat16`, the `torch_dtype` argument is ignored. The model loads with the dtype from its own `config.json`, like `torch.float32`, regardless of the user-specified dtype:
``` log
[INFO:swift] Setting torch_dtype: torch.float32
[INFO:swift] model_kwargs: {'device_map': 'auto', 'dtype': torch.float32}
```

## Solution
Explicitly pass `torch_dtype=self.args.torch_dtype` when constructing the inference engine in `vanilla_sampler.py`.

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>
Bug-catcher: Shuang Ren <1085843519@qq.com>
