### PR TITLE
fix(npu): optimize MoE weight synchronization for NPU colocate training with vLLM-Ascend.

### DIFF
--- a/examples/ascend/train/qwen3/qwen3_lora_fsdp/train.sh
+++ b/examples/ascend/train/qwen3/qwen3_lora_fsdp/train.sh
@@ -4,6 +4,7 @@
 # synchronization point caused by inter-card desynchronization when loading the model.
 export TASK_QUEUE_ENABLE=2
 export CPU_AFFINITY_CONF=2
+PYTORCH_NPU_ALLOC_CONF='expandable_segments:True' \
 ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
 accelerate launch --config_file "./examples/ascend/train/qwen3/qwen3_lora_fsdp/fsdp.json" \
     swift/cli/sft.py \

--- a/swift/megatron/trainers/rollout_mixin.py
+++ b/swift/megatron/trainers/rollout_mixin.py
@@ -623,10 +623,17 @@ class MegatronRolloutMixin(BaseRolloutTrainerMixin):
 
         if self.vllm_mode == 'colocate':
             llm_model = self.engine.inner_model
-            patch_vllm_moe_model_weight_loader(llm_model)
-            llm_model.load_weights(weight_iterator)
-            _model_config = self.engine.engine.model_config
-            finish_vllm_weight_reload(llm_model, model_config=_model_config, target_device=self.device)
+            ascend_reload_runner = None
+            if is_torch_npu_available():
+                from swift.model.npu_patch.vllm_ascend import get_vllm_ascend_reload_runner
+                ascend_reload_runner = get_vllm_ascend_reload_runner(self.engine)
+            if ascend_reload_runner is not None:
+                ascend_reload_runner.reload_weights(weights_iterator=weight_iterator, is_checkpoint_format=True)
+            else:
+                patch_vllm_moe_model_weight_loader(llm_model)
+                llm_model.load_weights(weight_iterator)
+                _model_config = self.engine.engine.model_config
+                finish_vllm_weight_reload(llm_model, model_config=_model_config, target_device=self.device)
         elif self.vllm_mode == 'server':
             self._load_weights_to_server_in_buckets(weight_iterator)
             if self.is_main_process:

--- a/swift/model/npu_patch/vllm_ascend.py
+++ b/swift/model/npu_patch/vllm_ascend.py
@@ -12,17 +12,48 @@ still responsible for guarding these entrypoints with an NPU/device check.
 """
 from __future__ import annotations
 
+import inspect
 import sys
 
 from swift.model.npu_patch.vllm_ascend_lora import (patch_vllm_ascend_lora_runtime, validate_vllm_ascend_lora_training,
                                                     validate_vllm_ascend_megatron_lora_training)
 from swift.model.npu_patch.vllm_ascend_memory import patch_vllm_ascend_memory_runtime
 from swift.model.npu_patch.vllm_ascend_moe import (patch_vllm_ascend_moe_expert_weight_loader,
-                                                   patch_vllm_ascend_moe_runtime, should_skip_vllm_ascend_moe_post_load,
-                                                   use_vllm_ascend_moe_preprocessed_weight)
+                                                   patch_vllm_ascend_moe_runtime)
 from swift.utils.logger import get_logger
 
 logger = get_logger()
+
+
+def get_vllm_ascend_reload_runner(engine):
+    """Return the vLLM-Ascend runner with checkpoint-aware reload support.
+
+    vLLM 0.18 exposes ``reload_weights(..., is_checkpoint_format=...)`` on its
+    legacy model runner.  vLLM-Ascend's default v1 runner inherits that method,
+    while its experimental v2 runner and older releases do not.  Detect the
+    actual runner capability so GPU and unsupported Ascend paths keep their
+    existing SWIFT weight-sync lifecycle.
+    """
+    try:
+        model_executor = engine.inner_model_executor
+        driver_worker = model_executor.driver_worker
+        worker = getattr(driver_worker, 'worker', driver_worker)
+        model_runner = worker.model_runner
+    except AttributeError:
+        return None
+
+    if not type(model_runner).__module__.startswith('vllm_ascend'):
+        return None
+    reload_weights = getattr(model_runner, 'reload_weights', None)
+    if not callable(reload_weights):
+        return None
+    try:
+        if 'is_checkpoint_format' not in inspect.signature(reload_weights).parameters:
+            return None
+    except (TypeError, ValueError):
+        return None
+    logger.info_once('Using vLLM-Ascend checkpoint-aware reload_weights for colocate weight synchronization.')
+    return model_runner
 
 
 def _patch_flash_attn_optional_import() -> None:
@@ -60,10 +91,9 @@ def patch_vllm_ascend_runtime(*, colocate: bool = False) -> None:
 
 
 __all__ = [
+    'get_vllm_ascend_reload_runner',
     'patch_vllm_ascend_moe_expert_weight_loader',
     'patch_vllm_ascend_runtime',
-    'should_skip_vllm_ascend_moe_post_load',
-    'use_vllm_ascend_moe_preprocessed_weight',
     'validate_vllm_ascend_lora_training',
     'validate_vllm_ascend_megatron_lora_training',
 ]

--- a/swift/model/npu_patch/vllm_ascend_moe.py
+++ b/swift/model/npu_patch/vllm_ascend_moe.py
@@ -21,11 +21,8 @@ from swift.utils.logger import get_logger
 
 logger = get_logger()
 
-_VLLM_ASCEND_MOE_SYNC_LAYOUT_ATTR = '_swift_vllm_ascend_moe_weight_sync_layout'
-_VLLM_ASCEND_MOE_SKIP_POST_LOAD_ATTR = '_swift_vllm_ascend_moe_skip_post_load'
-_VLLM_ASCEND_MOE_PROCESSED_LAYOUT = 'megatron_processed'
-_VLLM_ASCEND_MOE_PREPROCESSED_LAYOUT = 'fsdp2_preprocessed'
-_QWEN_MOE_MODEL_TYPES = {'qwen3_moe', 'qwen3_5_moe'}
+_VLLM_ASCEND_MOE_PROCESSED_WEIGHT_LOADED_ATTR = '_swift_vllm_ascend_moe_processed_weight_loaded'
+_VLLM_ASCEND_MOE_POST_LOAD_PATCHED_ATTR = '_swift_vllm_ascend_moe_post_load_patched'
 
 
 def _patch_vllm_ascend_device_op_nonquant_routing() -> None:
@@ -204,40 +201,38 @@ def patch_vllm_ascend_moe_runtime() -> None:
     _patch_vllm_ascend_moe_sleep_layout()
 
 
-def _is_qwen_moe_model(model) -> bool:
-    return getattr(getattr(model, 'config', None), 'model_type', None) in _QWEN_MOE_MODEL_TYPES
+def _is_vllm_ascend_unquantized_fused_moe_method(quant_method) -> bool:
+    """Return whether the layer uses Ascend's unquantized FusedMoE method."""
+    quant_method_module = type(quant_method).__module__ if quant_method is not None else ''
+    if not quant_method_module.startswith('vllm_ascend'):
+        return False
+    try:
+        from vllm.model_executor.layers.fused_moe import UnquantizedFusedMoEMethod
+    except (ImportError, AttributeError):
+        return False
+    return isinstance(quant_method, UnquantizedFusedMoEMethod)
 
 
-def configure_vllm_ascend_moe_weight_sync(vllm_model, train_model, *, is_fsdp2: bool) -> None:
-    """Record the vLLM-Ascend MoE sync layout required by this training backend."""
-    fsdp2_qwen_moe = is_fsdp2 and _is_qwen_moe_model(train_model)
-    layout = _VLLM_ASCEND_MOE_PROCESSED_LAYOUT
-    # Current vLLM-Ascend 0.18 non-quantized Qwen MoE forward keeps
-    # ``need_trans=False`` and feeds ``w13_weight`` directly to
-    # ``npu_grouped_matmul``.  After FSDP2 runtime sync, write Qwen MoE weights
-    # directly into the runtime [hidden, I_tp] direction and skip checkpoint
-    # post-load processing; otherwise post-load transposes them back to
-    # [I_tp, hidden] and the first rollout fails with a hidden-size mismatch
-    # such as 2048 vs 192/384.
-    setattr(vllm_model, _VLLM_ASCEND_MOE_SYNC_LAYOUT_ATTR, layout)
-    setattr(vllm_model, _VLLM_ASCEND_MOE_SKIP_POST_LOAD_ATTR, fsdp2_qwen_moe)
+def _patch_vllm_ascend_moe_post_load(experts) -> None:
+    """Skip post-load only for an expert layer already written in runtime layout."""
+    quant_method = getattr(experts, 'quant_method', None)
+    if not _is_vllm_ascend_unquantized_fused_moe_method(quant_method):
+        return
+    if getattr(quant_method, _VLLM_ASCEND_MOE_POST_LOAD_PATCHED_ATTR, False):
+        return
 
+    origin_process_weights = getattr(quant_method, 'process_weights_after_loading', None)
+    if origin_process_weights is None:
+        return
 
-def configure_vllm_ascend_moe_preprocessed_weight_sync(vllm_model) -> None:
-    """Record that reload writes the layout expected before vLLM-Ascend post-processing."""
-    setattr(vllm_model, _VLLM_ASCEND_MOE_SYNC_LAYOUT_ATTR, _VLLM_ASCEND_MOE_PREPROCESSED_LAYOUT)
-    setattr(vllm_model, _VLLM_ASCEND_MOE_SKIP_POST_LOAD_ATTR, False)
+    def process_weights_after_loading(layer):
+        if getattr(layer, _VLLM_ASCEND_MOE_PROCESSED_WEIGHT_LOADED_ATTR, False):
+            setattr(layer, _VLLM_ASCEND_MOE_PROCESSED_WEIGHT_LOADED_ATTR, False)
+            return
+        return origin_process_weights(layer)
 
-
-def use_vllm_ascend_moe_preprocessed_weight(vllm_model) -> bool:
-    """Return whether runtime sync should write the pre-process MoE layout."""
-    return getattr(vllm_model, _VLLM_ASCEND_MOE_SYNC_LAYOUT_ATTR,
-                   _VLLM_ASCEND_MOE_PROCESSED_LAYOUT) == _VLLM_ASCEND_MOE_PREPROCESSED_LAYOUT
-
-
-def should_skip_vllm_ascend_moe_post_load(vllm_model) -> bool:
-    """Return whether vLLM post-load processing should be skipped after sync."""
-    return bool(getattr(vllm_model, _VLLM_ASCEND_MOE_SKIP_POST_LOAD_ATTR, False))
+    quant_method.process_weights_after_loading = process_weights_after_loading
+    setattr(quant_method, _VLLM_ASCEND_MOE_POST_LOAD_PATCHED_ATTR, True)
 
 
 def expand_fused_moe_expert_names_for_vllm_ascend(name: str):
@@ -320,10 +315,13 @@ def patch_vllm_ascend_moe_expert_weight_loader(experts,
         w13_weight after process: [local_experts, hidden, 2 * intermediate_per_tp]
         w2_weight after process : [local_experts, intermediate_per_tp, hidden]
 
-    ``load_preprocessed_weight`` selects the server full-reload target.  FSDP2
-    Qwen MoE colocate runtime sync keeps the processed target and deliberately
-    skips the post-load transpose because current vLLM-Ascend non-quantized
-    grouped matmul consumes the [hidden, I_tp] direction in this path.
+    ``load_preprocessed_weight`` selects the server full-reload target.
+    Colocate runtime sync keeps the processed target because current
+    vLLM-Ascend non-quantized grouped matmul consumes the [hidden, I_tp]
+    direction in this path.  A layer-local marker is set only after this
+    wrapper actually copies such a tensor.  Its unquantized FusedMoE post-load
+    wrapper consumes that marker and skips only the redundant transpose for
+    this expert layer; all other model post-load processing still runs.
 
     This wrapper keeps the normal vLLM loader for initial checkpoint load,
     quantized experts, and non-Ascend backends.  It only handles the 3D
@@ -332,23 +330,19 @@ def patch_vllm_ascend_moe_expert_weight_loader(experts,
     """
     if 'w13_weight' not in name and 'w2_weight' not in name:
         return
-    quant_method = getattr(experts, 'quant_method', None)
-    quant_method_module = type(quant_method).__module__ if quant_method is not None else ''
-    if not quant_method_module.startswith('vllm_ascend'):
+    if not _is_vllm_ascend_unquantized_fused_moe_method(getattr(experts, 'quant_method', None)):
         return
+    _patch_vllm_ascend_moe_post_load(experts)
+    setattr(experts, _VLLM_ASCEND_MOE_PROCESSED_WEIGHT_LOADED_ATTR, False)
 
     def make_ascend_moe_weight_loader(experts, origin_weight_loader):
 
         def load_processed_ascend_weight(param, loaded_weight, weight_name, shard_id, expert_id, return_success=False):
-            quant_method = getattr(experts, 'quant_method', None)
-            quant_method_module = type(quant_method).__module__ if quant_method is not None else ''
             # Only the GRPO runtime-sync path needs special handling here.
             # SWIFT provides HF/Megatron tensors, while vLLM-Ascend stores MoE
             # experts as 3D per-local-expert tensors.  Initial checkpoint load
             # and other layouts continue to use the original vLLM loader.
-            is_runtime_sync_into_processed_param = (
-                param.data.dim() == 3 and loaded_weight.dim() in {2, 3}
-                and quant_method_module.startswith('vllm_ascend'))
+            is_runtime_sync_into_processed_param = param.data.dim() == 3 and loaded_weight.dim() in {2, 3}
             if not is_runtime_sync_into_processed_param:
                 return origin_weight_loader(param, loaded_weight, weight_name, shard_id, expert_id, return_success)
 
@@ -357,15 +351,15 @@ def patch_vllm_ascend_moe_expert_weight_loader(experts,
 
             loaded_expert_sample = loaded_weight[0] if loaded_weight.dim() == 3 else loaded_weight
 
-            def prepare_fsdp2_preprocessed_target_layout():
-                """FSDP2 path: write weights before vLLM-Ascend post-load processing."""
+            def prepare_preprocessed_target_layout():
+                """Write weights before vLLM-Ascend post-load processing."""
                 if is_w13_shard and param.data.shape[1] == loaded_expert_sample.shape[-1]:
                     param.data = param.data.transpose(1, 2).contiguous()
                 elif is_w2_shard and param.data.shape[2] == loaded_expert_sample.shape[0]:
                     param.data = param.data.transpose(1, 2).contiguous()
 
-            def prepare_megatron_processed_target_layout():
-                """Megatron path: write weights into vLLM-Ascend runtime layout."""
+            def prepare_processed_target_layout():
+                """Write weights into the vLLM-Ascend runtime layout."""
                 if (is_w13_shard and param.data.shape[-1] == loaded_expert_sample.shape[-1]
                         and param.data.shape[-2] != loaded_expert_sample.shape[-1]):
                     param.data = param.data.transpose(1, 2).contiguous()
@@ -375,8 +369,8 @@ def patch_vllm_ascend_moe_expert_weight_loader(experts,
 
             tp_rank = experts.tp_rank
 
-            def copy_fsdp2_preprocessed_expert(local_expert_id: int, loaded_expert_weight) -> bool:
-                """Copy FSDP2 fused expert weights into pre-process vLLM-Ascend layout."""
+            def copy_preprocessed_expert(local_expert_id: int, loaded_expert_weight) -> bool:
+                """Copy expert weights into the pre-process vLLM-Ascend layout."""
                 param_data = param.data[local_expert_id]
                 if is_w13_shard:
                     # Target: [2 * intermediate_per_tp, hidden].
@@ -395,8 +389,8 @@ def patch_vllm_ascend_moe_expert_weight_loader(experts,
 
                 return False
 
-            def copy_megatron_processed_expert(local_expert_id: int, loaded_expert_weight) -> bool:
-                """Copy Megatron/HF expert shards into processed vLLM-Ascend layout."""
+            def copy_processed_expert(local_expert_id: int, loaded_expert_weight) -> bool:
+                """Copy expert shards into the processed vLLM-Ascend layout."""
                 param_data = param.data[local_expert_id]
                 if is_w13_shard:
                     # Target: [hidden, 2 * intermediate_per_tp].
@@ -416,11 +410,11 @@ def patch_vllm_ascend_moe_expert_weight_loader(experts,
                 return False
 
             if load_preprocessed_weight:
-                prepare_fsdp2_preprocessed_target_layout()
-                copy_one_expert = copy_fsdp2_preprocessed_expert
+                prepare_preprocessed_target_layout()
+                copy_one_expert = copy_preprocessed_expert
             else:
-                prepare_megatron_processed_target_layout()
-                copy_one_expert = copy_megatron_processed_expert
+                prepare_processed_target_layout()
+                copy_one_expert = copy_processed_expert
 
             if loaded_weight.dim() == 3:
                 copied = False
@@ -429,6 +423,8 @@ def patch_vllm_ascend_moe_expert_weight_loader(experts,
                     if local_expert_id == -1:
                         continue
                     copied = copy_one_expert(local_expert_id, loaded_expert_weight) or copied
+                if copied and not load_preprocessed_weight:
+                    setattr(experts, _VLLM_ASCEND_MOE_PROCESSED_WEIGHT_LOADED_ATTR, True)
                 return copied if return_success else None
 
             local_expert_id = experts._map_global_expert_id_to_local_expert_id(expert_id)
@@ -436,6 +432,8 @@ def patch_vllm_ascend_moe_expert_weight_loader(experts,
                 return False if return_success else None
 
             if copy_one_expert(local_expert_id, loaded_weight):
+                if not load_preprocessed_weight:
+                    setattr(experts, _VLLM_ASCEND_MOE_PROCESSED_WEIGHT_LOADED_ATTR, True)
                 return True if return_success else None
 
             return origin_weight_loader(param, loaded_weight, weight_name, shard_id, expert_id, return_success)
@@ -455,12 +453,8 @@ def patch_vllm_ascend_moe_expert_weight_loader(experts,
 
 
 __all__ = [
-    'configure_vllm_ascend_moe_preprocessed_weight_sync',
-    'configure_vllm_ascend_moe_weight_sync',
     'expand_fused_moe_expert_names_for_vllm_ascend',
     'expand_fused_moe_expert_weight_for_vllm_ascend',
     'patch_vllm_ascend_moe_expert_weight_loader',
     'patch_vllm_ascend_moe_runtime',
-    'should_skip_vllm_ascend_moe_post_load',
-    'use_vllm_ascend_moe_preprocessed_weight',
 ]

--- a/swift/pipelines/infer/rollout.py
+++ b/swift/pipelines/infer/rollout.py
@@ -103,10 +103,7 @@ def _set_death_signal():
 
 
 def _patch_full_weight_reload_loader(model) -> None:
-    if is_vllm_ascend_available():
-        from swift.model.npu_patch.vllm_ascend_moe import configure_vllm_ascend_moe_preprocessed_weight_sync
-        configure_vllm_ascend_moe_preprocessed_weight_sync(model)
-    patch_vllm_moe_model_weight_loader(model)
+    patch_vllm_moe_model_weight_loader(model, load_preprocessed_weight=is_vllm_ascend_available())
 
 
 class WeightSyncWorkerExtension:

--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -1010,6 +1010,7 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
 
         state_dicts = iter_state_dicts()
         if ascend_reload_runner is not None:
+
             def iter_weights():
                 for state_dict in state_dicts:
                     yield from state_dict.items()

--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -973,38 +973,62 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
 
         gather_if_zero3 = get_gather_if_zero3_context(self)
 
-        # Colocate: patch MoE weight_loader once before loading all groups
+        ascend_reload_runner = None
+        if self.vllm_mode == 'colocate' and is_torch_npu_available():
+            from swift.model.npu_patch.vllm_ascend import get_vllm_ascend_reload_runner
+            ascend_reload_runner = get_vllm_ascend_reload_runner(self.engine)
         if self.vllm_mode == 'colocate':
-            from swift.model.npu_patch.vllm_ascend_moe import configure_vllm_ascend_moe_weight_sync
-            configure_vllm_ascend_moe_weight_sync(self.engine.inner_model, self.model, is_fsdp2=self._is_fsdp2)
-            patch_vllm_moe_model_weight_loader(self.engine.inner_model)
+            if ascend_reload_runner is None:
+                # Legacy vLLM-Ascend and GPU keep the existing in-place reload
+                # path. The Ascend fallback loader writes directly into the
+                # processed MoE layout and guards its redundant post-load.
+                patch_vllm_moe_model_weight_loader(self.engine.inner_model)
 
-        for i, parameter_group in enumerate(self.parameter_groups):
-            parameter_group_no_lora = self.parameter_groups_no_lora[i]
+        def iter_state_dicts():
+            for i, parameter_group in enumerate(self.parameter_groups):
+                parameter_group_no_lora = self.parameter_groups_no_lora[i]
 
-            if not self._is_fsdp2:
-                parameters = [
-                    parameter for name, parameter in self.model.named_parameters()
-                    if not parameter_group or name in parameter_group
-                ]
-            else:
-                parameters = []
+                if not self._is_fsdp2:
+                    parameters = [
+                        parameter for name, parameter in self.model.named_parameters()
+                        if not parameter_group or name in parameter_group
+                    ]
+                else:
+                    parameters = []
 
-            with gather_if_zero3(parameters):
-                if should_merge:
-                    with patch_lora_merge(self.model, parameter_group):
-                        self.model.merge_adapter()
-
-                try:
-                    state_dict = self._collect_state_dict_for_vllm(parameter_group, parameter_group_no_lora)
-                    self._load_state_dict_to_vllm(state_dict)
-                finally:
+                with gather_if_zero3(parameters):
                     if should_merge:
-                        with patch_lora_unmerge(self.model):
-                            self.model.unmerge_adapter()
+                        with patch_lora_merge(self.model, parameter_group):
+                            self.model.merge_adapter()
+
+                    try:
+                        yield self._collect_state_dict_for_vllm(parameter_group, parameter_group_no_lora)
+                    finally:
+                        if should_merge:
+                            with patch_lora_unmerge(self.model):
+                                self.model.unmerge_adapter()
+
+        state_dicts = iter_state_dicts()
+        if ascend_reload_runner is not None:
+            def iter_weights():
+                for state_dict in state_dicts:
+                    yield from state_dict.items()
+
+            weights = iter_weights()
+            try:
+                ascend_reload_runner.reload_weights(weights_iterator=weights, is_checkpoint_format=True)
+            finally:
+                weights.close()
+                state_dicts.close()
+        else:
+            try:
+                for state_dict in state_dicts:
+                    self._load_state_dict_to_vllm(state_dict)
+            finally:
+                state_dicts.close()
 
         # Re-run process_weights_after_loading once after ALL groups loaded
-        if self.vllm_mode == 'colocate':
+        if self.vllm_mode == 'colocate' and ascend_reload_runner is None:
             _model_config = self.engine.engine.model_config
             llm_model = self.engine.inner_model
             finish_vllm_weight_reload(llm_model, model_config=_model_config, target_device=self.accelerator.device)

--- a/swift/rlhf_trainers/utils.py
+++ b/swift/rlhf_trainers/utils.py
@@ -1012,7 +1012,7 @@ def _get_moe_model_registry():
     return _moe_model_registry_cache
 
 
-def patch_vllm_moe_model_weight_loader(model):
+def patch_vllm_moe_model_weight_loader(model, *, load_preprocessed_weight: bool = False):
     """
     Patch vLLM MoE model to add weight_loader attribute to expert weights.
 
@@ -1022,6 +1022,8 @@ def patch_vllm_moe_model_weight_loader(model):
 
     Args:
         model: The vLLM model to patch.
+        load_preprocessed_weight: Whether Ascend MoE expert loaders should write
+            checkpoint layout for a subsequent post-load processing pass.
     """
     # Check if already patched (idempotent). On NPU/vLLM-Ascend, sleep/wake
     # and full-model reload can recreate expert Parameters while keeping this
@@ -1062,16 +1064,14 @@ def patch_vllm_moe_model_weight_loader(model):
         return
 
     def maybe_patch_vllm_ascend_moe_expert_weight_loader(experts, name, param):
-        quant_method = getattr(experts, 'quant_method', None)
-        if not is_torch_npu_available() or not type(quant_method).__module__.startswith('vllm_ascend'):
+        if not is_torch_npu_available():
             return
-        from swift.model.npu_patch.vllm_ascend import (patch_vllm_ascend_moe_expert_weight_loader,
-                                                       use_vllm_ascend_moe_preprocessed_weight)
+        from swift.model.npu_patch.vllm_ascend import patch_vllm_ascend_moe_expert_weight_loader
         patch_vllm_ascend_moe_expert_weight_loader(
             experts,
             name,
             param,
-            load_preprocessed_weight=use_vllm_ascend_moe_preprocessed_weight(original_model),
+            load_preprocessed_weight=load_preprocessed_weight,
         )
 
     for layer in inner_model.layers:
@@ -1099,10 +1099,6 @@ def patch_vllm_moe_model_weight_loader(model):
 def finish_vllm_weight_reload(vllm_model, model_config, target_device):
     if vllm_model is None or model_config is None or target_device is None:
         return
-    if is_torch_npu_available():
-        from swift.model.npu_patch.vllm_ascend import should_skip_vllm_ascend_moe_post_load
-        if should_skip_vllm_ascend_moe_post_load(vllm_model):
-            return
     try:
         from vllm.model_executor.model_loader.utils import process_weights_after_loading
         process_weights_after_loading(vllm_model, model_config, target_device)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Summary

Fix MoE weight synchronization for NPU colocate training with vLLM-Ascend.

## Problem

During colocated Megatron/FSDP2 training, SWIFT synchronizes HF/Megatron MoE expert weights into vLLM-Ascend. vLLM-Ascend stores unquantized FusedMoE weights in a processed runtime layout and applies additional layout processing through `process_weights_after_loading`.

The previous synchronization path mixed SWIFT-side loading and vLLM-Ascend post-load processing. This could transpose the same expert weights twice and cause the first rollout to fail with MoE hidden/intermediate dimension mismatches.

The previous implementation also relied on Qwen-specific model checks and global model-level flags, which did not generalize cleanly to other MoE models or partially loaded layers.

## Changes

- Detect the actual vLLM-Ascend model runner and use its checkpoint-aware `reload_weights(..., is_checkpoint_format=True)` API when available.
- Preserve the existing GPU and legacy/unsupported Ascend fallback paths.
- Replace the Qwen model whitelist with implementation-based detection of vLLM-Ascend unquantized `FusedMoE` methods.
- Track whether each expert layer actually received processed-layout runtime weights.
- Skip redundant post-load processing only for layers that were populated by the colocated runtime-sync loader.
- Keep the server/full-reload path on the preprocessed checkpoint layout followed by one complete post-load pass.
- Support both regular 2D HF/Megatron expert shards and fused 3D FSDP2 expert tensors.

## Validation

- NPU smoke validation with Qwen3 reduced MoE, Megatron EP8, vLLM colocate TP8, vLLM 0.18.0 and vLLM-Ascend 0.18.0 completed two GRPO steps for AIME-2024 and DAPO-Math-17k, including checkpoint saves.

## Scope

This change fixes the vLLM-Ascend MoE weight-sync/layout lifecycle in colocate and full-reload paths. It does not change the GPU synchronization path and does not directly address unrelated vLLM logprobs/tokenizer failures that occur after weight synchronization.
