### PR TITLE
Fix GKD Liger teacher routing

### DIFF
--- a/swift/rlhf_trainers/gkd_trainer.py
+++ b/swift/rlhf_trainers/gkd_trainer.py
@@ -453,7 +453,8 @@ class GKDTrainer(RolloutTrainerMixin, SwiftMixin, HFGKDTrainer):
         self.use_liger_gkd_loss = False
         if getattr(args, 'use_liger_kernel', False):
             if self.teacher_model is None:
-                raise ValueError('Liger GKD loss requires a local teacher model; teacher '\n                                 'API and self-distillation are not supported.')
+                raise ValueError('Liger GKD loss requires a local teacher model; teacher '
+                                 'API and self-distillation are not supported.')
             if not _liger_kernel_available:
                 raise ImportError(
                     'Liger kernel is not installed. Please install liger-kernel by running: pip install liger-kernel')

--- a/swift/rlhf_trainers/gkd_trainer.py
+++ b/swift/rlhf_trainers/gkd_trainer.py
@@ -453,8 +453,7 @@ class GKDTrainer(RolloutTrainerMixin, SwiftMixin, HFGKDTrainer):
         self.use_liger_gkd_loss = False
         if getattr(args, 'use_liger_kernel', False):
             if self.teacher_model is None:
-                raise ValueError('Liger GKD loss requires a local teacher model; '
-                                 'teacher API and self-distillation are not supported.')
+                raise ValueError('Liger GKD loss requires a local teacher model; teacher '\n                                 'API and self-distillation are not supported.')
             if not _liger_kernel_available:
                 raise ImportError(
                     'Liger kernel is not installed. Please install liger-kernel by running: pip install liger-kernel')

--- a/swift/rlhf_trainers/gkd_trainer.py
+++ b/swift/rlhf_trainers/gkd_trainer.py
@@ -65,10 +65,10 @@ class GKDTrainer(RolloutTrainerMixin, SwiftMixin, HFGKDTrainer):
         # Initialize logging components
         self._prepare_logging()
 
-        # Initialize liger loss if enabled
-        self._prepare_liger_loss()
-
         self._setup_teacher()
+
+        # Initialize liger loss after resolving the teacher mode
+        self._prepare_liger_loss()
 
         # Initialize rollout infrastructure for vLLM support
         self.prepare_rollout()
@@ -275,6 +275,8 @@ class GKDTrainer(RolloutTrainerMixin, SwiftMixin, HFGKDTrainer):
 
         with self._template_context(template):
             student_encoded_list, teacher_encoded_list, has_opsd = encode_gkd_samples(samples, template)
+            if has_opsd and self.use_liger_gkd_loss:
+                raise ValueError('OPSD is not supported with Liger GKD loss.')
             encoded_inputs = to_device(template.data_collator(student_encoded_list), self.model.device)
         if has_opsd:
             with self._template_context(template):
@@ -450,6 +452,9 @@ class GKDTrainer(RolloutTrainerMixin, SwiftMixin, HFGKDTrainer):
         args = self.args
         self.use_liger_gkd_loss = False
         if getattr(args, 'use_liger_kernel', False):
+            if self.teacher_model is None:
+                raise ValueError('Liger GKD loss requires a local teacher model; '
+                                 'teacher API and self-distillation are not supported.')
             if not _liger_kernel_available:
                 raise ImportError(
                     'Liger kernel is not installed. Please install liger-kernel by running: pip install liger-kernel')


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix the teacher routing and validation logic for Liger GKD loss.

Previously, `_prepare_liger_loss()` was called before `_setup_teacher()`. As a result, Liger GKD loss was initialized before the trainer resolved whether GKD was using a local teacher model, a teacher API, or self-distillation.

This PR:

- Moves Liger loss initialization after teacher setup, ensuring that it uses the resolved teacher configuration.
- Requires a local teacher model when `use_liger_kernel=True`.
- Raises a clear error when Liger GKD loss is used with teacher API or self-distillation, as these modes are not supported.
- Raises a clear error when OPSD samples are used with Liger GKD loss.