### PR TITLE
fix(utils): preserve streamed download bytes

### DIFF
--- a/swift/utils/hub_utils.py
+++ b/swift/utils/hub_utils.py
@@ -154,10 +154,15 @@ def git_clone_github(github_url: str,
 def download_ms_file(url: str, local_path: str, cookies=None) -> None:
     if cookies is None:
         cookies = ModelScopeConfig.get_cookies()
-    resp = requests.get(url, cookies=cookies, stream=True)
-    with open(local_path, 'wb') as f:
-        for data in tqdm(resp.iter_lines()):
-            f.write(data)
+    with requests.get(url, cookies=cookies, stream=True) as resp:
+        resp.raise_for_status()
+        total_size = int(resp.headers.get('content-length', 0))
+        with open(local_path, 'wb') as f, tqdm(
+                total=total_size, unit='B', unit_scale=True, unit_divisor=1024,
+                desc=os.path.basename(local_path)) as pbar:
+            for chunk in resp.iter_content(chunk_size=8192):
+                f.write(chunk)
+                pbar.update(len(chunk))
 
 
 def _resolve_kernel_variant_str(repo_id: str) -> Optional[str]:
@@ -237,12 +242,12 @@ def download_file(url: str) -> str:
     file_path = os.path.join(cache_dir, file_name)
     if os.path.exists(file_path):
         return file_path
-    resp = requests.get(url, stream=True)
-    resp.raise_for_status()
-    total_size = int(resp.headers.get('content-length', 0))
-    with open(file_path, 'wb') as f, tqdm(
-            total=total_size, unit='B', unit_scale=True, unit_divisor=1024, desc=file_name) as pbar:
-        for chunk in resp.iter_content(chunk_size=8192):
-            f.write(chunk)
-            pbar.update(len(chunk))
+    with requests.get(url, stream=True) as resp:
+        resp.raise_for_status()
+        total_size = int(resp.headers.get('content-length', 0))
+        with open(file_path, 'wb') as f, tqdm(
+                total=total_size, unit='B', unit_scale=True, unit_divisor=1024, desc=file_name) as pbar:
+            for chunk in resp.iter_content(chunk_size=8192):
+                f.write(chunk)
+                pbar.update(len(chunk))
     return file_path

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -1,0 +1,59 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from swift.utils.hub_utils import download_file, download_ms_file
+
+
+class TestHubUtils(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self.tmp_dir = self._tmp_dir.name
+
+    def tearDown(self):
+        self._tmp_dir.cleanup()
+
+    @staticmethod
+    def _mock_response(chunks):
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.iter_content.return_value = chunks
+        response.iter_lines.return_value = [chunk.rstrip(b'\r\n') for chunk in chunks]
+        response.headers = {'content-length': str(sum(map(len, chunks)))}
+        return response
+
+    @patch('swift.utils.hub_utils.ModelScopeConfig.get_cookies', return_value={'session': 'test'})
+    @patch('swift.utils.hub_utils.requests.get')
+    def test_download_ms_file_preserves_bytes_and_closes_response(self, mock_get, mock_cookies):
+        chunks = [b'first line\n', b'\x00second line\r\n']
+        response = self._mock_response(chunks)
+        mock_get.return_value = response
+        local_path = os.path.join(self.tmp_dir, 'artifact.bin')
+
+        download_ms_file('https://example.com/artifact.bin', local_path)
+
+        with open(local_path, 'rb') as f:
+            self.assertEqual(f.read(), b''.join(chunks))
+        mock_get.assert_called_once_with('https://example.com/artifact.bin', cookies={'session': 'test'}, stream=True)
+        response.raise_for_status.assert_called_once_with()
+        response.__exit__.assert_called_once()
+
+    @patch('swift.utils.hub_utils.requests.get')
+    @patch('swift.utils.hub_utils.get_cache_dir')
+    def test_download_file_closes_response(self, mock_cache_dir, mock_get):
+        mock_cache_dir.return_value = self.tmp_dir
+        chunks = [b'model', b' data']
+        response = self._mock_response(chunks)
+        mock_get.return_value = response
+
+        file_path = download_file('https://example.com/model.bin')
+
+        with open(file_path, 'rb') as f:
+            self.assertEqual(f.read(), b''.join(chunks))
+        response.__exit__.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

`download_ms_file` streamed responses through `iter_lines()`. That API removes
line delimiters, so downloaded binary or text artifacts containing newline
bytes were silently changed on disk. Both streamed download helpers also left
their HTTP responses open after completion or failure.

This PR:

- streams ModelScope files with `iter_content()` to preserve the response bytes;
- validates the HTTP status before writing;
- closes responses reliably through their context manager;
- adds CPU-only regression coverage for byte preservation and response cleanup.

The change is limited to the two download helpers in `swift.utils.hub_utils`.
It does not change cache paths or retry behavior.

## Experiment results

Before the fix:

```text
expected: b'first line\n\x00second line\r\n'
actual:   b'first line\x00second line'
2 tests failed
```

After the fix:

```text
.venv/bin/python tests/run.py --pattern test_hub_utils.py
SUCCESS (Runs=2, success=2)

.venv/bin/pre-commit run --all-files
All hooks passed
```
