### PR TITLE
fix(utils): close daemon event loops on shutdown

### DIFF
--- a/swift/utils/utils.py
+++ b/swift/utils/utils.py
@@ -489,8 +489,12 @@ def shutdown_event_loop_in_daemon(thread: threading.Thread = None, loop: asyncio
     """
     if loop is None or thread is None:
         return
+    if loop.is_closed():
+        return
     loop.call_soon_threadsafe(loop.stop)
     thread.join(timeout=5)
+    if not thread.is_alive():
+        loop.close()
 
 
 def remove_response(messages) -> Optional[str]:

--- a/tests/utils/test_async_rewards.py
+++ b/tests/utils/test_async_rewards.py
@@ -34,6 +34,8 @@ class TestAsyncRewardFunctions(unittest.TestCase):
         # Give the thread time to finish
         thread.join(timeout=2)
         self.assertFalse(thread.is_alive())
+        self.assertTrue(loop.is_closed())
+        shutdown_event_loop_in_daemon(thread, loop)
 
     def test_run_async_function_in_daemon_loop(self):
         """Test running an async function in the daemon event loop."""


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

`shutdown_event_loop_in_daemon` stopped and joined the daemon thread but left
the event loop open. The stopped loop retained its selector and related
resources until garbage collection.

This PR closes the loop once its thread has exited. It also returns early for
an already closed loop, making repeated shutdown calls safe. If the thread
does not exit within the existing five-second timeout, the loop is not closed
from another thread.

The change is limited to the daemon event-loop lifecycle helper.

## Experiment results

Before the fix:

```text
{'thread_alive': False, 'loop_running': False, 'loop_closed': False}
FAILED (Runs=6, success=5, failures=1)
```

After the fix:

```text
.venv/bin/python tests/run.py --pattern test_async_rewards.py
SUCCESS (Runs=6, success=6)

.venv/bin/pre-commit run --all-files
All hooks passed
```
