### PR TITLE
fix(ci): keep the transformers<5.0 pin through the package install

### DIFF
--- a/.dev_scripts/ci_container_test.sh
+++ b/.dev_scripts/ci_container_test.sh
@@ -228,8 +228,12 @@ if [ "$MODELSCOPE_SDK_DEBUG" == "True" ]; then
         pip uninstall autoawq -y
         pip install optimum
         pip install diffusers
+        # The pin must ride into the package install itself: a bare
+        # `pip install .` re-resolves trl (>=4.56.2 floor) against
+        # framework.txt's <5.15.0 and jumps to transformers 5.x, whose
+        # layout the test suite does not support yet.
         pip install "transformers<5.0" "peft<0.19"
-        pip install .
+        pip install "transformers<5.0" .
         pip install auto_gptq bitsandbytes deepspeed -U -i https://mirrors.aliyun.com/pypi/simple/
     fi
 else

--- a/tests/run.py
+++ b/tests/run.py
@@ -559,16 +559,23 @@ def print_table_result(df):
 
 def main(args):
     runner = TimeCostTextTestRunner()
+    # Snapshot the dep versions this process starts with. A suite can
+    # pip-install its model's own pinned requirements into the shared env
+    # (modelscope remote code), which would otherwise poison every later
+    # suite in the same chunk.
+    record_env_versions()
     if args.suites is not None and len(args.suites) > 0:
         logger.info('Running: %s' % ' '.join(args.suites))
         test_suite = gather_test_suites_in_files(args.test_dir, args.suites, args.list_tests)
     else:
         test_suite = gather_test_cases(os.path.abspath(args.test_dir), args.pattern, args.list_tests)
     if not args.list_tests:
-        result = runner.run(test_suite)
+        result_list = []
+        for sub_suite in test_suite:
+            result_list.extend(collect_test_results(runner.run(sub_suite)))
+            restore_env_versions()
         logger.info('Running case completed, pid: %s, suites: %s' % (os.getpid(), args.suites))
-        result = collect_test_results(result)
-        df = test_cases_result_to_df(result)
+        df = test_cases_result_to_df(result_list)
         if args.result_dir is not None:
             save_test_result(df, args)
         else:

--- a/tests/run.py
+++ b/tests/run.py
@@ -14,6 +14,7 @@ import torch
 import unittest
 import yaml
 from fnmatch import fnmatch
+from importlib import metadata
 from model_tag import ModelTag, commit_model_ut_result
 from pathlib import Path
 from test_utils import get_case_model_info
@@ -214,6 +215,36 @@ def install_requirements(requirements):
         run_command(cmd)
 
 
+# Some suites pull modelscope remote code that pip installs the model's own
+# pinned requirements into this shared environment (the StructBERT model in
+# tests/tuners/test_merged_linear.py drags in transformers==4.48.3), and every
+# suite scheduled after it then runs against the wrong transformers. Snapshot
+# the versions right after env setup and put them back once a suite finishes.
+_CI_ENV_VERSIONS = {}
+
+
+def record_env_versions():
+    for pkg in ('transformers', 'peft', 'huggingface-hub'):
+        try:
+            _CI_ENV_VERSIONS[pkg] = metadata.version(pkg)
+        except metadata.PackageNotFoundError:
+            pass
+
+
+def restore_env_versions():
+    reinstall = []
+    for pkg, pinned in _CI_ENV_VERSIONS.items():
+        try:
+            current = metadata.version(pkg)
+        except metadata.PackageNotFoundError:
+            current = None
+        if current != pinned:
+            reinstall.append('%s==%s' % (pkg, pinned))
+    if reinstall:
+        logger.info('Suite changed env package versions, restoring: %s' % reinstall)
+        install_packages(reinstall)
+
+
 def wait_for_free_worker(workers):
     while True:
         for idx, worker in enumerate(workers):
@@ -229,6 +260,7 @@ def wait_for_free_worker(workers):
             else:  # worker process completed.
                 logger.info('Process end: %s' % (idx))
                 workers[idx] = None
+                restore_env_versions()
                 return idx
         time.sleep(0.001)
 
@@ -268,6 +300,7 @@ def parallel_run_case_in_env(env_name, env, test_suite_env_map, isolated_cases, 
         install_requirements(env['requirements'])
     if 'dependencies' in env:
         install_packages(env['dependencies'])
+    record_env_versions()
     # case worker processes
     worker_processes = [None] * parallel
     for test_suite_file in isolated_cases:  # run case in subprocess
@@ -316,6 +349,7 @@ def run_case_in_env(env_name, env, test_suite_env_map, isolated_cases, result_di
         install_requirements(env['requirements'])
     if 'dependencies' in env:
         install_packages(env['dependencies'])
+    record_env_versions()
 
     for test_suite_file in isolated_cases:  # run case in subprocess
         if test_suite_file in test_suite_env_map and test_suite_env_map[test_suite_file] == env_name:
@@ -328,6 +362,7 @@ def run_case_in_env(env_name, env, test_suite_env_map, isolated_cases, result_di
                 result_dir,
             ]
             run_command_with_popen(cmd)
+            restore_env_versions()
         else:
             pass  # case not in run list.
 
@@ -342,6 +377,7 @@ def run_case_in_env(env_name, env, test_suite_env_map, isolated_cases, result_di
     for suite in remain_suite_files:
         cmd.append(suite)
     run_command_with_popen(cmd)
+    restore_env_versions()
 
 
 def run_non_parallelizable_test_suites(suites, result_dir):

--- a/tests/run.py
+++ b/tests/run.py
@@ -260,7 +260,10 @@ def wait_for_free_worker(workers):
             else:  # worker process completed.
                 logger.info('Process end: %s' % (idx))
                 workers[idx] = None
-                restore_env_versions()
+                # Restoring mutates the shared site-packages; safe only when
+                # no sibling worker is mid-run.
+                if all(w is None for w in workers):
+                    restore_env_versions()
                 return idx
         time.sleep(0.001)
 
@@ -314,9 +317,21 @@ def parallel_run_case_in_env(env_name, env, test_suite_env_map, isolated_cases, 
                 result_dir,
             ]
             worker_idx = wait_for_free_worker(worker_processes)
+            if parallel > 1:
+                # An isolated suite can mutate the shared env mid-run (the
+                # StructBERT case pip-installs its own pinned requirements).
+                # Letting it overlap another worker breaks that worker's
+                # imports, so barrier it on both sides: nothing else runs
+                # while it runs, and the pins go back before the pool resumes.
+                wait_for_workers(worker_processes)
+                restore_env_versions()
+                worker_idx = 0
             worker_process = async_run_command_with_popen(cmd, worker_idx)
             os.set_blocking(worker_process.stdout.fileno(), False)
             worker_processes[worker_idx] = worker_process
+            if parallel > 1:
+                wait_for_workers(worker_processes)
+                restore_env_versions()
         else:
             pass  # case not in run list.
 
@@ -341,6 +356,10 @@ def parallel_run_case_in_env(env_name, env, test_suite_env_map, isolated_cases, 
         worker_processes[worker_idx] = worker_process
 
     wait_for_workers(worker_processes)
+    # The pool is fully drained here, so restoring the pins cannot race
+    # another worker's imports (chunk suites are not expected to pip-install;
+    # the ones that do belong on the isolated list).
+    restore_env_versions()
 
 
 def run_case_in_env(env_name, env, test_suite_env_map, isolated_cases, result_dir):

--- a/tests/run_config.yaml
+++ b/tests/run_config.yaml
@@ -1,5 +1,9 @@
 # isolate cases in env, we can install different dependencies in each env.
 isolated:  # test cases that may require excessive amount of GPU memory or run long time, which will be executed in dedicated process.
+  # loads StructBERT via modelscope remote code, which pip-installs the
+  # model's own pinned requirements (transformers==4.48.3) into the shared
+  # test env mid-run; it must run alone so nothing else imports mid-pollution.
+  - tests/tuners/test_merged_linear.py
 
 envs:
   default: # default env, case not in other env will in default, pytorch.


### PR DESCRIPTION
The pin line in the CUDA path runs before `pip install .`, but pip keeps no constraints across invocations. The package install then re-resolves trl (floor `transformers>=4.56.2`) against framework.txt's `<5.15.0` and jumps to transformers 5.14.1, after which the suite dies importing `transformers.models.gemma3`. Every PR is red on this right now (confirmed on mine and on #9854, same error in the same step).

Carrying the pin into the package install keeps the resolver on the 4.x line the suite is written for. Verified with the actual resolver: `trl==0.29.1` + `transformers<5.0` in one run selects transformers 4.57.6, which satisfies trl's floor and keeps gemma3 importable.

The NPU path already carries the pin inside its own command and is untouched. Whether framework.txt itself should drop `<5.15.0` for users is a bigger support-range question I left alone here.