### PR TITLE
fix(infer): propagate streaming errors

### DIFF
--- a/swift/infer_engine/infer_engine.py
+++ b/swift/infer_engine/infer_engine.py
@@ -84,8 +84,6 @@ class InferEngine(BaseInferEngine, ProcessorMixin):
                 async for item in await async_iter:
                     queue.put(item)
             except Exception as e:
-                if getattr(self, 'strict', True):
-                    raise
                 queue.put(e)
             else:
                 queue.put(None)
@@ -103,6 +101,8 @@ class InferEngine(BaseInferEngine, ProcessorMixin):
             if output is None or isinstance(output, Exception):
                 prog_bar.update()
                 self._update_metrics(pre_output, metrics)
+                if isinstance(output, Exception) and getattr(self, 'strict', True):
+                    raise output
                 return
             pre_output = output
             yield output

--- a/tests/infer/test_infer_engine.py
+++ b/tests/infer/test_infer_engine.py
@@ -1,0 +1,57 @@
+import queue
+import unittest
+from unittest.mock import Mock, patch
+
+from swift.infer_engine.infer_engine import InferEngine
+
+
+class _TestEngine(InferEngine):
+
+    async def infer_async(self, infer_request, request_config, **kwargs):
+        raise NotImplementedError
+
+
+class _TimeoutQueue(queue.Queue):
+
+    def get(self, block=True, timeout=None):
+        return super().get(block=block, timeout=0.5)
+
+
+async def _failing_stream():
+
+    async def _generator():
+        raise RuntimeError('stream failed')
+        yield
+
+    return _generator()
+
+
+class TestInferEngine(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = object.__new__(_TestEngine)
+        self.progress = Mock()
+
+    @patch('swift.infer_engine.infer_engine.Queue', _TimeoutQueue)
+    def test_stream_error_is_raised_in_strict_mode(self):
+        self.engine.strict = True
+        iterator = self.engine.async_iter_to_iter(_failing_stream(), self.progress, metrics=None)
+
+        with self.assertRaisesRegex(RuntimeError, 'stream failed'):
+            next(iterator)
+
+        self.progress.update.assert_called_once_with()
+
+    @patch('swift.infer_engine.infer_engine.Queue', _TimeoutQueue)
+    def test_stream_error_ends_iteration_in_non_strict_mode(self):
+        self.engine.strict = False
+        iterator = self.engine.async_iter_to_iter(_failing_stream(), self.progress, metrics=None)
+
+        with self.assertRaises(StopIteration):
+            next(iterator)
+
+        self.progress.update.assert_called_once_with()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Background

`InferEngine.async_iter_to_iter()` consumes an asynchronous stream in a
background thread and forwards items through a synchronous queue.

When the asynchronous stream failed in strict mode, the producer thread
re-raised the exception before placing any terminal value in the queue.
The consumer remained blocked on `queue.get()` and could not receive the
original error. In non-strict mode the exception was queued, but the
consumer treated it as a normal end-of-stream marker.

## Changes

- Always place asynchronous stream exceptions in the consumer queue.
- Re-raise the queued exception from the caller thread when
  `strict=True`.
- Preserve the existing non-strict behavior, where the failed stream
  ends without raising.
- Add CPU regression tests for both strict and non-strict modes using a
  timeout queue so the pre-fix deadlock is safely detectable.

## Verification

- `PYTHONPATH=. .venv/bin/python -m unittest tests.infer.test_infer_engine`
- `PYTHONPATH=. .venv/bin/python tests/run.py --pattern test_infer_engine.py`
- `PYTHONPATH=. .venv/bin/python -m unittest tests.infer.test_infer_engine tests.general.test_data_preprocess.TestProviderMessagesPreprocess tests.general.test_data_preprocess.TestRejectedMessagesPreprocess`
- `.venv/bin/pre-commit run --all-files`
- `git diff --check`

## Impact

Only asynchronous streaming failures are affected. Successful stream
items and metrics handling are unchanged. Strict callers now receive the
original exception instead of waiting indefinitely; non-strict callers
continue to terminate the failed stream quietly.

## Experiment results

Before the fix, the strict-mode regression test timed out waiting for the
queue and raised `queue.Empty` while the producer thread printed the
original `RuntimeError`. After the fix, the caller receives that
`RuntimeError` directly, and both strict and non-strict tests pass.
