### PR TITLE
[bugfix] report per-device maximum memory

### DIFF
--- a/swift/utils/torch_utils.py
+++ b/swift/utils/torch_utils.py
@@ -416,4 +416,4 @@ def get_max_reserved_memory() -> float:
         mems = [get_torch_device().max_memory_reserved(device=device) for device in devices]
     except AttributeError:
         return 0  # fix mps
-    return sum(mems) / 1024**3
+    return max(mems) / 1024**3

--- a/tests/utils/test_max_reserved_memory.py
+++ b/tests/utils/test_max_reserved_memory.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import Mock, call, patch
+
+from swift.utils import torch_utils
+
+GIB = 1024**3
+
+
+class TestMaxReservedMemory(unittest.TestCase):
+
+    @patch.object(torch_utils, 'get_device_count', return_value=3)
+    @patch.object(torch_utils, 'is_mp', return_value=True)
+    def test_model_parallel_reports_per_device_maximum(self, _, __):
+        device_api = Mock()
+        device_api.max_memory_reserved.side_effect = [16 * GIB, 40 * GIB, 24 * GIB]
+
+        with patch.object(torch_utils, 'get_torch_device', return_value=device_api):
+            memory = torch_utils.get_max_reserved_memory()
+
+        self.assertEqual(memory, 40)
+        self.assertEqual(
+            device_api.max_memory_reserved.call_args_list,
+            [call(device=0), call(device=1), call(device=2)],
+        )
+
+    @patch.object(torch_utils, 'get_device_count')
+    @patch.object(torch_utils, 'is_mp', return_value=False)
+    def test_non_model_parallel_uses_current_device(self, _, get_device_count):
+        device_api = Mock()
+        device_api.max_memory_reserved.return_value = 12 * GIB
+
+        with patch.object(torch_utils, 'get_torch_device', return_value=device_api):
+            memory = torch_utils.get_max_reserved_memory()
+
+        self.assertEqual(memory, 12)
+        get_device_count.assert_not_called()
+        device_api.max_memory_reserved.assert_called_once_with(device=None)
+
+    @patch.object(torch_utils, 'is_mp', return_value=False)
+    def test_missing_memory_api_returns_zero(self, _):
+        with patch.object(torch_utils, 'get_torch_device', return_value=object()):
+            memory = torch_utils.get_max_reserved_memory()
+
+        self.assertEqual(memory, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixes #9801.

## Problem

In the Transformers model-parallel path, `get_max_reserved_memory()` sums the
historical peak reserved memory of every visible device. The resulting
`memory(GiB)` value can exceed a single device's capacity and does not represent
a simultaneous aggregate peak.

## Fix

Report the maximum per-device value instead, as discussed in the issue. The
non-model-parallel path and the fallback for devices without the memory API are
unchanged.

## Experiment results

- Added CPU mock tests for multi-device model parallelism, the non-model-parallel
  path, and the missing-memory-API fallback.
- `python -m pytest -q tests/utils/test_max_reserved_memory.py`: 3 passed.
- `PYTHONPATH=. python tests/run.py --suites test_max_reserved_memory.py`: 3
  succeeded.
- `pre-commit run --all-files`: passed.
