### PR TITLE
fix(ci): use unique docker container names

### DIFF
--- a/.dev_scripts/dockerci.sh
+++ b/.dev_scripts/dockerci.sh
@@ -14,6 +14,8 @@ PR_CHANGED_FILES="${PR_CHANGED_FILES:-}"
 echo "PR modified files: $PR_CHANGED_FILES"
 PR_CHANGED_FILES=${PR_CHANGED_FILES//[ ]/#}
 echo "PR_CHANGED_FILES: $PR_CHANGED_FILES"
+CI_RUN_ID=${GITHUB_RUN_ID:-local-$$}
+CI_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT:-0}
 idx=0
 for gpu in $gpus
 do
@@ -21,7 +23,7 @@ do
   flock -n "$lock_fd" || { echo "WARN: gpu $gpu is in use!" >&2; idx=$((idx+1)); continue; }
   echo "get gpu lock $gpu"
 
-  CONTAINER_NAME="swift-ci-$idx"
+  CONTAINER_NAME="swift-ci-${CI_RUN_ID}-${CI_RUN_ATTEMPT}-${idx}"
   let is_get_file_lock=true
 
   # pull image if there are update

--- a/tests/general/test_dockerci.py
+++ b/tests/general/test_dockerci.py
@@ -1,0 +1,61 @@
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestDockerCI(unittest.TestCase):
+
+    @staticmethod
+    def _write_executable(path, content):
+        path.write_text(content)
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def test_container_name_includes_workflow_identity(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            docker_log = temp_path / 'docker.log'
+            script = (repo_root / '.dev_scripts/dockerci.sh').read_text()
+            portable_script = script.replace('exec {lock_fd}>"/tmp/gpu$gpu" || exit 1', 'lock_fd=9')
+            self.assertNotEqual(script, portable_script)
+            script_path = temp_path / 'dockerci.sh'
+            self._write_executable(script_path, portable_script)
+            self._write_executable(
+                temp_path / 'docker',
+                '#!/bin/sh\n'
+                'printf "%s\\n" "$*" >> "$DOCKER_LOG"\n',
+            )
+            self._write_executable(temp_path / 'flock', '#!/bin/sh\nexit 0\n')
+
+            env = os.environ.copy()
+            env.update({
+                'PATH': f'{temp_path}:{env["PATH"]}',
+                'DOCKER_LOG': str(docker_log),
+                'GITHUB_RUN_ID': '12345',
+                'GITHUB_RUN_ATTEMPT': '2',
+                'IMAGE_NAME': 'swift-ci-image',
+                'IMAGE_VERSION': 'latest',
+                'MODELSCOPE_CACHE': str(temp_path / 'modelscope-cache'),
+                'MODELSCOPE_HOME_CACHE': str(temp_path / 'home-cache'),
+                'CI_COMMAND': 'true',
+            })
+
+            result = subprocess.run(
+                ['bash', script_path],
+                cwd=repo_root,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            docker_commands = docker_log.read_text().splitlines()
+            run_command = next(command for command in docker_commands if command.startswith('run '))
+            self.assertIn('--name swift-ci-12345-2-0', run_command)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Background

The GPU CI launcher always names its Docker container `swift-ci-0` or
`swift-ci-1`. On a self-hosted runner, another active or stale workflow
can already own that global Docker name even after the GPU lock for the
current job is available.

This caused [run 30896752033](https://github.com/modelscope/ms-swift/actions/runs/30896752033)
to fail before tests started:

```text
Conflict. The container name "/swift-ci-0" is already in use
```

## Changes

- Include `GITHUB_RUN_ID`, `GITHUB_RUN_ATTEMPT`, and the selected GPU
  slot in each CI container name.
- Use `local-<pid>` and attempt `0` as deterministic local fallbacks.
- Add a CPU regression test that runs the launcher with stubbed
  `docker` and `flock` commands and verifies the complete `docker run`
  invocation.

## Verification

- `PYTHONPATH=. .venv/bin/python -m unittest tests.general.test_dockerci`
- `PYTHONPATH=. .venv/bin/python tests/run.py --pattern test_dockerci.py`
- `bash -n .dev_scripts/dockerci.sh`
- `.venv/bin/pre-commit run --all-files`
- `git diff --check`

## Impact

GPU selection and lock files are unchanged. Only the Docker container
name changes, preventing unrelated workflow runs from colliding in the
daemon-wide name namespace.

## Experiment results

Before the fix, the stubbed launcher emitted:

```text
--name swift-ci-0
```

With `GITHUB_RUN_ID=12345` and `GITHUB_RUN_ATTEMPT=2`, it now emits:

```text
--name swift-ci-12345-2-0
```
