### PR TITLE
fix(npu): handle BF16 MindSpeed grouped linear activation offload

### DIFF
--- a/swift/model/npu_patch/mindspeed.py
+++ b/swift/model/npu_patch/mindspeed.py
@@ -303,6 +303,28 @@ def patch_mindspeed_te_layernorm_linear_frozen_weight() -> None:
     logger.info('Patched MindSpeed TE LayerNormLinear to use Megatron frozen-weight backward for frozen weights.')
 
 
+def patch_mindspeed_te_grouped_linear_save_original_input() -> None:
+    """Allow BF16 MindSpeed grouped linear layers to use Megatron activation offloading."""
+    te_extension = importlib.import_module('megatron.core.extensions.transformer_engine')
+    set_save_original_input = te_extension.set_save_original_input
+    if getattr(set_save_original_input, '_swift_supports_mindspeed_bf16_grouped_linear', False):
+        return
+
+    @wraps(set_save_original_input)
+    def set_save_original_input_dispatch(module):
+        config = getattr(module, 'config', None)
+        is_mindspeed_grouped_linear = type(module).__module__ == 'mindspeed.te.pytorch.module.grouped_linear'
+        uses_quantized_tensors = bool(getattr(config, 'fp8', None) or getattr(config, 'fp4', None))
+        if is_mindspeed_grouped_linear and not uses_quantized_tensors:
+            # MindSpeed's BF16 TEGroupedLinearGMM saves the original input tensor directly.
+            return
+        return set_save_original_input(module)
+
+    set_save_original_input_dispatch._swift_supports_mindspeed_bf16_grouped_linear = True
+    te_extension.set_save_original_input = set_save_original_input_dispatch
+    logger.info('Patched Megatron set_save_original_input for MindSpeed BF16 grouped linear layers.')
+
+
 def patch_mindspeed_gdn_cp_helpers(megatron_args: dict[str, Any]) -> None:
     """Expose MindSpeed's backported GDN CP helpers to Megatron Core versions before 0.18."""
     if int(megatron_args.get('context_parallel_size', 1)) <= 1:
@@ -332,4 +354,5 @@ def apply_mindspeed_patches(megatron_args: dict[str, Any]) -> None:
     repatch(megatron_args)
     patch_mindspeed_gdn_cp_helpers(megatron_args)
     patch_mindspeed_te_layernorm_linear_frozen_weight()
+    patch_mindspeed_te_grouped_linear_save_original_input()
     patch_mindspeed_fla_gdn_implementation()


### PR DESCRIPTION
## PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

## PR information

### Background

When enabling fine-grained activation offloading for Qwen3/Qwen3-MoE training with Megatron + MindSpeed using the following configuration:

```json
{
  "fine_grained_activation_offloading": true,
  "offload_modules": ["expert_fc1"]
}
```

Megatron calls `set_save_original_input(self.linear_fc1)` during model initialization. However, BF16 MindSpeed grouped linear does not support this API, causing training to fail before it starts:

```text
ValueError: set_save_original_input is only needed on transformer-engine modules that save quantized tensors by default. It needs transformer-engine>=2.6.0dev0.
```

### Root Cause

MindSpeed's BF16 `TEGroupedLinearGMM` already saves the input tensor via `ctx.save_for_backward` in its custom autograd function for backward propagation.

Megatron's `set_save_original_input` is primarily intended for quantized Transformer Engine modules that need to preserve the original input. For BF16 MindSpeed grouped linear modules, calling this API is unnecessary and raises an exception because the module does not have a `save_original_input` attribute.

### Changes

- Wrap Megatron's `set_save_original_input` in `swift/model/npu_patch/mindspeed.py`.
- Skip the call for non-quantized MindSpeed grouped linear modules.
- Preserve the existing behavior for all other modules, including FP8 and FP4 modules.
- Add an idempotency guard to prevent the patch from being applied multiple times.
- Install the compatibility patch after MindSpeed `repatch`.

### Experiment Results

- Verified with end-to-end training using Qwen3-MoE, BF16, and 2-GPU GRPO.
- Training completed 2/2 steps successfully with `offload_modules=["expert_fc1"]` enabled.
- The validation configuration included vLLM colocation, LoRA, and `fine_grained_activation_offloading`.
- `py_compile` passed, and unit tests for the patch logic passed.

### Scope

This PR only fixes activation-offload compatibility for Megatron/MindSpeed grouped linear modules. It does not modify the Transformers/FSDP2 path or change FP8/FP4 behavior.

The reproduction script and temporary test files are not included in this PR.