### PR TITLE
fix(infer): align adapter names with batch size

### DIFF
--- a/swift/infer_engine/transformers_engine.py
+++ b/swift/infer_engine/transformers_engine.py
@@ -248,7 +248,8 @@ class TransformersEngine(InferEngine):
             'streamer': streamer,
             **inputs,
         }
-        adapter_names = self._get_adapter_names(adapter_request)
+        batch_size = inputs['attention_mask'].shape[0]
+        adapter_names = self._get_adapter_names(adapter_request, batch_size)
         if adapter_names is not None:
             generate_kwargs['adapter_names'] = adapter_names
         num_prompt_tokens = self._get_num_tokens(inputs)
@@ -265,7 +266,6 @@ class TransformersEngine(InferEngine):
         generate_kwargs = self.template.prepare_generate_kwargs(generate_kwargs, model=self.model)
         thread = Thread(target=_model_generate, kwargs=generate_kwargs)
         thread.start()
-        batch_size = inputs['attention_mask'].shape[0]
         all_is_finished = False
         is_finished = [False] * batch_size
         infer_streamers = [InferStreamer(self.template, template_inputs=template_inputs[i]) for i in range(batch_size)]
@@ -336,22 +336,22 @@ class TransformersEngine(InferEngine):
             if any(res):
                 yield res
 
-    def _get_adapter_names(self, adapter_request: Optional[AdapterRequest]) -> Optional[List[str]]:
+    def _get_adapter_names(self, adapter_request: Optional[AdapterRequest], batch_size: int) -> Optional[List[str]]:
         if adapter_request is None:
             if self._adapters_pool:
-                return ['__base__']
+                return ['__base__'] * batch_size
             return
         adapter_name = adapter_request.name
         if adapter_name not in self._adapters_pool:
             self._adapters_pool[adapter_name] = adapter_request
             self._add_adapter(adapter_request.path, adapter_name)
-        return [adapter_name]
+        return [adapter_name] * batch_size
 
     def _infer_forward(self, inputs: Dict[str, Any], adapter_request: Optional[AdapterRequest],
                        request_config: RequestConfig, **kwargs):
         call_kwargs = {}
         top_logprobs = request_config.top_logprobs or 20
-        adapter_names = self._get_adapter_names(adapter_request)
+        adapter_names = self._get_adapter_names(adapter_request, inputs['attention_mask'].shape[0])
         if adapter_names is not None:
             call_kwargs['adapter_names'] = adapter_names
         num_prompt_tokens = self._get_num_tokens(inputs)
@@ -410,7 +410,7 @@ class TransformersEngine(InferEngine):
                     template_inputs) -> List[ChatCompletionResponse]:
         # bos_token TODO: encoder-decoder
         generate_kwargs = {'generation_config': generation_config, **inputs}
-        adapter_names = self._get_adapter_names(adapter_request)
+        adapter_names = self._get_adapter_names(adapter_request, inputs['attention_mask'].shape[0])
         if adapter_names is not None:
             generate_kwargs['adapter_names'] = adapter_names
         num_prompt_tokens = self._get_num_tokens(inputs)

--- a/tests/infer/test_transformers_engine_adapters.py
+++ b/tests/infer/test_transformers_engine_adapters.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import Mock
+
+from swift.infer_engine.transformers_engine import TransformersEngine
+from swift.infer_engine.utils import AdapterRequest
+
+
+class TestTransformersEngineAdapters(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = object.__new__(TransformersEngine)
+        self.engine._adapters_pool = {}
+        self.engine._add_adapter = Mock()
+
+    def test_adapter_name_matches_batch_size(self):
+        adapter_request = AdapterRequest('lora1', '/tmp/lora1')
+
+        adapter_names = self.engine._get_adapter_names(adapter_request, batch_size=3)
+
+        self.assertEqual(adapter_names, ['lora1', 'lora1', 'lora1'])
+        self.engine._add_adapter.assert_called_once_with('/tmp/lora1', 'lora1')
+
+    def test_base_adapter_name_matches_batch_size(self):
+        self.engine._adapters_pool['lora1'] = AdapterRequest('lora1', '/tmp/lora1')
+
+        adapter_names = self.engine._get_adapter_names(None, batch_size=2)
+
+        self.assertEqual(adapter_names, ['__base__', '__base__'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixes #5285.

## Background

`TransformersEngine` accepted one `AdapterRequest` for a batch, but
`_get_adapter_names()` always returned a one-element list. PEFT requires
one adapter name per input, so batches larger than one failed with:

```text
ValueError: Length of `adapter_names` should be the same as the number
of inputs, but got 1 and 10 respectively.
```

The same mismatch affected base-model inference after an adapter had
already been loaded because the `__base__` marker was also returned only
once.

## Changes

- Pass the encoded batch size from streaming, forward, and generation
  inference paths to `_get_adapter_names()`.
- Repeat the selected adapter name for every sample in the batch.
- Repeat the `__base__` marker when running the base model after loading
  an adapter.
- Add CPU regression tests for both adapter and base-model batches.

## Verification

- `PYTHONPATH=. .venv/bin/python -m unittest tests.infer.test_transformers_engine_adapters`
- `PYTHONPATH=. .venv/bin/python tests/run.py --pattern test_transformers_engine_adapters.py`
- `.venv/bin/pre-commit run --all-files`
- `git diff --check`

## Impact

The change is limited to per-batch adapter-name construction in
`TransformersEngine`. Single-sample inference is unchanged, and the
existing API still applies one `AdapterRequest` to the whole batch.

## Experiment results

Before the fix, both regression cases failed because
`_get_adapter_names()` could not produce batch-aligned names. After the
fix, the selected adapter and `__base__` paths return lists whose lengths
match the batch size; both tests pass.
