### PR TITLE
fix(sampling): preserve remainder samples across shards

### DIFF
--- a/swift/pipelines/sampling/sampling.py
+++ b/swift/pipelines/sampling/sampling.py
@@ -43,8 +43,10 @@ class SwiftSampling(SwiftPipeline):
             args.dataset, split_dataset_ratio=0., shuffle=args.dataset_shuffle, **dataset_kwargs)
         logger.info(f'Sampling_dataset: {sampling_dataset}')
         dataset_len = len(sampling_dataset)
-        piece_len = dataset_len // self.total_piece
-        sampling_dataset = sampling_dataset.select(range(piece_len * self.cur_piece, piece_len * (self.cur_piece + 1)))
+        piece_len, remainder = divmod(dataset_len, self.total_piece)
+        start = piece_len * self.cur_piece + min(self.cur_piece, remainder)
+        end = start + piece_len + int(self.cur_piece < remainder)
+        sampling_dataset = sampling_dataset.select(range(start, end))
         return sampling_dataset
 
     def run(self):

--- a/tests/sample/test_sampling.py
+++ b/tests/sample/test_sampling.py
@@ -1,0 +1,47 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from swift.pipelines.sampling.sampling import SwiftSampling
+
+
+class FakeDataset:
+
+    def __init__(self, values):
+        self.values = values
+
+    def __len__(self):
+        return len(self.values)
+
+    def select(self, indices):
+        return FakeDataset([self.values[i] for i in indices])
+
+
+class TestSampling(unittest.TestCase):
+
+    @patch('swift.pipelines.sampling.sampling.load_dataset')
+    def test_data_range_partitions_cover_dataset(self, mock_load_dataset):
+        args = SimpleNamespace(
+            dataset=['test-dataset'],
+            dataset_shuffle=False,
+            get_dataset_kwargs=lambda: {},
+        )
+
+        for dataset_size, expected_sizes in [(10, [4, 3, 3]), (2, [1, 1, 0])]:
+            with self.subTest(dataset_size=dataset_size):
+                dataset = FakeDataset(list(range(dataset_size)))
+                mock_load_dataset.return_value = dataset, None
+                shards = []
+                for shard_index in range(3):
+                    sampling = SwiftSampling.__new__(SwiftSampling)
+                    sampling.args = args
+                    sampling.cur_piece = shard_index
+                    sampling.total_piece = 3
+                    shards.append(sampling._get_dataset().values)
+
+                self.assertEqual([len(shard) for shard in shards], expected_sizes)
+                self.assertEqual([item for shard in shards for item in shard], list(range(dataset_size)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

`SwiftSampling._get_dataset` calculated one fixed shard size with integer
division. When the dataset size was not divisible by the number of
`data_range` shards, every shard used that truncated size and the remainder
samples were never processed.

For example, 10 samples split across 3 processes produced shard sizes
`[3, 3, 3]`, silently dropping sample 9.

This PR distributes the remainder across the first shards. The resulting
shards remain contiguous and ordered, differ in size by at most one, and cover
each input exactly once. Datasets smaller than the shard count are also
handled, with empty shards only after all samples have been assigned.

The change is limited to dataset partitioning for `data_range`; sampling,
resume, and output behavior are unchanged.

## Experiment results

Before the fix:

```text
10 samples / 3 shards -> [3, 3, 3], sample 9 missing
FAILED (Runs=1, success=0, failures=1)
```

After the fix:

```text
10 samples / 3 shards -> [4, 3, 3], complete ordered coverage
 2 samples / 3 shards -> [1, 1, 0], complete ordered coverage

.venv/bin/python tests/run.py --test_dir tests/sample --pattern test_sampling.py
SUCCESS (Runs=1, success=1)

.venv/bin/pre-commit run --all-files
All hooks passed
```
