### PR TITLE
[megatron] Fix MTP-only pipeline layout stages

### DIFF
--- a/docs/source/Megatron-SWIFT/Command-line-parameters.md
+++ b/docs/source/Megatron-SWIFT/Command-line-parameters.md
@@ -166,6 +166,7 @@
 - microbatch_group_size_per_vp_stage: 每个虚拟流水线阶段处理的连续微批次数量。默认为None，等于pipeline_model_parallel_size。
 - 🔥pipeline_model_parallel_layout: 一个描述自定义流水线（pp/vpp）模型并行布局的字符串。例如：`"Et*4|(tttt|)*14tmL"`。其中 E、L、t、m 分别表示嵌入层（embedding）、损失层（loss）、Transformer 解码器层和 MTP 层。阶段之间用 "|" 分隔。重复的阶段或层可以通过乘法表示。逗号仅用于提升可读性（无实际语法作用）。默认值为 None，表示不使用此参数设置布局。
   - 该参数通常在异构GPU集群上使用。
+  - 布局中的 `m` 数量必须与实际构建的 MTP 层数一致。使用 `mtp_shared_weights=true` 时只构建一个共享 MTP 层并重复执行，因此布局中只需要一个 `m`。
 - 🔥expert_model_parallel_size: 专家并行数，默认为1。
 - 🔥expert_tensor_parallel_size: 专家TP并行度。默认值为1。
 

--- a/docs/source_en/Megatron-SWIFT/Command-line-parameters.md
+++ b/docs/source_en/Megatron-SWIFT/Command-line-parameters.md
@@ -172,6 +172,7 @@ For guidance on selecting parallelization strategies, please refer to the [Train
 - microbatch_group_size_per_vp_stage: The number of consecutive microbatches processed by each virtual pipeline stage. Defaults to None, which equals `pipeline_model_parallel_size`.
 - 🔥pipeline_model_parallel_layout: A string describing a custom pipeline (pp/vpp) model parallel layout. For example: `"Et*4|(tttt|)*14tmL"`. Here, E, L, t, and m denote the embedding layer, loss layer, Transformer decoder layer, and MTP layer, respectively. Stages are separated by "|". Repeated stages or layers can be expressed using multiplication. Commas are only for cosmetic readability and have no syntactic meaning. The default value is None, indicating that this argument is not used to set the layout.
   - This parameter is typically used on heterogeneous GPU clusters.
+  - The number of `m` entries must match the number of MTP layers that are actually built. With `mtp_shared_weights=true`, only one shared MTP layer is built and repeatedly applied, so the layout requires only one `m`.
 - 🔥expert_model_parallel_size: The degree of expert parallelism, default is 1.
 - 🔥expert_tensor_parallel_size: expert tensor-parallel size. Default is 1.
 

--- a/swift/megatron/init.py
+++ b/swift/megatron/init.py
@@ -17,6 +17,82 @@ from swift.utils import (HfConfigFactory, disable_safe_ddp_context_use_barrier, 
 logger = get_logger()
 
 
+def _get_mtp_transformer_layer_spec(loader, transformer_layer_spec, vp_stage=None):
+    """Get a decoder layer spec for building an MTP-only pipeline stage.
+
+    Megatron builds an MTP layer from a decoder layer spec. A custom pipeline
+    layout may place MTP in a stage without decoder layers, in which case the
+    local transformer block cannot provide that spec. Build a temporary view of
+    the layout that moves the last preceding decoder stage into the MTP stage,
+    ask the model-specific loader for its specs, then restore the original
+    layout. The returned spec is only used as a template; the actual decoder
+    layout is not changed.
+    """
+    layer_specs = getattr(transformer_layer_spec, 'layer_specs', None)
+    if layer_specs is None or len(layer_specs) > 0:
+        return transformer_layer_spec
+
+    config = loader.config
+    layout = getattr(config, 'pipeline_model_parallel_layout', None)
+    if layout is None:
+        return transformer_layer_spec
+
+    from megatron.core import mpu
+    from megatron.core.transformer.enums import LayerType
+
+    pp_rank = mpu.get_pipeline_model_parallel_rank()
+    vp_rank = vp_stage or 0
+    current_stage = layout.layout[pp_rank][vp_rank]
+    if LayerType.mtp not in current_stage:
+        return transformer_layer_spec
+
+    fallback_layout = deepcopy(layout)
+    donor_stage = None
+    for candidate_vp_rank in range(fallback_layout.virtual_pipeline_model_parallel_size):
+        for candidate_pp_rank in range(fallback_layout.pipeline_model_parallel_size):
+            if (candidate_pp_rank, candidate_vp_rank) == (pp_rank, vp_rank):
+                break
+            candidate_stage = fallback_layout.layout[candidate_pp_rank][candidate_vp_rank]
+            if LayerType.decoder in candidate_stage:
+                donor_stage = candidate_stage
+        else:
+            continue
+        break
+
+    if donor_stage is None:
+        raise ValueError('Unable to build an MTP-only pipeline stage: no preceding decoder layer was found.')
+
+    # Move the last decoder stage's decoder layers while preserving any other
+    # layer types in that stage. Keeping the decoder group together also
+    # preserves model-specific intra-stage validation, such as DSA index sharing.
+    donor_num_decoders = donor_stage.count(LayerType.decoder)
+    donor_stage[:] = [layer_type for layer_type in donor_stage if layer_type != LayerType.decoder]
+    fallback_stage = fallback_layout.layout[pp_rank][vp_rank]
+    mtp_idx = fallback_stage.index(LayerType.mtp)
+    fallback_stage[mtp_idx:mtp_idx] = [LayerType.decoder] * donor_num_decoders
+    fallback_layout.flatten_layout = []
+    for candidate_vp_rank in range(fallback_layout.virtual_pipeline_model_parallel_size):
+        for candidate_pp_rank in range(fallback_layout.pipeline_model_parallel_size):
+            fallback_layout.flatten_layout.extend(fallback_layout.layout[candidate_pp_rank][candidate_vp_rank])
+
+    config.pipeline_model_parallel_layout = fallback_layout
+    try:
+        mtp_transformer_layer_spec = loader.get_transformer_layer_spec(vp_stage=vp_stage)
+    finally:
+        config.pipeline_model_parallel_layout = layout
+
+    if not mtp_transformer_layer_spec.layer_specs:
+        raise ValueError('Unable to build an MTP-only pipeline stage: no decoder layer spec was generated.')
+
+    # Keep this in sync with ModelLoader.build_model. These replacements are
+    # normally applied to the local transformer block, which is empty here.
+    loader._set_shared_expert_gate(mtp_transformer_layer_spec)
+    loader._set_transformer_layer(mtp_transformer_layer_spec)
+    loader._replace_mla_attention(mtp_transformer_layer_spec)
+    loader._replace_router(mtp_transformer_layer_spec)
+    return mtp_transformer_layer_spec
+
+
 def _patch__batched_p2p_ops():
     from megatron.core.pipeline_parallel import p2p_communication
 
@@ -116,7 +192,21 @@ def _patch_unified_memory():
 def _patch_mcore_bridge():
     import mcore_bridge
     from mcore_bridge import GPTBridge
+    from mcore_bridge.model.register import ModelLoader
     logger.info(f'mcore_bridge.__version__: {mcore_bridge.__version__}')
+
+    origin_get_mtp_block_spec = ModelLoader.get_mtp_block_spec
+
+    if not getattr(origin_get_mtp_block_spec, '_swift_supports_mtp_only_stage', False):
+
+        def get_mtp_block_spec(self, transformer_layer_spec, vp_stage=None):
+            transformer_layer_spec = _get_mtp_transformer_layer_spec(
+                self, transformer_layer_spec, vp_stage=vp_stage)
+            return origin_get_mtp_block_spec(self, transformer_layer_spec, vp_stage=vp_stage)
+
+        get_mtp_block_spec._swift_supports_mtp_only_stage = True
+        ModelLoader.get_mtp_block_spec = get_mtp_block_spec
+
     origin_save_weights = GPTBridge.save_weights
 
     def save_weights(


### PR DESCRIPTION
## Summary

- support custom pipeline layouts where an MTP-only VP stage has no local decoder layers
- derive the model-specific MTP template from the final preceding decoder stage without changing the actual pipeline layout
- document how the number of `m` entries relates to shared MTP layers

## Root cause

`mcore-bridge` passed the current VP stage's local transformer block to Megatron when constructing the MTP block. For an MTP-only stage such as `E(|tt)*30,|mL`, that block has no decoder specs, so Megatron indexed an empty `layer_specs` list.

The compatibility patch creates a temporary, internally consistent layout view that exposes the final decoder stage to the model-specific loader. It restores the original configuration in a `finally` block before model construction continues.

Closes #9823
