### PR TITLE
fix(infer): reject prompts without generation space

### DIFF
--- a/swift/infer_engine/infer_engine.py
+++ b/swift/infer_engine/infer_engine.py
@@ -218,6 +218,11 @@ class InferEngine(BaseInferEngine, ProcessorMixin):
             logger.warning(
                 'The current model is unable to retrieve `max_model_len`. It is set to the default value of 8192.')
         max_max_tokens = max_model_len - num_tokens + self.max_tokens_offset
+        if max_max_tokens <= 0:
+            raise ValueError(
+                f'Input length ({num_tokens}) leaves no room for generation with max_model_len ({max_model_len}) '
+                f'and max_tokens_offset ({self.max_tokens_offset}). Please shorten the input or increase max_model_len.'
+            )
         if max_tokens is None:
             request_config.max_tokens = max_max_tokens
         elif max_max_tokens < request_config.max_tokens:

--- a/tests/infer/test_infer_engine_limits.py
+++ b/tests/infer/test_infer_engine_limits.py
@@ -1,0 +1,46 @@
+import unittest
+
+from swift.infer_engine.infer_engine import InferEngine
+from swift.infer_engine.protocol import RequestConfig
+
+
+class _TestEngine(InferEngine):
+
+    async def infer_async(self, infer_request, request_config, **kwargs):
+        raise NotImplementedError
+
+
+class TestInferEngineLimits(unittest.TestCase):
+
+    @staticmethod
+    def _engine(max_model_len):
+        engine = object.__new__(_TestEngine)
+        engine.max_model_len = max_model_len
+        engine.max_tokens_offset = 0
+        return engine
+
+    def test_rejects_prompt_longer_than_context(self):
+        engine = self._engine(max_model_len=4)
+        request_config = RequestConfig(max_tokens=2)
+
+        with self.assertRaisesRegex(ValueError, r'Input length \(5\).*max_model_len \(4\)'):
+            engine.set_default_max_tokens(request_config, {'input_ids': [1, 2, 3, 4, 5]})
+
+    def test_rejects_prompt_that_leaves_no_generation_space(self):
+        engine = self._engine(max_model_len=4)
+        request_config = RequestConfig(max_tokens=None)
+
+        with self.assertRaisesRegex(ValueError, r'Input length \(4\).*max_model_len \(4\)'):
+            engine.set_default_max_tokens(request_config, {'input_ids': [1, 2, 3, 4]})
+
+    def test_caps_requested_tokens_to_available_context(self):
+        engine = self._engine(max_model_len=5)
+        request_config = RequestConfig(max_tokens=4)
+
+        engine.set_default_max_tokens(request_config, {'input_ids': [1, 2, 3]})
+
+        self.assertEqual(request_config.max_tokens, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixes #6441.

## Background

When an encoded prompt consumes all or more than the model context,
`set_default_max_tokens()` currently calculates a zero or negative
generation limit and stores it in the request configuration.

The invalid value then reaches a backend-specific configuration class,
which raises a secondary error such as:

```text
ValueError: `max_new_tokens` must be greater than 0, but is -5923.
```

This obscures the actual problem: the prompt itself leaves no room for
generation.

## Changes

- Reject requests when the available generation space is zero or
  negative.
- Report the input token count, model context limit, and configured
  offset in the error.
- Preserve the existing behavior that caps valid requests to the
  remaining context.
- Add CPU boundary tests for overlong, exactly-full, and valid prompts.

## Verification

- `PYTHONPATH=. .venv/bin/python -m unittest tests.infer.test_infer_engine_limits`
- `PYTHONPATH=. .venv/bin/python tests/run.py --pattern test_infer_engine_limits.py`
- `.venv/bin/pre-commit run --all-files`
- `git diff --check`

## Impact

Valid inference requests are unchanged. Requests that previously
propagated zero or negative generation limits now fail earlier with an
actionable error. The change applies consistently to inference backends
that use `set_default_max_tokens()`.

## Experiment results

Before the fix, prompts of length 5 and 4 with `max_model_len=4`
produced generation limits of `-1` and `0` without a direct error. After
the fix, both raise the input-length error, while a valid prompt still
caps the requested generation length from 4 to 2.
