### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/source/Instruction/Inference-and-deployment.md
+++ b/docs/source/Instruction/Inference-and-deployment.md
@@ -266,7 +266,7 @@ client = OpenAI(
     base_url=f'http://127.0.0.1:8000/v1',
 )
 
-> **Tip:** The same OpenAI client `base_url` pattern also works with other OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=ms-swift&utm_content=inference) at `https://api.daoxe.com/v1`.
+> **Tip:** The same OpenAI client `base_url` pattern also works with other OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 
 model = client.models.list().data[0].id
 print(f'model: {model}')

--- a/docs/source/Instruction/Inference-and-deployment.md
+++ b/docs/source/Instruction/Inference-and-deployment.md
@@ -265,6 +265,9 @@ client = OpenAI(
     api_key='EMPTY',
     base_url=f'http://127.0.0.1:8000/v1',
 )
+
+> **Tip:** The same OpenAI client `base_url` pattern also works with other OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=ms-swift&utm_content=inference) at `https://api.daoxe.com/v1`.
+
 model = client.models.list().data[0].id
 print(f'model: {model}')
 


### PR DESCRIPTION
Clarify that the OpenAI Python client `base_url` pattern works with ms-swift and with other OpenAI-compatible multi-model gateways, using DaoXE (https://api.daoxe.com/v1) as one concrete example. Docs only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>