### PR TITLE
[Template] Support standalone tool observations

### DIFF
--- a/swift/agent_template/base.py
+++ b/swift/agent_template/base.py
@@ -109,6 +109,19 @@ class ReactCompatMixin:
                 res.append(tool_message['content'])
         return assistant_content, res
 
+    def _format_react_standalone_tool_responses(self, tool_messages) -> 'Prompt':
+        assert len(tool_messages) > 0
+        res = []
+        for tool_message in tool_messages:
+            tool_content = tool_message['content']
+            res.extend(['\n', self.keyword.observation, '\n', tool_content])
+        return res
+
+    def _format_standalone_tool_responses(self, tool_messages) -> 'Prompt':
+        """Format observations that do not follow an assistant tool call."""
+        raise NotImplementedError(
+            f'Agent template {self.__class__.__name__} does not support standalone tool responses.')
+
     @staticmethod
     def _parse_tool_call(content) -> Dict[str, Any]:
         obj = BaseAgentTemplate._parse_json(content)

--- a/swift/agent_template/glm4.py
+++ b/swift/agent_template/glm4.py
@@ -62,6 +62,12 @@ class ChatGLM4AgentTemplate(BaseAgentTemplate):
         res.append('<|assistant|>\n')
         return assistant_content, res
 
+    def _format_standalone_tool_responses(self, tool_messages) -> 'Prompt':
+        res = []
+        for tool_message in tool_messages:
+            res.extend(['<|observation|>\n', tool_message['content']])
+        return res
+
     def _format_tool_calls(self, tool_call_messages) -> str:
         tool_calls = []
         for message in tool_call_messages:
@@ -153,6 +159,16 @@ class GLM4_5AgentTemplate(BaseAgentTemplate):
                 res.append(f'<tool_response>{tool_content}</tool_response>')
             res.append('<|assistant|>')
         return assistant_content, res
+
+    def _format_standalone_tool_responses(self, tool_messages) -> 'Prompt':
+        res = ['<|observation|>']
+        for tool_message in tool_messages:
+            tool_content = tool_message['content']
+            if self.model_type == 'glm4_5':
+                res.append(f'\n<tool_response>\n{tool_content}\n</tool_response>')
+            elif self.model_type in {'glm4_7', 'glm5_1'}:
+                res.append(f'<tool_response>{tool_content}</tool_response>')
+        return res
 
     def _format_tool_calls(self, tool_call_messages) -> str:
         tool_calls = []

--- a/swift/agent_template/hermes.py
+++ b/swift/agent_template/hermes.py
@@ -54,6 +54,23 @@ class HermesAgentTemplate(BaseAgentTemplate):
             res.append(context)
         return assistant_content, res
 
+    def _format_standalone_tool_responses(self, tool_messages) -> 'Prompt':
+        """Render standalone results as a native tool-response user turn."""
+        if not hasattr(self, 'template_meta'):
+            return super()._format_standalone_tool_responses(tool_messages)
+
+        res = (self.template_meta.chat_sep or []).copy()
+        total_tool = self._get_tool_responses(tool_messages)
+        for context in self.template_meta.prompt:
+            if isinstance(context, str) and '{{QUERY}}' in context:
+                query_prefix = context.split('{{QUERY}}', maxsplit=1)[0]
+                if query_prefix:
+                    res.append(query_prefix)
+                res.append(total_tool)
+                return res
+            res.append(context)
+        raise ValueError(f'Template prompt does not contain {{{{QUERY}}}}: {self.template_meta.prompt}')
+
     def _format_tools(self, tools: List[Union[str, dict]], system: Optional[str] = None, user_message=None) -> str:
         tool_descs = [json.dumps(self.wrap_tool(tool), ensure_ascii=False) for tool in tools]
         system = system or ''

--- a/swift/agent_template/react.py
+++ b/swift/agent_template/react.py
@@ -6,6 +6,9 @@ from .base import BaseAgentTemplate
 
 class ReactEnAgentTemplate(BaseAgentTemplate):
 
+    def _format_standalone_tool_responses(self, tool_messages):
+        return self._format_react_standalone_tool_responses(tool_messages)
+
     def _format_tools(self, tools: List[Union[str, dict]], system: Optional[str] = None, user_message=None) -> str:
         tool_names = []
         tool_descs = []
@@ -37,6 +40,9 @@ Begin!
 
 
 class ReactZnAgentTemplate(BaseAgentTemplate):
+
+    def _format_standalone_tool_responses(self, tool_messages):
+        return self._format_react_standalone_tool_responses(tool_messages)
 
     def _format_tools(self, tools: List[Union[str, dict]], system: Optional[str] = None, user_message=None) -> str:
         tool_names = []

--- a/swift/dataset/preprocessor/core.py
+++ b/swift/dataset/preprocessor/core.py
@@ -16,6 +16,7 @@ from packaging import version
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from swift.template import history_to_messages
+from swift.template.template_inputs import normalize_openai_tool_calls
 from swift.utils import get_logger, is_dist, is_master, safe_ddp_context
 
 DATASET_TYPE = Union[HfDataset, HfIterableDataset]
@@ -511,43 +512,9 @@ class MessagesPreprocessor(RowPreprocessor):
                 message['role'] = 'tool_response'
 
     @staticmethod
-    def _parse_arguments(arguments: Any) -> Any:
-        if not isinstance(arguments, str):
-            return arguments
-        try:
-            return json.loads(arguments)
-        except json.JSONDecodeError:
-            return arguments
-
-    @classmethod
-    def openai_to_messages(cls, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def openai_to_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Convert OpenAI tool-call messages to the SWIFT canonical roles."""
-        new_messages = []
-        for message in messages:
-            if message.get('role') != 'assistant' or not message.get('tool_calls'):
-                new_messages.append(message)
-                continue
-
-            content = message.get('content')
-            if content:
-                new_messages.append({
-                    key: value
-                    for key, value in message.items() if key in {'role', 'content', 'loss', 'loss_scale'}
-                })
-            for tool_call in message['tool_calls']:
-                function = tool_call.get('function', tool_call)
-                tool_message = {
-                    'role': 'tool_call',
-                    'content': {
-                        'name': function['name'],
-                        'arguments': cls._parse_arguments(function.get('arguments', {})),
-                    },
-                }
-                for key in ['loss', 'loss_scale']:
-                    if key in message:
-                        tool_message[key] = message[key]
-                new_messages.append(tool_message)
-        return new_messages
+        return normalize_openai_tool_calls(messages)
 
     @staticmethod
     def _anthropic_image_source(block: Dict[str, Any]) -> str:

--- a/swift/template/base.py
+++ b/swift/template/base.py
@@ -354,6 +354,48 @@ class Template(ProcessorMixin):
             else:
                 i += 1
 
+    def _preprocess_standalone_tools(self, inputs: StdTemplateInputs) -> None:
+        """Fold tool observations without a preceding assistant call into the query.
+
+        The SWIFT encoder consumes alternating query/assistant pairs. A native chat
+        template can nevertheless accept a tool result directly after a user message.
+        Agent templates provide the exact observation syntax, which is appended to the
+        current query before pairing it with the following assistant response.
+        """
+        if self.template_backend != 'swift':
+            return
+        messages = inputs.messages
+        i = 0
+        while i < len(messages):
+            if (messages[i]['role'] != 'tool' or i > 0 and messages[i - 1]['role'] in {'assistant', 'tool'}):
+                i += 1
+                continue
+
+            i_start = i
+            while i + 1 < len(messages) and messages[i + 1]['role'] == 'tool':
+                i += 1
+            tool_messages = messages[i_start:i + 1]
+
+            if i_start == 0:
+                raise ValueError('A standalone tool message must follow a user message.')
+            query_message = messages[i_start - 1]
+            if query_message['role'] != 'user':
+                raise ValueError(
+                    f'A standalone tool message must follow a user message. Previous message: {query_message}')
+            query_content = query_message.get('content') or ''
+            if not isinstance(query_content, str):
+                raise ValueError('Standalone tool messages currently require text-only user content. '
+                                 f'Content: {query_content}')
+
+            agent_template = self.agent_template
+            agent_template.template_meta = self.template_meta
+            tool_context = agent_template._format_standalone_tool_responses(tool_messages)
+            if not all(isinstance(context, str) for context in tool_context):
+                raise ValueError(f'Standalone tool formatting must produce text contexts: {tool_context}')
+            query_message['content'] = query_content + ''.join(tool_context)
+            del messages[i_start:i + 1]
+            i = i_start
+
     def prepare_engine_kwargs(self) -> Dict[str, Any]:
         return {}
 
@@ -1242,6 +1284,7 @@ class Template(ProcessorMixin):
             None. The input messages list is updated in-place.
         """
         self._preprocess_tool_call(inputs)
+        self._preprocess_standalone_tools(inputs)
         messages = inputs.messages
         if len(messages) < 2:
             return

--- a/swift/template/template_inputs.py
+++ b/swift/template/template_inputs.py
@@ -11,6 +11,43 @@ from .utils import Messages, Tool, get_last_user_round, messages_to_history
 logger = get_logger()
 
 
+def normalize_openai_tool_calls(messages: Messages) -> Messages:
+    """Convert OpenAI assistant ``tool_calls`` into SWIFT canonical messages."""
+    normalized = []
+    for message in messages:
+        tool_calls = message.get('tool_calls') if message.get('role') == 'assistant' else None
+        if not tool_calls:
+            normalized.append(message)
+            continue
+
+        content = message.get('content')
+        if content:
+            normalized.append({
+                key: value
+                for key, value in message.items() if key in {'role', 'content', 'loss', 'loss_scale'}
+            })
+        for tool_call in tool_calls:
+            function = tool_call.get('function', tool_call)
+            arguments = function.get('arguments', {})
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    pass
+            tool_message = {
+                'role': 'tool_call',
+                'content': {
+                    'name': function['name'],
+                    'arguments': arguments,
+                },
+            }
+            for key in ['loss', 'loss_scale']:
+                if key in message:
+                    tool_message[key] = message[key]
+            normalized.append(tool_message)
+    return normalized
+
+
 @dataclass
 class StdTemplateInputs:
     # only user/tool/assistant
@@ -62,7 +99,9 @@ class StdTemplateInputs:
         for key in ['label', 'channel', 'margin', 'rejected_response']:
             if key in inputs:
                 kwargs[key] = inputs[key]
-        messages = inputs['messages']
+        # Dataset loading performs the same conversion, but Template.encode also
+        # accepts dictionaries directly and must not require a placeholder content.
+        messages = normalize_openai_tool_calls(inputs['messages'])
         tools = inputs.get('tools')
         objects = inputs.get('objects') or {}
         chat_template_kwargs = inputs.get('chat_template_kwargs') or {}
@@ -76,8 +115,9 @@ class StdTemplateInputs:
         for message in messages:
             if message['role'] == 'tool_response':
                 message['role'] = 'tool'
-            if message['role'] in {'tool_call', 'tool'} and not isinstance(message['content'], str):
-                message['content'] = json.dumps(message['content'], ensure_ascii=False)
+            content = message.get('content')
+            if message['role'] in {'tool_call', 'tool'} and not isinstance(content, str):
+                message['content'] = json.dumps(content, ensure_ascii=False)
 
         media_kwargs = StdTemplateInputs.remove_messages_media(messages)
         for k in list(media_kwargs.keys()):
@@ -108,8 +148,8 @@ class StdTemplateInputs:
     def remove_messages_media(messages: Messages) -> Dict[str, Any]:
         res = {'images': [], 'audios': [], 'videos': []}
         for message in messages:
-            content = message['content']
-            if isinstance(content, str):
+            content = message.get('content')
+            if content is None or isinstance(content, str):
                 continue
             elif (isinstance(content, list) and content
                   and isinstance(content[0], int)) or (isinstance(content, dict) and 'token_ids' in content):


### PR DESCRIPTION
## What changed

- Normalize OpenAI `assistant.tool_calls` before direct template encoding, including messages without a `content` field.
- Support standalone `tool` observations following a user message in the Swift template backend.
- Add native standalone-observation formatting for ReAct, Hermes/Qwen, and GLM agent templates.
- Reuse the same OpenAI tool-call normalization in dataset preprocessing.

## Root cause

Direct template encoding accessed `content` before normalizing `assistant.tool_calls`, and the Swift encoder could not represent a `user -> tool -> assistant` sequence even when the model chat template supports standalone observations.

## Compatibility

Existing `assistant -> tool(s)` behavior is unchanged. Standalone observations remain prompt-side and are excluded from labels.

Fixes #9843
Refs #8499
