### PR TITLE
fix: preserve explicit PEFT LoRA dtype

### DIFF
--- a/swift/tuners/peft.py
+++ b/swift/tuners/peft.py
@@ -144,6 +144,22 @@ def _convert_dtype(target: torch.nn.Module, adapter_name: str, lora_dtype: str):
             target.lora_embedding_B[adapter_name].to(torch_dtype)
 
 
+def _cast_adapter_dtype_hook(self, adapter_name: str, autocast_adapter_dtype: bool = True):
+    """Keep an explicitly configured Swift LoRA dtype from being upcast by PEFT.
+
+    PEFT calls ``_cast_adapter_dtype`` after the LoRA modules have been
+    created.  Its default behavior upcasts fp16/bf16 adapters to fp32, which
+    silently overrides Swift's ``lora_dtype`` setting.  Only disable that
+    automatic cast when the Swift extension is explicitly configured; the
+    default PEFT behavior remains unchanged for all other adapters.
+    """
+    peft_config = getattr(self, 'peft_config', {})
+    config = peft_config.get(adapter_name) if isinstance(peft_config, dict) else None
+    if getattr(config, 'lora_dtype', None) is not None:
+        autocast_adapter_dtype = False
+    return self._cast_adapter_dtype_origin(adapter_name, autocast_adapter_dtype)
+
+
 def create_optimizer_param_groups(self: PeftModel, **defaults):
     if not isinstance(self.peft_config[self.active_adapter],
                       LoraConfig) or self.peft_config[self.active_adapter].lorap_lr_ratio is None:
@@ -361,6 +377,9 @@ def hot_patch_peft_module():
 
     LoraModel.__init_origin__ = LoraModel.__init__
     LoraModel.__init__ = __new_init__
+    if not hasattr(LoraModel, '_cast_adapter_dtype_origin'):
+        LoraModel._cast_adapter_dtype_origin = LoraModel._cast_adapter_dtype
+        LoraModel._cast_adapter_dtype = _cast_adapter_dtype_hook
 
     # Support LoRA+
     PeftModel.create_optimizer_param_groups = create_optimizer_param_groups

--- a/tests/tuners/test_peft.py
+++ b/tests/tuners/test_peft.py
@@ -133,18 +133,19 @@ class TestPeft(unittest.TestCase):
             self.assertTrue(key in state_dict2)
             self.assertTrue(all(torch.isclose(state_dict[key], state_dict2[key]).flatten().detach().cpu()))
 
-    @unittest.skip
     def test_peft_lora_dtype(self):
         model = SbertForSequenceClassification(SbertConfig())
         model2 = copy.deepcopy(model)
         model3 = copy.deepcopy(model)
         lora_config = LoraConfig(target_modules=['query', 'key', 'value'], lora_dtype='float16')
         model = Swift.prepare_model(model, lora_config)
+        self.assertTrue(model.base_model.bert.encoder.layer[0].attention.self.key.lora_A.default.weight.dtype ==
+                        torch.float16)
         model.save_pretrained(self.tmp_dir, safe_serialization=False)
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'additional_config.json')))
         model2 = Swift.from_pretrained(model2, self.tmp_dir)
         self.assertTrue(model2.base_model.model.bert.encoder.layer[0].attention.self.key.lora_A.default.weight.dtype ==
-                        torch.float32)
+                        torch.float16)
         self.assertTrue(model2.peft_config['default'].lora_dtype == 'float16')
         state_dict = model.state_dict()
         state_dict2 = model2.state_dict()


### PR DESCRIPTION
## What does this PR do?

Fixes #9694. When the PEFT backend receives Swift's explicit `lora_dtype` (`float16`/`bfloat16`), PEFT's post-initialization `_cast_adapter_dtype` currently upcasts those adapter weights back to fp32. This makes the documented Swift option ineffective and produces unnecessarily large checkpoints.

This patch hooks that cast only when the Swift `LoraConfig` explicitly has `lora_dtype`, preserving PEFT's default behavior for all other adapters. The existing skipped `test_peft_lora_dtype` regression test is enabled and now checks both initial injection and reload preserve fp16.

## Validation

- `python3 -m py_compile swift/tuners/peft.py tests/tuners/test_peft.py`
- `git diff --check` on both changed files
- Full PEFT test requires the repository CI dependencies (`torch`, `peft`, ModelScope); they are not installed in this environment.