### PR TITLE
Support OpenAI and Anthropic message processors

### DIFF
--- a/docs/source/Customization/Custom-dataset.md
+++ b/docs/source/Customization/Custom-dataset.md
@@ -10,7 +10,7 @@
 
 ms-swift的标准数据集格式可接受的keys包括: 'messages'、'rejected_response'、'label'、'images'、'videos'、'audios'、'tools'和'objects'。其中'messages'是必需的key，'rejected_response'用于DPO等RLHF训练，'label'用于KTO训练和分类模型训练，'images'、'videos'、'audios'用于存储多模态数据的路径或者url，'tools'用于Agent任务，'objects'用于grounding任务。
 
-ms-swift中存在三种核心预处理器：`MessagesPreprocessor`、`AlpacaPreprocessor`、`ResponsePreprocessor`。MessagesPreprocessor用于将类messages和sharegpt格式的数据集转换为标准格式，AlpacaPreprocessor则转换alpaca格式的数据集，ResponsePreprocessor则转换类query/response格式的数据集。`AutoPreprocessor`则自动选择合适的预处理进行处理。
+ms-swift中存在三种核心预处理器：`MessagesPreprocessor`、`AlpacaPreprocessor`、`ResponsePreprocessor`。MessagesPreprocessor用于将类messages和sharegpt格式的数据集转换为标准格式，并自动转换OpenAI的`tool_calls`以及Anthropic的`tool_use`/`tool_result`内容块；需要显式指定格式时，也可以使用`OpenAIMessagesPreprocessor`和`AnthropicMessagesPreprocessor`。AlpacaPreprocessor则转换alpaca格式的数据集，ResponsePreprocessor则转换类query/response格式的数据集。`AutoPreprocessor`则自动选择合适的预处理进行处理。
 
 以下四种格式在`AutoPreprocessor`处理下都会转换成ms-swift标准格式中的messages字段，即都可以直接使用`--dataset <dataset-path>`接入：
 
@@ -23,6 +23,16 @@ messages格式（标准格式）:
 sharegpt格式:
 ```jsonl
 {"system": "<system>", "conversation": [{"human": "<query1>", "assistant": "<response1>"}, {"human": "<query2>", "assistant": "<response2>"}]}
+```
+
+OpenAI工具调用格式:
+```jsonl
+{"messages": [{"role": "user", "content": "天气如何？"}, {"role": "assistant", "content": null, "tool_calls": [{"type": "function", "function": {"name": "get_weather", "arguments": "{\"city\":\"Beijing\"}"}}]}, {"role": "tool", "content": "晴"}]}
+```
+
+Anthropic工具调用格式:
+```jsonl
+{"messages": [{"role": "assistant", "content": [{"type": "text", "text": "我来查询。"}, {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "Beijing"}}]}, {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "晴"}]}]}
 ```
 
 query-response格式:

--- a/docs/source/Customization/Custom-dataset.md
+++ b/docs/source/Customization/Custom-dataset.md
@@ -10,9 +10,9 @@
 
 ms-swift的标准数据集格式可接受的keys包括: 'messages'、'rejected_response'、'label'、'images'、'videos'、'audios'、'tools'和'objects'。其中'messages'是必需的key，'rejected_response'用于DPO等RLHF训练，'label'用于KTO训练和分类模型训练，'images'、'videos'、'audios'用于存储多模态数据的路径或者url，'tools'用于Agent任务，'objects'用于grounding任务。
 
-ms-swift中存在三种核心预处理器：`MessagesPreprocessor`、`AlpacaPreprocessor`、`ResponsePreprocessor`。MessagesPreprocessor用于将类messages和sharegpt格式的数据集转换为标准格式，并自动转换OpenAI的`tool_calls`以及Anthropic的`tool_use`/`tool_result`内容块；需要显式指定格式时，也可以使用`OpenAIMessagesPreprocessor`和`AnthropicMessagesPreprocessor`。AlpacaPreprocessor则转换alpaca格式的数据集，ResponsePreprocessor则转换类query/response格式的数据集。`AutoPreprocessor`则自动选择合适的预处理进行处理。
+ms-swift中存在三种核心预处理器：`MessagesPreprocessor`、`AlpacaPreprocessor`、`ResponsePreprocessor`。MessagesPreprocessor用于将类messages和sharegpt格式的数据集转换为标准格式，并自动转换OpenAI的`tool_calls`以及Anthropic的`tool_use`/`tool_result`/`image`内容块；需要显式指定格式时，也可以使用`OpenAIMessagesPreprocessor`和`AnthropicMessagesPreprocessor`。AlpacaPreprocessor则转换alpaca格式的数据集，ResponsePreprocessor则转换类query/response格式的数据集。`AutoPreprocessor`则自动选择合适的预处理进行处理。
 
-以下四种格式在`AutoPreprocessor`处理下都会转换成ms-swift标准格式中的messages字段，即都可以直接使用`--dataset <dataset-path>`接入：
+以下格式在`AutoPreprocessor`处理下都会转换成ms-swift标准格式中的messages字段，即都可以直接使用`--dataset <dataset-path>`接入：
 
 messages格式（标准格式）:
 ```jsonl
@@ -34,6 +34,12 @@ Anthropic工具调用格式:
 ```jsonl
 {"messages": [{"role": "assistant", "content": [{"type": "text", "text": "我来查询。"}, {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "Beijing"}}]}, {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "晴"}]}]}
 ```
+
+Anthropic多模态工具调用格式:
+```jsonl
+{"messages": [{"role": "user", "content": [{"type": "text", "text": "图片中有什么？"}, {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "{base64_encoded}"}}]}, {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "inspect_image", "input": {}}]}, {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": [{"type": "image", "source": {"type": "url", "url": "https://example.com/result.png"}}, {"type": "text", "text": "阳光明媚的海滩。"}]}]}]}
+```
+- Anthropic的base64和URL图片源会按原始顺序转换为`<image>`占位符和顶层`images`字段。
 
 query-response格式:
 ```jsonl

--- a/docs/source/Customization/Custom-dataset.md
+++ b/docs/source/Customization/Custom-dataset.md
@@ -30,6 +30,12 @@ OpenAI工具调用格式:
 {"messages": [{"role": "user", "content": "天气如何？"}, {"role": "assistant", "content": null, "tool_calls": [{"type": "function", "function": {"name": "get_weather", "arguments": "{\"city\":\"Beijing\"}"}}]}, {"role": "tool", "content": "晴"}]}
 ```
 
+OpenAI Chat Completions多模态工具调用格式:
+```jsonl
+{"messages": [{"role": "user", "content": [{"type": "text", "text": "比较这两张图片。"}, {"type": "image_url", "image_url": {"url": "data:image/png;base64,{base64_encoded}"}}, {"type": "image_url", "image_url": "https://example.com/input.png"}]}, {"role": "assistant", "content": [{"type": "text", "text": "我来检查。"}], "tool_calls": [{"type": "function", "function": {"name": "inspect_images", "arguments": "{\"detail\":\"high\"}"}}]}]}
+```
+- OpenAI的`image_url`内容块会按原始顺序转换为`<image>`占位符和顶层`images`字段。该示例使用Chat Completions格式；Responses API的`input_text`和`input_image`内容块采用不同的数据结构。
+
 Anthropic工具调用格式:
 ```jsonl
 {"messages": [{"role": "assistant", "content": [{"type": "text", "text": "我来查询。"}, {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "Beijing"}}]}, {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "晴"}]}]}

--- a/docs/source_en/Customization/Custom-dataset.md
+++ b/docs/source_en/Customization/Custom-dataset.md
@@ -11,7 +11,7 @@ The following is an introduction to the dataset formats that `AutoPreprocessor` 
 
 The standard dataset format for ms-swift accepts keys such as: 'messages', 'rejected_response', 'label', 'images', 'videos', 'audios', 'tools', and 'objects'. Among these, 'messages' is a required key. 'rejected_response' is used for DPO and other RLHF training, 'label' is used for KTO training and classification model training. The keys 'images', 'videos', and 'audios' are used to store paths or URLs for multimodal data, 'tools' is used for Agent tasks, and 'objects' is used for grounding tasks.
 
-There are three core preprocessors in ms-swift: `MessagesPreprocessor`, `AlpacaPreprocessor`, and `ResponsePreprocessor`. `MessagesPreprocessor` is used to convert datasets in the messages and sharegpt format into the standard format. `AlpacaPreprocessor` converts datasets in the alpaca format, while `ResponsePreprocessor` converts datasets in the query/response format. `AutoPreprocessor` automatically selects the appropriate preprocessor for the task.
+There are three core preprocessors in ms-swift: `MessagesPreprocessor`, `AlpacaPreprocessor`, and `ResponsePreprocessor`. `MessagesPreprocessor` is used to convert datasets in the messages and sharegpt format into the standard format. It also automatically normalizes OpenAI `tool_calls` and Anthropic `tool_use`/`tool_result` content blocks. The provider-specific `OpenAIMessagesPreprocessor` and `AnthropicMessagesPreprocessor` classes can be used when explicit format selection is preferred. `AlpacaPreprocessor` converts datasets in the alpaca format, while `ResponsePreprocessor` converts datasets in the query/response format. `AutoPreprocessor` automatically selects the appropriate preprocessor for the task.
 
 The following four formats will all be converted into the `messages` field of the ms-swift standard format under the processing of `AutoPreprocessor`, meaning they can all be directly used with `--dataset <dataset-path>`:
 
@@ -24,6 +24,16 @@ Messages format (standard format):
 ShareGPT format:
 ```jsonl
 {"system": "<system>", "conversation": [{"human": "<query1>", "assistant": "<response1>"}, {"human": "<query2>", "assistant": "<response2>"}]}
+```
+
+OpenAI tool-call format:
+```jsonl
+{"messages": [{"role": "user", "content": "How is the weather?"}, {"role": "assistant", "content": null, "tool_calls": [{"type": "function", "function": {"name": "get_weather", "arguments": "{\"city\":\"Beijing\"}"}}]}, {"role": "tool", "content": "Sunny"}]}
+```
+
+Anthropic tool-use format:
+```jsonl
+{"messages": [{"role": "assistant", "content": [{"type": "text", "text": "I will check."}, {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "Beijing"}}]}, {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "Sunny"}]}]}
 ```
 
 Query-Response format:

--- a/docs/source_en/Customization/Custom-dataset.md
+++ b/docs/source_en/Customization/Custom-dataset.md
@@ -31,6 +31,12 @@ OpenAI tool-call format:
 {"messages": [{"role": "user", "content": "How is the weather?"}, {"role": "assistant", "content": null, "tool_calls": [{"type": "function", "function": {"name": "get_weather", "arguments": "{\"city\":\"Beijing\"}"}}]}, {"role": "tool", "content": "Sunny"}]}
 ```
 
+OpenAI Chat Completions multimodal tool-call format:
+```jsonl
+{"messages": [{"role": "user", "content": [{"type": "text", "text": "Compare these images."}, {"type": "image_url", "image_url": {"url": "data:image/png;base64,{base64_encoded}"}}, {"type": "image_url", "image_url": "https://example.com/input.png"}]}, {"role": "assistant", "content": [{"type": "text", "text": "I will inspect them."}], "tool_calls": [{"type": "function", "function": {"name": "inspect_images", "arguments": "{\"detail\":\"high\"}"}}]}]}
+```
+- OpenAI `image_url` blocks are converted to `<image>` placeholders and the top-level `images` field in their original order. This example uses the Chat Completions format; Responses API `input_text` and `input_image` blocks use a different schema.
+
 Anthropic tool-use format:
 ```jsonl
 {"messages": [{"role": "assistant", "content": [{"type": "text", "text": "I will check."}, {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "Beijing"}}]}, {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "Sunny"}]}]}

--- a/docs/source_en/Customization/Custom-dataset.md
+++ b/docs/source_en/Customization/Custom-dataset.md
@@ -11,9 +11,9 @@ The following is an introduction to the dataset formats that `AutoPreprocessor` 
 
 The standard dataset format for ms-swift accepts keys such as: 'messages', 'rejected_response', 'label', 'images', 'videos', 'audios', 'tools', and 'objects'. Among these, 'messages' is a required key. 'rejected_response' is used for DPO and other RLHF training, 'label' is used for KTO training and classification model training. The keys 'images', 'videos', and 'audios' are used to store paths or URLs for multimodal data, 'tools' is used for Agent tasks, and 'objects' is used for grounding tasks.
 
-There are three core preprocessors in ms-swift: `MessagesPreprocessor`, `AlpacaPreprocessor`, and `ResponsePreprocessor`. `MessagesPreprocessor` is used to convert datasets in the messages and sharegpt format into the standard format. It also automatically normalizes OpenAI `tool_calls` and Anthropic `tool_use`/`tool_result` content blocks. The provider-specific `OpenAIMessagesPreprocessor` and `AnthropicMessagesPreprocessor` classes can be used when explicit format selection is preferred. `AlpacaPreprocessor` converts datasets in the alpaca format, while `ResponsePreprocessor` converts datasets in the query/response format. `AutoPreprocessor` automatically selects the appropriate preprocessor for the task.
+There are three core preprocessors in ms-swift: `MessagesPreprocessor`, `AlpacaPreprocessor`, and `ResponsePreprocessor`. `MessagesPreprocessor` is used to convert datasets in the messages and sharegpt format into the standard format. It also automatically normalizes OpenAI `tool_calls` and Anthropic `tool_use`/`tool_result`/`image` content blocks. The provider-specific `OpenAIMessagesPreprocessor` and `AnthropicMessagesPreprocessor` classes can be used when explicit format selection is preferred. `AlpacaPreprocessor` converts datasets in the alpaca format, while `ResponsePreprocessor` converts datasets in the query/response format. `AutoPreprocessor` automatically selects the appropriate preprocessor for the task.
 
-The following four formats will all be converted into the `messages` field of the ms-swift standard format under the processing of `AutoPreprocessor`, meaning they can all be directly used with `--dataset <dataset-path>`:
+The following formats will all be converted into the `messages` field of the ms-swift standard format under the processing of `AutoPreprocessor`, meaning they can all be directly used with `--dataset <dataset-path>`:
 
 Messages format (standard format):
 ```jsonl
@@ -35,6 +35,12 @@ Anthropic tool-use format:
 ```jsonl
 {"messages": [{"role": "assistant", "content": [{"type": "text", "text": "I will check."}, {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "Beijing"}}]}, {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "Sunny"}]}]}
 ```
+
+Anthropic multimodal tool-use format:
+```jsonl
+{"messages": [{"role": "user", "content": [{"type": "text", "text": "What is in this image?"}, {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "{base64_encoded}"}}]}, {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "inspect_image", "input": {}}]}, {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": [{"type": "image", "source": {"type": "url", "url": "https://example.com/result.png"}}, {"type": "text", "text": "A sunny beach."}]}]}]}
+```
+- Anthropic base64 and URL image sources are converted to `<image>` placeholders and the top-level `images` field in their original order.
 
 Query-Response format:
 ```jsonl

--- a/swift/dataset/__init__.py
+++ b/swift/dataset/__init__.py
@@ -6,8 +6,8 @@ from . import dataset
 from .loader import DATASET_TYPE, DatasetLoader, DatasetSyntax, load_dataset
 from .media import MediaResource
 from .packing import IterablePackingDataset, PackingDataset
-from .preprocessor import (AlpacaPreprocessor, AutoPreprocessor, MessagesPreprocessor, ResponsePreprocessor,
-                           RowPreprocessor)
+from .preprocessor import (AlpacaPreprocessor, AnthropicMessagesPreprocessor, AutoPreprocessor, MessagesPreprocessor,
+                           OpenAIMessagesPreprocessor, ResponsePreprocessor, RowPreprocessor)
 from .register import (DATASET_MAPPING, DatasetMeta, SubsetDataset, get_dataset_list, register_dataset,
                        register_dataset_info)
 from .utils import (AddLengthPreprocessor, EncodePreprocessor, LazyLLMDataset, get_temporary_cache_files_directory,

--- a/swift/dataset/preprocessor/__init__.py
+++ b/swift/dataset/preprocessor/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
-from .core import (DATASET_TYPE, AlpacaPreprocessor, AutoPreprocessor, ClsPreprocessor, MessagesPreprocessor,
-                   ResponsePreprocessor, RowPreprocessor)
+from .core import (DATASET_TYPE, AlpacaPreprocessor, AnthropicMessagesPreprocessor, AutoPreprocessor, ClsPreprocessor,
+                   MessagesPreprocessor, OpenAIMessagesPreprocessor, ResponsePreprocessor, RowPreprocessor)
 from .extra import ClsGenerationPreprocessor, GroundingMixin, TextGenerationPreprocessor

--- a/swift/dataset/preprocessor/core.py
+++ b/swift/dataset/preprocessor/core.py
@@ -1,6 +1,7 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import ast
 import datasets
+import json
 import numpy as np
 import os
 from collections import Counter
@@ -12,7 +13,7 @@ from datasets import Sequence, Value
 from itertools import chain
 from modelscope.hub.utils.utils import get_cache_dir
 from packaging import version
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from swift.template import history_to_messages
 from swift.utils import get_logger, is_dist, is_master, safe_ddp_context
@@ -449,6 +450,7 @@ class MessagesPreprocessor(RowPreprocessor):
             repair_messages: Callable[[Union[str, List[Dict[str, str]]]],
                                       Optional[List[Dict[str, str]]]] = default_repair_messages,
             inner_key: Optional[str] = None,
+            message_format: Literal['auto', 'swift', 'openai', 'anthropic'] = 'auto',
             **kwargs):
         super().__init__(columns=columns, **kwargs)
         self.role_keys = ['role', 'from'] if role_key is None else [role_key]
@@ -461,6 +463,7 @@ class MessagesPreprocessor(RowPreprocessor):
         self.system_role = system_role
         self.repair_messages = repair_messages
         self.inner_key = inner_key
+        self.message_format = message_format
 
         message_keys = ['messages', 'conversation', 'conversations']
         for key in message_keys:
@@ -508,6 +511,112 @@ class MessagesPreprocessor(RowPreprocessor):
                 message['role'] = 'tool_response'
 
     @staticmethod
+    def _parse_arguments(arguments: Any) -> Any:
+        if not isinstance(arguments, str):
+            return arguments
+        try:
+            return json.loads(arguments)
+        except json.JSONDecodeError:
+            return arguments
+
+    @classmethod
+    def openai_to_messages(cls, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Convert OpenAI tool-call messages to the SWIFT canonical roles."""
+        new_messages = []
+        for message in messages:
+            if message.get('role') != 'assistant' or not message.get('tool_calls'):
+                new_messages.append(message)
+                continue
+
+            content = message.get('content')
+            if content:
+                new_messages.append({
+                    key: value
+                    for key, value in message.items() if key in {'role', 'content', 'loss', 'loss_scale'}
+                })
+            for tool_call in message['tool_calls']:
+                function = tool_call.get('function', tool_call)
+                tool_message = {
+                    'role': 'tool_call',
+                    'content': {
+                        'name': function['name'],
+                        'arguments': cls._parse_arguments(function.get('arguments', {})),
+                    },
+                }
+                for key in ['loss', 'loss_scale']:
+                    if key in message:
+                        tool_message[key] = message[key]
+                new_messages.append(tool_message)
+        return new_messages
+
+    @staticmethod
+    def _anthropic_block_content(content: Any) -> Any:
+        if not isinstance(content, list):
+            return content
+        text = ''.join(block.get('text', '') for block in content if block.get('type') == 'text')
+        return text
+
+    @classmethod
+    def anthropic_to_messages(cls, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Convert Anthropic content blocks to the SWIFT canonical roles."""
+        new_messages = []
+        for message in messages:
+            content = message.get('content')
+            if not isinstance(content, list):
+                new_messages.append(message)
+                continue
+
+            pending_text = []
+            message_metadata = {key: message[key] for key in ['loss', 'loss_scale'] if key in message}
+
+            def flush_text():
+                if pending_text:
+                    new_messages.append({'role': message['role'], 'content': ''.join(pending_text), **message_metadata})
+                    pending_text.clear()
+
+            for block in content:
+                block_type = block.get('type')
+                if block_type == 'text':
+                    pending_text.append(block.get('text', ''))
+                elif block_type == 'tool_use':
+                    flush_text()
+                    new_messages.append({
+                        'role': 'tool_call',
+                        'content': {
+                            'name': block['name'],
+                            'arguments': block.get('input', {}),
+                        },
+                        **message_metadata,
+                    })
+                elif block_type == 'tool_result':
+                    flush_text()
+                    new_messages.append({
+                        'role': 'tool_response',
+                        'content': cls._anthropic_block_content(block.get('content', '')),
+                        **message_metadata,
+                    })
+            flush_text()
+        return new_messages
+
+    def normalize_provider_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        message_format = self.message_format
+        if message_format == 'auto':
+            if any(message.get('tool_calls') for message in messages):
+                message_format = 'openai'
+            elif any(
+                    isinstance(message.get('content'), list) and any(
+                        block.get('type') in {'tool_use', 'tool_result'} for block in message['content'])
+                    for message in messages):
+                message_format = 'anthropic'
+            else:
+                message_format = 'swift'
+        if message_format == 'openai':
+            return self.openai_to_messages(messages)
+        if message_format == 'anthropic':
+            return self.anthropic_to_messages(messages)
+        return messages
+
+    @staticmethod
     def _to_std_key(messages: List[Dict[str, str]], std_key: str, optional_keys: List[str]) -> None:
         for message in messages:
             for key in optional_keys:
@@ -524,6 +633,7 @@ class MessagesPreprocessor(RowPreprocessor):
         messages: Optional[List[Dict[str, str]]] = self.repair_messages(messages)
         if not messages or isinstance(messages, str):
             return
+        messages = self.normalize_provider_messages(messages)
         self._to_std_key(messages, 'role', self.role_keys)
         self._to_std_key(messages, 'content', self.content_keys)
         system = row.pop('system', None)
@@ -533,6 +643,18 @@ class MessagesPreprocessor(RowPreprocessor):
             self.to_std_messages(messages, system)  # inplace
         row['messages'] = messages
         return row
+
+
+class OpenAIMessagesPreprocessor(MessagesPreprocessor):
+
+    def __init__(self, **kwargs):
+        super().__init__(message_format='openai', **kwargs)
+
+
+class AnthropicMessagesPreprocessor(MessagesPreprocessor):
+
+    def __init__(self, **kwargs):
+        super().__init__(message_format='anthropic', **kwargs)
 
 
 class ClsPreprocessor(ResponsePreprocessor):

--- a/swift/dataset/preprocessor/core.py
+++ b/swift/dataset/preprocessor/core.py
@@ -550,15 +550,44 @@ class MessagesPreprocessor(RowPreprocessor):
         return new_messages
 
     @staticmethod
-    def _anthropic_block_content(content: Any) -> Any:
-        if not isinstance(content, list):
-            return content
-        text = ''.join(block.get('text', '') for block in content if block.get('type') == 'text')
-        return text
+    def _anthropic_image_source(block: Dict[str, Any]) -> str:
+        source = block.get('source') or {}
+        source_type = source.get('type')
+        if source_type == 'base64':
+            media_type = source.get('media_type')
+            data = source.get('data')
+            if not media_type or not data:
+                raise ValueError(f'Invalid Anthropic base64 image block: {block}')
+            return f'data:{media_type};base64,{data}'
+        if source_type == 'url':
+            url = source.get('url')
+            if not url:
+                raise ValueError(f'Invalid Anthropic URL image block: {block}')
+            return url
+        raise ValueError(f'Unsupported Anthropic image source type: {source_type}')
 
     @classmethod
-    def anthropic_to_messages(cls, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _anthropic_block_content(cls, content: Any, media: Dict[str, List[Any]]) -> Any:
+        if not isinstance(content, list):
+            return content
+        parts = []
+        for block in content:
+            block_type = block.get('type')
+            if block_type == 'text':
+                parts.append(block.get('text', ''))
+            elif block_type == 'image':
+                parts.append('<image>')
+                media['images'].append(cls._anthropic_image_source(block))
+            else:
+                raise ValueError(f'Unsupported Anthropic content block type: {block_type}')
+        return ''.join(parts)
+
+    @classmethod
+    def anthropic_to_messages(cls,
+                              messages: List[Dict[str, Any]],
+                              media: Optional[Dict[str, List[Any]]] = None) -> List[Dict[str, Any]]:
         """Convert Anthropic content blocks to the SWIFT canonical roles."""
+        media = media if media is not None else {'images': []}
         new_messages = []
         for message in messages:
             content = message.get('content')
@@ -566,20 +595,27 @@ class MessagesPreprocessor(RowPreprocessor):
                 new_messages.append(message)
                 continue
 
-            pending_text = []
+            pending_content = []
             message_metadata = {key: message[key] for key in ['loss', 'loss_scale'] if key in message}
 
-            def flush_text():
-                if pending_text:
-                    new_messages.append({'role': message['role'], 'content': ''.join(pending_text), **message_metadata})
-                    pending_text.clear()
+            def flush_content():
+                if pending_content:
+                    new_messages.append({
+                        'role': message['role'],
+                        'content': ''.join(pending_content),
+                        **message_metadata
+                    })
+                    pending_content.clear()
 
             for block in content:
                 block_type = block.get('type')
                 if block_type == 'text':
-                    pending_text.append(block.get('text', ''))
+                    pending_content.append(block.get('text', ''))
+                elif block_type == 'image':
+                    pending_content.append('<image>')
+                    media['images'].append(cls._anthropic_image_source(block))
                 elif block_type == 'tool_use':
-                    flush_text()
+                    flush_content()
                     new_messages.append({
                         'role': 'tool_call',
                         'content': {
@@ -589,23 +625,27 @@ class MessagesPreprocessor(RowPreprocessor):
                         **message_metadata,
                     })
                 elif block_type == 'tool_result':
-                    flush_text()
+                    flush_content()
                     new_messages.append({
                         'role': 'tool_response',
-                        'content': cls._anthropic_block_content(block.get('content', '')),
+                        'content': cls._anthropic_block_content(block.get('content', ''), media),
                         **message_metadata,
                     })
-            flush_text()
+                else:
+                    raise ValueError(f'Unsupported Anthropic content block type: {block_type}')
+            flush_content()
         return new_messages
 
-    def normalize_provider_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def normalize_provider_messages(self, messages: List[Dict[str, Any]],
+                                    media: Dict[str, List[Any]]) -> List[Dict[str, Any]]:
         message_format = self.message_format
         if message_format == 'auto':
             if any(message.get('tool_calls') for message in messages):
                 message_format = 'openai'
             elif any(
                     isinstance(message.get('content'), list) and any(
-                        block.get('type') in {'tool_use', 'tool_result'} for block in message['content'])
+                        block.get('type') in {'tool_use', 'tool_result'}
+                        or block.get('type') == 'image' and 'source' in block for block in message['content'])
                     for message in messages):
                 message_format = 'anthropic'
             else:
@@ -613,7 +653,7 @@ class MessagesPreprocessor(RowPreprocessor):
         if message_format == 'openai':
             return self.openai_to_messages(messages)
         if message_format == 'anthropic':
-            return self.anthropic_to_messages(messages)
+            return self.anthropic_to_messages(messages, media)
         return messages
 
     @staticmethod
@@ -633,7 +673,12 @@ class MessagesPreprocessor(RowPreprocessor):
         messages: Optional[List[Dict[str, str]]] = self.repair_messages(messages)
         if not messages or isinstance(messages, str):
             return
-        messages = self.normalize_provider_messages(messages)
+        media = {'images': []}
+        messages = self.normalize_provider_messages(messages, media)
+        for key, value in media.items():
+            if value:
+                assert not row.get(key), f'Cannot mix Anthropic content blocks with the top-level `{key}` field.'
+                row[key] = value
         self._to_std_key(messages, 'role', self.role_keys)
         self._to_std_key(messages, 'content', self.content_keys)
         system = row.pop('system', None)

--- a/tests/general/test_data_preprocess.py
+++ b/tests/general/test_data_preprocess.py
@@ -132,6 +132,37 @@ class TestDataPreprocess(unittest.TestCase):
         supervised_text = self.processor.decode(supervised_ids)
         self.assertIn('get_weather', supervised_text)
 
+    def test_nested_tool_arguments(self):
+        tool_row = {
+            'messages': [{
+                'role': 'user',
+                'content': 'Compare the weather in Beijing and Shanghai.',
+            }, {
+                'role':
+                'assistant',
+                'content':
+                None,
+                'tool_calls': [{
+                    'type': 'function',
+                    'function': {
+                        'name': 'get_weather',
+                        'arguments': '{"cities":["Beijing","Shanghai"],"options":{"units":["celsius","fahrenheit"]}}',
+                    },
+                }],
+            }]
+        }
+        tool_row = OpenAIMessagesPreprocessor().preprocess(tool_row)
+        arguments = tool_row['messages'][-1]['content']['arguments']
+        self.assertEqual(arguments['cities'], ['Beijing', 'Shanghai'])
+        self.assertEqual(arguments['options'], {'units': ['celsius', 'fahrenheit']})
+
+        encoded = self.template.encode(tool_row)
+        supervised_ids = [token_id for token_id, label in zip(encoded['input_ids'], encoded['labels']) if label != -100]
+        supervised_text = self.processor.decode(supervised_ids)
+        self.assertIn('get_weather', supervised_text)
+        self.assertIn('Beijing', supervised_text)
+        self.assertIn('Shanghai', supervised_text)
+
     def test_packing_dataset(self):
         dataset, _ = load_dataset(['AI-ModelScope/alpaca-gpt4-data-zh#20'], num_proc=1, strict=False)
         encoded_dataset = self._encode_dataset(dataset)

--- a/tests/general/test_data_preprocess.py
+++ b/tests/general/test_data_preprocess.py
@@ -6,6 +6,9 @@ from swift.model import get_processor
 from swift.template import get_template, load_image
 from swift.template.template_inputs import StdTemplateInputs
 
+PNG_BASE64 = ('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ'
+              '/pLvAAAAAElFTkSuQmCC')
+
 
 class TestDataPreprocess(unittest.TestCase):
     """Lightweight data preprocessing tests (no model forward/backward).
@@ -303,6 +306,52 @@ class TestProviderMessagesPreprocess(unittest.TestCase):
             },
         }])
 
+    def test_openai_multimodal_content_blocks(self):
+        base64_image = f'data:image/png;base64,{PNG_BASE64}'
+        image_url = 'https://example.com/input.png'
+        row = {
+            'messages': [{
+                'role':
+                'user',
+                'content': [{
+                    'type': 'text',
+                    'text': 'Compare these images: ',
+                }, {
+                    'type': 'image_url',
+                    'image_url': {
+                        'url': base64_image,
+                    },
+                }, {
+                    'type': 'image_url',
+                    'image_url': image_url,
+                }],
+            }, {
+                'role':
+                'assistant',
+                'content': [{
+                    'type': 'text',
+                    'text': 'I will inspect them.',
+                }],
+                'tool_calls': [{
+                    'type': 'function',
+                    'function': {
+                        'name': 'inspect_images',
+                        'arguments': '{"detail":"high"}',
+                    },
+                }],
+            }]
+        }
+        result = OpenAIMessagesPreprocessor().preprocess(row)
+        self.assertEqual([message['role'] for message in result['messages']], ['user', 'assistant', 'tool_call'])
+        self.assertEqual(result['messages'][-1]['content'], {'name': 'inspect_images', 'arguments': {'detail': 'high'}})
+
+        template_inputs = StdTemplateInputs.from_dict(result)
+        self.assertEqual(template_inputs.messages[0]['content'], 'Compare these images: <image><image>')
+        self.assertEqual(template_inputs.messages[1]['content'], 'I will inspect them.')
+        self.assertEqual(template_inputs.images, [base64_image, image_url])
+        self.assertIn('inspect_images', template_inputs.messages[-1]['content'])
+        self.assertEqual(load_image(template_inputs.images[0]).size, (1, 1))
+
     def test_anthropic_content_blocks(self):
         row = {
             'messages': [{
@@ -360,12 +409,9 @@ class TestProviderMessagesPreprocess(unittest.TestCase):
                 }, {
                     'type': 'image',
                     'source': {
-                        'type':
-                        'base64',
-                        'media_type':
-                        'image/png',
-                        'data': ('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ'
-                                 '/pLvAAAAAElFTkSuQmCC'),
+                        'type': 'base64',
+                        'media_type': 'image/png',
+                        'data': PNG_BASE64,
                     },
                 }],
             }, {
@@ -412,8 +458,7 @@ class TestProviderMessagesPreprocess(unittest.TestCase):
             'content': '<image>A sunny beach.',
         }])
         self.assertEqual(result['images'], [
-            ('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ'
-             '/pLvAAAAAElFTkSuQmCC'),
+            f'data:image/png;base64,{PNG_BASE64}',
             'https://example.com/result.png',
         ])
         self.assertEqual(load_image(result['images'][0]).size, (1, 1))

--- a/tests/general/test_data_preprocess.py
+++ b/tests/general/test_data_preprocess.py
@@ -1,6 +1,7 @@
 import unittest
 
-from swift.dataset import EncodePreprocessor, MessagesPreprocessor, PackingDataset, load_dataset
+from swift.dataset import (AnthropicMessagesPreprocessor, EncodePreprocessor, MessagesPreprocessor,
+                           OpenAIMessagesPreprocessor, PackingDataset, load_dataset)
 from swift.model import get_processor
 from swift.template import get_template
 
@@ -122,10 +123,14 @@ class TestDataPreprocess(unittest.TestCase):
                 },
             ]
         }
+        tool_row = OpenAIMessagesPreprocessor().preprocess(tool_row)
         encoded = self.template.encode(tool_row, return_length=True)
         self.assertIn('input_ids', encoded)
         self.assertIn('labels', encoded)
         self.assertGreater(len(encoded['input_ids']), 0)
+        supervised_ids = [token_id for token_id, label in zip(encoded['input_ids'], encoded['labels']) if label != -100]
+        supervised_text = self.processor.decode(supervised_ids)
+        self.assertIn('get_weather', supervised_text)
 
     def test_packing_dataset(self):
         dataset, _ = load_dataset(['AI-ModelScope/alpaca-gpt4-data-zh#20'], num_proc=1, strict=False)
@@ -201,6 +206,116 @@ class TestRejectedMessagesPreprocess(unittest.TestCase):
         }
         result = MessagesPreprocessor().preprocess(row)
         self.assertEqual(result['rejected_messages'][-1]['content'], 'bad')
+
+
+class TestProviderMessagesPreprocess(unittest.TestCase):
+
+    def test_openai_parallel_tool_calls(self):
+        row = {
+            'messages': [{
+                'role':
+                'assistant',
+                'content':
+                '',
+                'tool_calls': [{
+                    'id': 'call_weather',
+                    'type': 'function',
+                    'function': {
+                        'name': 'get_weather',
+                        'arguments': '{"city": "Beijing"}'
+                    },
+                }, {
+                    'id': 'call_time',
+                    'type': 'function',
+                    'function': {
+                        'name': 'get_time',
+                        'arguments': '{"timezone": "Asia/Shanghai"}'
+                    },
+                }],
+                'loss':
+                True,
+            }, {
+                'role': 'tool',
+                'tool_call_id': 'call_weather',
+                'content': 'sunny',
+            }]
+        }
+        result = OpenAIMessagesPreprocessor().preprocess(row)
+        self.assertEqual([message['role'] for message in result['messages']], ['tool_call', 'tool_call', 'tool'])
+        self.assertEqual(result['messages'][0]['content'], {'name': 'get_weather', 'arguments': {'city': 'Beijing'}})
+        self.assertTrue(result['messages'][0]['loss'])
+
+    def test_openai_is_auto_detected(self):
+        row = {
+            'messages': [{
+                'role': 'assistant',
+                'content': None,
+                'tool_calls': [{
+                    'function': {
+                        'name': 'search',
+                        'arguments': {
+                            'query': 'ms-swift'
+                        }
+                    }
+                }],
+            }]
+        }
+        result = MessagesPreprocessor().preprocess(row)
+        self.assertEqual(result['messages'], [{
+            'role': 'tool_call',
+            'content': {
+                'name': 'search',
+                'arguments': {
+                    'query': 'ms-swift'
+                }
+            },
+        }])
+
+    def test_anthropic_content_blocks(self):
+        row = {
+            'messages': [{
+                'role':
+                'assistant',
+                'content': [{
+                    'type': 'text',
+                    'text': 'I will check.'
+                }, {
+                    'type': 'tool_use',
+                    'id': 'toolu_weather',
+                    'name': 'get_weather',
+                    'input': {
+                        'city': 'Beijing'
+                    },
+                }],
+            }, {
+                'role':
+                'user',
+                'content': [{
+                    'type': 'tool_result',
+                    'tool_use_id': 'toolu_weather',
+                    'content': [{
+                        'type': 'text',
+                        'text': 'sunny'
+                    }],
+                }],
+            }]
+        }
+        result = AnthropicMessagesPreprocessor().preprocess(row)
+        self.assertEqual(result['messages'], [{
+            'role': 'assistant',
+            'content': 'I will check.'
+        }, {
+            'role': 'tool_call',
+            'content': {
+                'name': 'get_weather',
+                'arguments': {
+                    'city': 'Beijing'
+                }
+            },
+        }, {
+            'role': 'tool_response',
+            'content': 'sunny'
+        }])
 
 
 if __name__ == '__main__':

--- a/tests/general/test_data_preprocess.py
+++ b/tests/general/test_data_preprocess.py
@@ -3,7 +3,8 @@ import unittest
 from swift.dataset import (AnthropicMessagesPreprocessor, EncodePreprocessor, MessagesPreprocessor,
                            OpenAIMessagesPreprocessor, PackingDataset, load_dataset)
 from swift.model import get_processor
-from swift.template import get_template
+from swift.template import get_template, load_image
+from swift.template.template_inputs import StdTemplateInputs
 
 
 class TestDataPreprocess(unittest.TestCase):
@@ -347,6 +348,79 @@ class TestProviderMessagesPreprocess(unittest.TestCase):
             'role': 'tool_response',
             'content': 'sunny'
         }])
+
+    def test_anthropic_multimodal_content_blocks(self):
+        row = {
+            'messages': [{
+                'role':
+                'user',
+                'content': [{
+                    'type': 'text',
+                    'text': 'What is in this image? '
+                }, {
+                    'type': 'image',
+                    'source': {
+                        'type':
+                        'base64',
+                        'media_type':
+                        'image/png',
+                        'data': ('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ'
+                                 '/pLvAAAAAElFTkSuQmCC'),
+                    },
+                }],
+            }, {
+                'role': 'assistant',
+                'content': [{
+                    'type': 'tool_use',
+                    'id': 'toolu_image',
+                    'name': 'inspect_image',
+                    'input': {},
+                }],
+            }, {
+                'role':
+                'user',
+                'content': [{
+                    'type':
+                    'tool_result',
+                    'tool_use_id':
+                    'toolu_image',
+                    'content': [{
+                        'type': 'image',
+                        'source': {
+                            'type': 'url',
+                            'url': 'https://example.com/result.png',
+                        },
+                    }, {
+                        'type': 'text',
+                        'text': 'A sunny beach.',
+                    }],
+                }],
+            }]
+        }
+        result = AnthropicMessagesPreprocessor().preprocess(row)
+        self.assertEqual(result['messages'], [{
+            'role': 'user',
+            'content': 'What is in this image? <image>',
+        }, {
+            'role': 'tool_call',
+            'content': {
+                'name': 'inspect_image',
+                'arguments': {}
+            },
+        }, {
+            'role': 'tool_response',
+            'content': '<image>A sunny beach.',
+        }])
+        self.assertEqual(result['images'], [
+            ('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ'
+             '/pLvAAAAAElFTkSuQmCC'),
+            'https://example.com/result.png',
+        ])
+        self.assertEqual(load_image(result['images'][0]).size, (1, 1))
+
+        template_inputs = StdTemplateInputs.from_dict(result)
+        self.assertEqual(template_inputs.images, result['images'])
+        self.assertEqual(template_inputs.messages[-1]['content'], '<image>A sunny beach.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What changed

- normalize OpenAI `assistant.tool_calls` into SWIFT `tool_call` messages
- normalize Anthropic `tool_use` and `tool_result` content blocks into SWIFT canonical roles
- add explicit `OpenAIMessagesPreprocessor` and `AnthropicMessagesPreprocessor` classes
- auto-detect provider tool-call formats in `MessagesPreprocessor`
- document both accepted formats in English and Chinese

## Why

`MessagesPreprocessor._check_messages` keeps only `role`, `content`, `loss`, and `loss_scale`. OpenAI-style tool calls stored in `assistant.tool_calls` were therefore silently removed during dataset preprocessing even though templates can encode tool calls. This can produce training examples that retain assistant narration but lose the actual tool-call targets.

Anthropic tool-use traces similarly need their content blocks expanded into SWIFT's canonical `assistant`, `tool_call`, and `tool_response` roles before template encoding.

## Impact

OpenAI and Anthropic agent traces can now be passed through the normal dataset preprocessing path without an external conversion script. Parallel OpenAI tool calls, string or object arguments, Anthropic text/tool interleaving, nested text tool results, and loss metadata are covered.

The regression test also decodes supervised labels and asserts that the tool name is present, rather than only checking that template encoding succeeds.

## Validation

- `pre-commit run --all-files`
- `python -m unittest tests.general.test_data_preprocess.TestProviderMessagesPreprocess tests.general.test_data_preprocess.TestRejectedMessagesPreprocess tests.general.test_data_preprocess.TestDataPreprocess.test_tool_message`

Related to #8327 and #9084.
