### PR TITLE
[bugfix] Fix Qwen3.5 non-packing causal conv routing

### DIFF
--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1383,7 +1383,8 @@ def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
             attention_mask: Optional[torch.Tensor] = None,
             **kwargs,
         ):
-            if not sequence_parallel.enabled() and 'cu_seq_lens_q' not in kwargs:
+            # Transformers may propagate optional FlashAttention kwargs with None values in non-packing paths.
+            if not sequence_parallel.enabled() and kwargs.get('cu_seq_lens_q') is None:
                 kwargs = {}
                 if 'cache_position' in parameters:
                     kwargs['cache_position'] = cache_position


### PR DESCRIPTION
## What changed

- Treat `cu_seq_lens_q=None` as a non-packing Qwen3.5 forward instead of selecting the FLA packing/sequence-parallel implementation merely because the optional kwarg is present.

## Root cause

In `transformers==5.12.1`, the failing line reported in #9810 is after the causal-convolution call, not immediately after `in_proj_qkv`. The native `causal_conv1d_fn` returns a tensor, while FLA's `causal_conv1d` returns an `(output, state)` tuple.

Older ms-swift code could install the FLA callable into `mod.causal_conv1d_fn` when the packed path was selected. Although #9643 isolated that callable on current `main`, the wrapper still selected the packed path whenever the `cu_seq_lens_q` key existed, even when its value was `None`. Optional FlashAttention kwargs can be propagated with `None` in a regular non-packing forward.

This change uses the value of `cu_seq_lens_q` to select the packed path, so a normal Qwen3.5 SFT forward stays on the Transformers implementation.

## Impact

Qwen3.5 non-packing SFT, including LoRA, gradient checkpointing, DeepSpeed, and resume flows, no longer enters the tuple-returning FLA causal-convolution path solely because an empty optional kwarg was propagated.

Fixes #9810.

## Validation

- `flake8 swift/model/models/qwen.py`
- `isort --check-only swift/model/models/qwen.py`
- `yapf --diff swift/model/models/qwen.py`
- `git diff --check`
