### PR TITLE
fix(npu): fix context parallelism for Qwen3.5

### DIFF
--- a/swift/model/npu_patch/mindspeed.py
+++ b/swift/model/npu_patch/mindspeed.py
@@ -303,11 +303,33 @@ def patch_mindspeed_te_layernorm_linear_frozen_weight() -> None:
     logger.info('Patched MindSpeed TE LayerNormLinear to use Megatron frozen-weight backward for frozen weights.')
 
 
+def patch_mindspeed_gdn_cp_helpers(megatron_args: dict[str, Any]) -> None:
+    """Expose MindSpeed's backported GDN CP helpers to Megatron Core versions before 0.18."""
+    if int(megatron_args.get('context_parallel_size', 1)) <= 1:
+        return
+
+    megatron_gdn = importlib.import_module('megatron.core.ssm.gated_delta_net')
+    mindspeed_gdn = importlib.import_module('mindspeed.core.ssm.gated_delta_net')
+    patched_helpers = []
+    for helper_name in ('tensor_a2a_cp2hp', 'tensor_a2a_hp2cp'):
+        if hasattr(megatron_gdn, helper_name):
+            continue
+        helper = getattr(mindspeed_gdn, helper_name, None)
+        if helper is None:
+            raise RuntimeError(f'MindSpeed does not provide the required GDN CP helper: {helper_name}.')
+        setattr(megatron_gdn, helper_name, helper)
+        patched_helpers.append(helper_name)
+
+    if patched_helpers:
+        logger.info('Patched Megatron GDN CP helpers from MindSpeed: %s.', ', '.join(patched_helpers))
+
+
 def apply_mindspeed_patches(megatron_args: dict[str, Any]) -> None:
     """Apply MindSpeed compatibility patches around its runtime repatch in the required order."""
     from mindspeed.megatron_adaptor import repatch
 
     patch_mindspeed_te_cp_implementation(megatron_args)
     repatch(megatron_args)
+    patch_mindspeed_gdn_cp_helpers(megatron_args)
     patch_mindspeed_te_layernorm_linear_frozen_weight()
     patch_mindspeed_fla_gdn_implementation()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
## Problem

Qwen3.5 Megatron training with context parallelism fails during the first forward pass.

Reproduction topology:

- Megatron-Core 0.16.0
- mcore-bridge 1.7.0.dev0
- CP=2, TP=1, PP=1
- `USE_MCORE_GDN=1`

```text
File ".../mcore_bridge/model/modules/gated_delta_net.py", line 210, in forward
    from megatron.core.ssm.gated_delta_net import tensor_a2a_cp2hp, tensor_a2a_hp2cp
ImportError: cannot import name 'tensor_a2a_cp2hp' from
'megatron.core.ssm.gated_delta_net'
```

MindSpeed provides backported implementations of both helpers, but they are not
exported through `megatron.core.ssm.gated_delta_net`, which is the namespace
used by mcore-bridge during the GDN context-parallel forward pass.

## Fix

After MindSpeed `repatch`, expose the MindSpeed implementations through the
Megatron GDN module when:

- `context_parallel_size > 1`;
- the corresponding helper is missing from Megatron-Core.

Existing Megatron-Core implementations are preserved.

## Verification

Qwen3.5-4B Megatron training completed successfully with:

- CP=2, TP=1, PP=1
- BF16 LoRA
- packing and padding-free enabled
- two forward/backward/optimizer steps
- Megatron checkpoint and safetensors successfully saved
