### PR TITLE
feat(rollout): support min_p sampling in GRPO/DAPO rollout (#9824)

### DIFF
--- a/docs/source/Instruction/Command-line-parameters.md
+++ b/docs/source/Instruction/Command-line-parameters.md
@@ -572,6 +572,7 @@ RLHF参数继承于[训练参数](#训练参数)。
 - temperature: 默认为0.9，该参数将在PPO、GRPO、GKD中使用。
 - top_k: rollout采样的top-k参数，-1表示不进行top-k过滤。默认为-1。
 - top_p: rollout采样的top-p参数，1.0表示不进行top-p过滤。默认为1.0。
+- min_p: rollout采样的min-p参数，概率低于最高概率token概率`min_p`倍的token将被过滤，0.0表示不进行min-p过滤。默认为0.0。仅对vLLM后端生效。
 
 #### GKD参数
 - lmbda: 默认为0.5。该参数在GKD中使用。控制学生数据比例的 lambda 参数（即策略内学生生成输出所占的比例）。若lmbda为0，则不使用学生生成数据。

--- a/docs/source_en/Instruction/Command-line-parameters.md
+++ b/docs/source_en/Instruction/Command-line-parameters.md
@@ -584,6 +584,7 @@ RLHF arguments inherit from the [training arguments](#training-arguments).
 - temperature: Default is 0.9; this parameter will be used in PPO, GRPO and GKD.
 - top_k: Top-k parameter for rollout sampling. -1 means no top-k filtering is applied. Default is -1.
 - top_p: Top-p parameter for rollout sampling. 1.0 means no top-p filtering is applied. Default is 1.0.
+- min_p: Min-p parameter for rollout sampling. Tokens whose probability is below `min_p` times the probability of the most likely token are filtered out. 0.0 means no min-p filtering is applied. Default is 0.0. Only effective with the vLLM backend.
 
 #### GKD Arguments
 - lmbda: Default is 0.5. This parameter is used in GKD. It controls the lambda parameter for the proportion of student data (i.e., the proportion of student-generated outputs within the strategy). If lmbda is 0, student-generated data is not used.

--- a/swift/infer_engine/protocol.py
+++ b/swift/infer_engine/protocol.py
@@ -191,6 +191,7 @@ class RequestConfig:
     temperature: Optional[float] = None
     top_k: Optional[int] = None
     top_p: Optional[float] = None
+    min_p: Optional[float] = None
     repetition_penalty: Optional[float] = None
     num_beams: int = 1
     stop: Optional[List[str]] = field(default_factory=list)

--- a/swift/infer_engine/vllm_engine.py
+++ b/swift/infer_engine/vllm_engine.py
@@ -515,7 +515,7 @@ class VllmEngine(InferEngine):
 
     def _prepare_generation_config(self, request_config: RequestConfig) -> SamplingParams:
         kwargs = {'max_tokens': request_config.max_tokens}
-        for key in ['temperature', 'top_k', 'top_p', 'repetition_penalty']:
+        for key in ['temperature', 'top_k', 'top_p', 'min_p', 'repetition_penalty']:
             new_value = getattr(request_config, key)
             if new_value is None:
                 kwargs[key] = getattr(self.generation_config, key)

--- a/swift/megatron/trainers/rollout_mixin.py
+++ b/swift/megatron/trainers/rollout_mixin.py
@@ -140,6 +140,7 @@ class MegatronRolloutMixin(BaseRolloutTrainerMixin):
             temperature=args.temperature,
             top_p=getattr(args, 'top_p', 1.0),
             top_k=getattr(args, 'top_k', -1),
+            min_p=getattr(args, 'min_p', 0.0),
             repetition_penalty=getattr(args, 'repetition_penalty', 1.0),
             stop=getattr(args, 'stop_words', None),
             return_details=True,

--- a/swift/rlhf_trainers/args_mixin.py
+++ b/swift/rlhf_trainers/args_mixin.py
@@ -108,6 +108,8 @@ class RolloutTrainerArgumentsMixin(VllmArguments):
             no filtering. Defaults to -1.
         top_p (float): If set to a float < 1, only the smallest set of most probable tokens with probabilities that
             add up to top_p or higher are kept for generation. Defaults to 1.0.
+        min_p (float): Minimum token probability, scaled by the probability of the most likely token. Tokens below
+            the resulting threshold are filtered out. 0.0 means no filtering. Defaults to 0.0.
         repetition_penalty (float): The parameter for repetition penalty. 1.0 means no penalty. Defaults to 1.0.
         stop_words (List[str]): A list of strings that will stop the generation when they are generated. Defaults to an
             empty list.
@@ -159,6 +161,7 @@ class RolloutTrainerArgumentsMixin(VllmArguments):
     # generation args
     top_k: int = -1
     top_p: float = 1.0
+    min_p: float = 0.0
     repetition_penalty: float = 1.
     stop_words: List[str] = field(default_factory=list)
 

--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -359,6 +359,7 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
             temperature=args.temperature,
             top_p=args.top_p,
             top_k=args.top_k,
+            min_p=args.min_p,
             repetition_penalty=args.repetition_penalty,
             stop=args.stop_words,
             return_details=True,


### PR DESCRIPTION
Closes #9824.

### Problem

`RolloutTrainerArgumentsMixin` exposes `top_k`, `top_p` and `repetition_penalty` for rollout sampling, but not `min_p`. Passing `--min_p 0.1` to a GRPO/DAPO run therefore fails argument parsing:

```
remaining_argv: ['--min_p', '0.1']
```

`RequestConfig` has no `min_p` field either, so even setting it programmatically would not reach vLLM — `VllmEngine._prepare_generation_config` only forwards `temperature`, `top_k`, `top_p` and `repetition_penalty` to `SamplingParams`.

### Change

- `RolloutTrainerArgumentsMixin`: new `min_p: float = 0.0` argument (documented in the class docstring).
- `RequestConfig`: new `min_p: Optional[float] = None`, alongside `top_k`/`top_p`.
- `RolloutTrainerMixin` and the Megatron rollout mixin: pass `min_p` when building `RequestConfig`.
- `VllmEngine._prepare_generation_config`: add `min_p` to the keys forwarded to `SamplingParams`.
- Docs: document the new rollout parameter in both `Command-line-parameters.md` files.

The default is `0.0` (vLLM's own "no min-p filtering" value), so behaviour is unchanged for runs that do not set it. Server mode needs no extra work: `VLLMClient` serializes the request config with `asdict()`, so the new field is carried to `swift rollout` automatically. Other backends (SGLang, LMDeploy, transformers) keep their existing key lists and simply ignore the field, matching how their generation configs are already scoped.

### Verification

I do not have a multi-GPU box to run the GRPO suite, so I verified the parts that are testable standalone — the dataclasses were extracted with `ast` and exercised on `main` vs. this branch:

```
OLD: RequestConfig(..., min_p=0.1) -> TypeError: __init__() got an unexpected keyword argument 'min_p'
NEW: RequestConfig(..., min_p=0.1) -> ok, min_p=0.1; asdict() payload contains min_p

RolloutTrainerArgumentsMixin fields — added: ['min_p'], removed: []
```

All touched modules byte-compile, and no line exceeds the 120-column limit (`swift/infer_engine/protocol.py:507` is a pre-existing long docstring line, unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
