### PR TITLE
fix(internvl): pass max patch count to vllm

### DIFF
--- a/swift/template/templates/internvl.py
+++ b/swift/template/templates/internvl.py
@@ -30,6 +30,7 @@ class InternvlTemplate(Template):
     def replace_tag(self, media_type: Literal['image', 'video', 'audio'], index: int,
                     inputs: StdTemplateInputs) -> List[Context]:
         if self.mode == 'vllm':
+            inputs.mm_processor_kwargs.setdefault('max_dynamic_patch', self.max_num)
             image_context = ['<image>\n']
         else:
             image_context = ['<img>', [-100], '</img>\n']

--- a/tests/general/test_internvl_template.py
+++ b/tests/general/test_internvl_template.py
@@ -1,0 +1,44 @@
+import unittest
+from types import SimpleNamespace
+
+from swift.template.templates.internvl import InternvlTemplate
+
+
+class TestInternvlTemplate(unittest.TestCase):
+
+    @staticmethod
+    def _template(mode):
+        template = object.__new__(InternvlTemplate)
+        template.mode = mode
+        template.max_num = 6
+        return template
+
+    def test_vllm_receives_max_dynamic_patch(self):
+        template = self._template('vllm')
+        inputs = SimpleNamespace(mm_processor_kwargs={})
+
+        context = template.replace_tag('image', 0, inputs)
+
+        self.assertEqual(context, ['<image>\n'])
+        self.assertEqual(inputs.mm_processor_kwargs, {'max_dynamic_patch': 6})
+
+    def test_vllm_preserves_explicit_max_dynamic_patch(self):
+        template = self._template('vllm')
+        inputs = SimpleNamespace(mm_processor_kwargs={'max_dynamic_patch': 4})
+
+        template.replace_tag('image', 0, inputs)
+
+        self.assertEqual(inputs.mm_processor_kwargs, {'max_dynamic_patch': 4})
+
+    def test_transformers_does_not_receive_vllm_processor_kwargs(self):
+        template = self._template('transformers')
+        inputs = SimpleNamespace(mm_processor_kwargs={})
+
+        context = template.replace_tag('image', 0, inputs)
+
+        self.assertEqual(context, ['<img>', [-100], '</img>\n'])
+        self.assertEqual(inputs.mm_processor_kwargs, {})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixes #7631.

## Background

InternVL templates read the `MAX_NUM` environment variable into
`template.max_num`. The Transformers backend uses this value during
local image preprocessing, but the vLLM branch only emitted the image
placeholder and did not forward the patch limit.

As a result, vLLM used the model configuration's default
`max_dynamic_patch`, potentially producing prompts that exceeded the
model context even when users set `MAX_NUM`.

vLLM's InternVL processor accepts `max_dynamic_patch` through its
multimodal processor kwargs, and `VllmEngine` already forwards
`inputs.mm_processor_kwargs` with each request.

## Changes

- Forward `template.max_num` as `max_dynamic_patch` for InternVL
  templates in vLLM mode.
- Use `setdefault` so an explicit per-request `max_dynamic_patch`
  remains authoritative.
- Add CPU tests for default propagation, explicit override precedence,
  and unchanged Transformers behavior.

## Verification

- `PYTHONPATH=. .venv/bin/python -m unittest tests.general.test_internvl_template`
- `PYTHONPATH=. .venv/bin/python tests/run.py --pattern test_internvl_template.py`
- `PYTHONPATH=. .venv/bin/python -m unittest tests.general.test_internvl_template tests.general.test_data_preprocess.TestProviderMessagesPreprocess tests.general.test_data_preprocess.TestRejectedMessagesPreprocess`
- `.venv/bin/pre-commit run --all-files`
- `git diff --check`

## Impact

The change only adds a vLLM multimodal processor kwarg for InternVL
templates. Transformers preprocessing is unchanged. Existing explicit
per-request values are preserved.

## Experiment results

Before the fix, the vLLM regression test observed an empty
`mm_processor_kwargs` dictionary despite `max_num=6`. After the fix it
contains `{"max_dynamic_patch": 6}`; all three template tests and ten
related tests pass.
