### PR TITLE
Fix export merge_lora with quantization not working

### DIFF
--- a/swift/pipelines/export/merge_lora.py
+++ b/swift/pipelines/export/merge_lora.py
@@ -35,28 +35,30 @@ def merge_lora(args: ExportArguments, device_map=None, replace_if_exists=False) 
         # If the model is quantized, perform the merge on the original (unquantized) model.
         # https://github.com/huggingface/peft/issues/2321
         origin_quant_method = args.quant_method
-        args.quant_method = None
         origin_device_map = args.device_map
+        args.quant_method = None
         args.device_map = device_map or args.device_map
-        logger.info(f'merge_device_map: {device_map}')
-        model, template = prepare_model_template(args)
-        logger.info('Merge LoRA...')
-        check_tie_word_embeddings(model)
-        Swift.merge_and_unload(model)
-        model = model.model
-        logger.info('Saving merged weights...')
+        try:
+            logger.info(f'merge_device_map: {device_map}')
+            model, template = prepare_model_template(args)
+            logger.info('Merge LoRA...')
+            check_tie_word_embeddings(model)
+            Swift.merge_and_unload(model)
+            model = model.model
+            logger.info('Saving merged weights...')
 
-        save_checkpoint(
-            model,
-            template.processor,
-            output_dir,
-            safe_serialization=args.safe_serialization,
-            model_dirs=args.adapters,
-            max_shard_size=args.max_shard_size,
-            additional_saved_files=model.model_meta.additional_saved_files)
-        logger.info(f'Successfully merged LoRA and saved in `{output_dir}`.')
-        args.device_map = origin_device_map
-        args.quant_method = origin_quant_method
+            save_checkpoint(
+                model,
+                template.processor,
+                output_dir,
+                safe_serialization=args.safe_serialization,
+                model_dirs=args.adapters,
+                max_shard_size=args.max_shard_size,
+                additional_saved_files=model.model_meta.additional_saved_files)
+            logger.info(f'Successfully merged LoRA and saved in `{output_dir}`.')
+        finally:
+            args.quant_method = origin_quant_method
+            args.device_map = origin_device_map
 
     args.model = output_dir
     args.model_dir = output_dir

--- a/swift/pipelines/export/merge_lora.py
+++ b/swift/pipelines/export/merge_lora.py
@@ -34,6 +34,7 @@ def merge_lora(args: ExportArguments, device_map=None, replace_if_exists=False) 
     else:
         # If the model is quantized, perform the merge on the original (unquantized) model.
         # https://github.com/huggingface/peft/issues/2321
+        origin_quant_method = args.quant_method
         args.quant_method = None
         origin_device_map = args.device_map
         args.device_map = device_map or args.device_map
@@ -55,6 +56,7 @@ def merge_lora(args: ExportArguments, device_map=None, replace_if_exists=False) 
             additional_saved_files=model.model_meta.additional_saved_files)
         logger.info(f'Successfully merged LoRA and saved in `{output_dir}`.')
         args.device_map = origin_device_map
+        args.quant_method = origin_quant_method
 
     args.model = output_dir
     args.model_dir = output_dir


### PR DESCRIPTION
### PR type
- [X] Bug Fix

### PR information
This PR fixes the bug in the swift export command when using `--merge_lora true --quant_method awq --quant_bits 4`. The LoRA adapter was merged, but quantization was not applied – the merged model remained full‑precision.
### An easy way to reproduce
Prepare a model such as Qwen2.5-0.5B `(size = 954M)`:
``` md
[huangyt@localhost qwen2.5-0.5B]$ pwd
/home/huangyt/qwen2.5-0.5B
[huangyt@localhost qwen2.5-0.5B]$ ls -alh
总用量 954M
drwxr-xr-x.  2 huangyt    huangyt    4.0K  7月 31 17:59 .
drwxr-xr-x. 35 huangyt    huangyt    4.0K  7月 31 19:02 ..
-rw-r--r--.  1 huangyt    huangyt     659  7月 31 17:25 config.json
-rw-r--r--.  1 huangyt    huangyt       2  7月 31 17:25 configuration.json
-rw-r--r--.  1 huangyt    huangyt     242  7月 31 17:25 generation_config.json
-rw-r--r--.  1 huangyt    huangyt    1.5K  7月 31 17:25 gitattributes
-rw-r--r--.  1 huangyt    huangyt     12K  7月 31 17:25 LICENSE
-rw-r--r--.  1 huangyt    huangyt    1.6M  7月 31 17:25 merges.txt
-rw-r--r--.  1 huangyt    huangyt    943M  7月 31 17:25 model.safetensors
-rw-r--r--.  1 huangyt    huangyt    4.9K  7月 31 17:25 README.md
-rw-r--r--.  1 huangyt    huangyt    7.2K  7月 31 17:59 tokenizer_config.json
-rw-r--r--.  1 huangyt    huangyt    6.8M  7月 31 17:25 tokenizer.json
-rw-r--r--.  1 huangyt    huangyt    2.7M  7月 31 17:25 vocab.json
``` 

#### Without patch
``` md

swift export --model /home/huangyt/qwen2.5-0.5B --adapter /home/huangyt/train/output/v7-20260731-172841/checkpoint-3 --merge_lora true --quant_method awq --quant_bits 4 --dataset /home/huangyt/train/data --output_dir /home/huangyt/train/output/merge_lora/

[INFO:swift] Merge LoRA...
[INFO:swift] Saving merged weights...
Writing model shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.60it/s]
[INFO:swift] Successfully merged LoRA and saved in `/home/huangyt/train/output/v7-20260731-172841/checkpoint-3-merged`.
[INFO:swift] End time of running main: 2026-07-31 18:58:37.897565

[huangyt@localhost ~]$ cd /home/huangyt/train/output/v7-20260731-172841/checkpoint-3-merged
[huangyt@localhost checkpoint-3-merged]$ ls -alh
总用量 954M
drwxr-xr-x. 2 huangyt huangyt 4.0K  7月 31 18:58 .
drwxr-xr-x. 6 huangyt huangyt 4.0K  7月 31 18:58 ..
-rw-r--r--. 1 huangyt huangyt  39K  7月 31 18:58 args.json
-rw-r--r--. 1 huangyt huangyt 2.5K  7月 31 18:58 chat_template.jinja
-rw-r--r--. 1 huangyt huangyt 1.3K  7月 31 18:58 config.json
-rw-r--r--. 1 huangyt huangyt  242  7月 31 18:58 generation_config.json
-rw-------. 1 huangyt huangyt 943M  7月 31 18:58 model.safetensors
-rw-r--r--. 1 huangyt huangyt  377  7月 31 18:58 tokenizer_config.json
-rw-r--r--. 1 huangyt huangyt  11M  7月 31 18:58 tokenizer.json

``` 
It is still 954 MB, not quantized, and not placed under the given --output_dir.

#### With patch
``` md

swift export --model /home/huangyt/qwen2.5-0.5B --adapter /home/huangyt/train/output/v7-20260731-172841/checkpoint-3 --merge_lora true --quant_method awq --quant_bits 4 --dataset /home/huangyt/train/data --output_dir /home/huangyt/train/output/merge_lora/

AWQ: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 24/24 [03:14<00:00,  8.10s/it]
Writing model shards: 0it [00:00, ?it/s]
[INFO:swift] model: Qwen2AWQForCausalLM(
  (model): Qwen2ForCausalLM(
    (model): Qwen2Model(
      (embed_tokens): Embedding(151936, 896, padding_idx=151643)
      (layers): ModuleList(
        (0-23): 24 x Qwen2DecoderLayer(
          (self_attn): Qwen2Attention(
            (q_proj): WQLinear_GEMM(in_features=896, out_features=896, bias=True, w_bit=4, group_size=128)
            (k_proj): WQLinear_GEMM(in_features=896, out_features=128, bias=True, w_bit=4, group_size=128)
            (v_proj): WQLinear_GEMM(in_features=896, out_features=128, bias=True, w_bit=4, group_size=128)
            (o_proj): WQLinear_GEMM(in_features=896, out_features=896, bias=False, w_bit=4, group_size=128)
          )
          (mlp): Qwen2MLP(
            (gate_proj): WQLinear_GEMM(in_features=896, out_features=4864, bias=False, w_bit=4, group_size=128)
            (up_proj): WQLinear_GEMM(in_features=896, out_features=4864, bias=False, w_bit=4, group_size=128)
            (down_proj): WQLinear_GEMM(in_features=4864, out_features=896, bias=False, w_bit=4, group_size=128)
            (act_fn): SiLUActivation()
          )
          (input_layernorm): Qwen2RMSNorm((896,), eps=1e-06)
          (post_attention_layernorm): Qwen2RMSNorm((896,), eps=1e-06)
        )
      )
      (norm): Qwen2RMSNorm((896,), eps=1e-06)
      (rotary_emb): Qwen2RotaryEmbedding()
    )
    (lm_head): Linear(in_features=896, out_features=151936, bias=False)
  )
)
[INFO:swift] model_parameter_info: Qwen2AWQForCausalLM: 136.1786M Params (136.1786M Trainable [100.0000%]), 47.9010M Buffers.
[INFO:swift] Successfully quantized the model and saved in `/home/huangyt/train/output/merge_lora`.
[INFO:swift] End time of running main: 2026-07-31 19:06:17.057557


[huangyt@localhost ~]$ cd /home/huangyt/train/output/merge_lora
[huangyt@localhost merge_lora]$ ls -lah
总用量 449M
drwxr-xr-x.  2 huangyt huangyt 4.0K  7月 31 19:06 .
drwxr-xr-x. 11 huangyt huangyt 4.0K  7月 31 19:03 ..
-rw-r--r--.  1 huangyt huangyt  29K  7月 31 19:03 args.json
-rw-r--r--.  1 huangyt huangyt 2.5K  7月 31 19:06 chat_template.jinja
-rw-r--r--.  1 huangyt huangyt 1.5K  7月 31 19:06 config.json
-rw-r--r--.  1 huangyt huangyt  242  7月 31 19:06 generation_config.json
-rw-------.  1 huangyt huangyt 438M  7月 31 19:06 model.safetensors
-rw-r--r--.  1 huangyt huangyt  377  7月 31 19:06 tokenizer_config.json
-rw-r--r--.  1 huangyt huangyt  11M  7月 31 19:06 tokenizer.json
``` 
The log shows that AWQ was run and the model was quantized down to 449 MB.


Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>
