### PR TITLE
fix(infer): skip invalid dataset samples

### DIFF
--- a/swift/pipelines/infer/infer.py
+++ b/swift/pipelines/infer/infer.py
@@ -37,6 +37,7 @@ class SwiftInfer(SwiftPipeline):
         else:
             self.template = args.get_template()
             self.infer_engine = self.get_infer_engine(args, self.template)
+        self.infer_engine.strict = args.strict
         self.random_state = np.random.RandomState(args.data_seed)
 
     def __getattr__(self, key: str):
@@ -301,6 +302,9 @@ class SwiftInfer(SwiftPipeline):
         if not (args.infer_backend == 'vllm' and rank >= 0
                 and args.rank % args.vllm_tensor_parallel_size != 0):  # DP & TP
             for data, resp, labels in zip(val_dataset, resp_list, labels_list):
+                if isinstance(resp, Exception):
+                    logger.warning(f'Skipping an inference sample due to error: {resp}')
+                    continue
                 response = resp.choices[0].message.content
                 data['messages'].append({'role': 'assistant', 'content': response})
                 data = {'response': response, 'labels': labels, 'logprobs': resp.choices[0].logprobs, **data}

--- a/tests/infer/test_infer_pipeline.py
+++ b/tests/infer/test_infer_pipeline.py
@@ -1,0 +1,82 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from swift.pipelines.base import SwiftPipeline
+from swift.pipelines.infer.infer import SwiftInfer
+
+
+class TestInferPipeline(unittest.TestCase):
+
+    def test_infer_engine_uses_data_strict_setting(self):
+        args = SimpleNamespace(
+            merge_lora=False,
+            infer_backend='transformers',
+            adapters=[],
+            max_batch_size=1,
+            data_seed=42,
+            strict=False,
+        )
+        engine = SimpleNamespace(model='model')
+
+        def init_pipeline(pipeline, pipeline_args):
+            pipeline.args = pipeline_args
+
+        with patch.object(SwiftPipeline, '__init__', init_pipeline), \
+                patch('swift.pipelines.infer.infer.prepare_model_template', return_value=('model', 'template')), \
+                patch('swift.pipelines.infer.infer.TransformersEngine', return_value=engine):
+            pipeline = SwiftInfer(args)
+
+        self.assertFalse(pipeline.infer_engine.strict)
+
+    def test_batch_infer_skips_failed_samples(self):
+        pipeline = object.__new__(SwiftInfer)
+        pipeline.args = SimpleNamespace(
+            task_type='causal_lm',
+            infer_backend='transformers',
+            rank=-1,
+            global_world_size=1,
+            vllm_tensor_parallel_size=1,
+        )
+        pipeline.infer_kwargs = {}
+
+        def response(content):
+            message = SimpleNamespace(content=content)
+            choice = SimpleNamespace(message=message, logprobs=None)
+            return SimpleNamespace(choices=[choice])
+
+        pipeline.infer = Mock(return_value=[response('first'), ValueError('invalid media'), response('third')])
+        dataset = [{
+            'messages': [{
+                'role': 'user',
+                'content': 'one'
+            }, {
+                'role': 'assistant',
+                'content': 'label one'
+            }]
+        }, {
+            'messages': [{
+                'role': 'user',
+                'content': 'two'
+            }, {
+                'role': 'assistant',
+                'content': 'label two'
+            }]
+        }, {
+            'messages': [{
+                'role': 'user',
+                'content': 'three'
+            }, {
+                'role': 'assistant',
+                'content': 'label three'
+            }]
+        }]
+
+        result = pipeline._batch_infer(dataset, request_config=object())
+
+        self.assertEqual([item['response'] for item in result], ['first', 'third'])
+        self.assertEqual([item['labels'] for item in result], ['label one', 'label three'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixes #7045.

## Background

`InferArguments.strict` defaults to `False`, but `SwiftInfer` did not
propagate that setting to its inference engine. Template encoding
therefore still raised on the first invalid image, audio, or other
sample instead of allowing the remaining dataset to continue.

There was a second failure path when strict mode was disabled manually:
the engine returned the per-sample exception in its aligned response
list, and `_batch_infer()` attempted to access `resp.choices`, raising
`AttributeError`.

## Changes

- Propagate `args.strict` to the inference engine created by
  `SwiftInfer`.
- Skip exception responses while assembling dataset inference results,
  with a warning that preserves the original error message.
- Add CPU regression tests for strict-setting propagation and mixed
  valid/invalid batch results.

## Verification

- `PYTHONPATH=. .venv/bin/python -m unittest tests.infer.test_infer_pipeline`
- `PYTHONPATH=. .venv/bin/python tests/run.py --pattern test_infer_pipeline.py`
- `PYTHONPATH=. .venv/bin/python -m unittest tests.infer.test_infer_pipeline tests.general.test_data_preprocess.TestProviderMessagesPreprocess tests.general.test_data_preprocess.TestRejectedMessagesPreprocess`
- `.venv/bin/pre-commit run --all-files`
- `git diff --check`

## Impact

The change affects dataset inference when `strict=False`. Valid samples
retain their existing outputs and labels; invalid samples are logged and
omitted from the result list. Strict inference and deployment behavior
remain unchanged.

## Experiment results

Before the fix, the regression tests failed because the engine had no
propagated `strict` value and because an exception response was treated
as a normal completion. After the fix, both cases pass and valid samples
before and after the failed entry are preserved.
