### PR TITLE
fix(sample): don't crash on torch_dtype in engine_kwargs

### DIFF
--- a/swift/pipelines/sampling/vanilla_sampler.py
+++ b/swift/pipelines/sampling/vanilla_sampler.py
@@ -13,6 +13,16 @@ from .utils import get_messages_md5, get_reward
 logger = get_logger()
 
 
+def _pop_engine_torch_dtype(engine_kwargs):
+    # torch_dtype is always passed explicitly from --torch_dtype; a leftover
+    # copy in engine_kwargs (the old workaround for it being ignored) would
+    # crash engine construction with a duplicate keyword argument.
+    engine_kwargs = dict(engine_kwargs)
+    if engine_kwargs.pop('torch_dtype', None) is not None:
+        logger.warning('`torch_dtype` in engine_kwargs is ignored, please use `--torch_dtype` instead.')
+    return engine_kwargs
+
+
 @RayHelper.worker(group=['sampler', 'prm', 'orm'])
 class VanillaSampler(Sampler):
 
@@ -42,7 +52,7 @@ class VanillaSampler(Sampler):
                 model_type=self.args.model_type,
                 template=self.template,
                 torch_dtype=self.args.torch_dtype,
-                **self.args.engine_kwargs)
+                **_pop_engine_torch_dtype(self.args.engine_kwargs))
             self.infer_engine.strict = False
 
     @RayHelper.function(group='sampler')

--- a/tests/general/test_sampler_engine_kwargs.py
+++ b/tests/general/test_sampler_engine_kwargs.py
@@ -1,0 +1,36 @@
+import torch
+
+from swift.pipelines.sampling.vanilla_sampler import _pop_engine_torch_dtype
+
+
+def _engine_stub(*args, torch_dtype=None, **kwargs):
+    return torch_dtype, kwargs
+
+
+def test_engine_kwargs_torch_dtype_no_crash():
+    # dtype in engine_kwargs was the workaround while --torch_dtype was ignored;
+    # it must survive the explicit argument now instead of raising TypeError.
+    cleaned = _pop_engine_torch_dtype({'torch_dtype': 'bfloat16', 'max_model_len': 4096})
+    torch_dtype, kwargs = _engine_stub('model', torch_dtype=torch.bfloat16, **cleaned)
+    assert torch_dtype == torch.bfloat16
+    assert kwargs == {'max_model_len': 4096}
+
+
+def test_engine_kwargs_passthrough():
+    assert _pop_engine_torch_dtype({'max_model_len': 4096}) == {'max_model_len': 4096}
+    assert _pop_engine_torch_dtype({'torch_dtype': None}) == {}
+    assert _pop_engine_torch_dtype({}) == {}
+
+
+def test_duplicate_torch_dtype_would_raise():
+    try:
+        _engine_stub('model', torch_dtype=torch.bfloat16, **{'torch_dtype': 'bfloat16'})
+    except TypeError:
+        return
+    raise AssertionError('expected TypeError without the pop')
+
+
+if __name__ == '__main__':
+    test_engine_kwargs_torch_dtype_no_crash()
+    test_engine_kwargs_passthrough()
+    test_duplicate_torch_dtype_would_raise()


### PR DESCRIPTION
#9808 made `swift sample` honor `--torch_dtype` by passing it to the sampler engine explicitly, which was the right fix for the flag being ignored. One side effect: while the flag was ignored, the only way to pick a dtype was `--engine_kwargs '{"torch_dtype":"bfloat16"}'`, because engine_kwargs splats straight into the engine constructor, and all three sampler engines (transformers / vllm / lmdeploy) take a named `torch_dtype` parameter. Those commands now crash at engine construction with `TypeError: got multiple values for keyword argument 'torch_dtype'`.

Pop the key out of engine_kwargs before the splat and warn that `--torch_dtype` is the way to set it. The flag always wins, so #9808's intent stays intact.

Verification: new `tests/general/test_sampler_engine_kwargs.py` covers the crash case, passthrough of unrelated keys, and a sanity check that the duplicate really does raise without the pop. yapf / flake8 / isort clean.
