### PR TITLE
Fix local/unfused Megatron attention and LoRA on Ascend

### DIFF
--- a/swift/megatron/model/utils.py
+++ b/swift/megatron/model/utils.py
@@ -73,7 +73,7 @@ def get_mcore_model_config(args, hf_config):
         kwargs.update(args.megatron_extra_kwargs)
     config = ModelConfig(**kwargs)
     if is_torch_npu_available():
-        setattr(config, 'use_flash_attn', config.attention_backend.name != 'local')
+        setattr(config, 'use_flash_attn', config.attention_backend.name not in {'local', 'unfused'})
     _check_attention_backend(args, config)
     _check_padding_free(args, config)
     return config

--- a/swift/megatron/model/utils.py
+++ b/swift/megatron/model/utils.py
@@ -26,7 +26,7 @@ def _check_padding_free(args, config):
     attention_backend = config.attention_backend.name
     message = None
 
-    if attention_backend == 'unfused':
+    if attention_backend in {'local', 'unfused'}:
         message = f'Attention backend "{attention_backend}" is not supported in padding-free mode'
 
     if message:
@@ -72,8 +72,8 @@ def get_mcore_model_config(args, hf_config):
     if args.megatron_extra_kwargs:
         kwargs.update(args.megatron_extra_kwargs)
     config = ModelConfig(**kwargs)
-    if is_torch_npu_available() and getattr(args, 'attention_backend', 'flash') != 'local':
-        setattr(config, 'use_flash_attn', True)
+    if is_torch_npu_available():
+        setattr(config, 'use_flash_attn', config.attention_backend.name != 'local')
     _check_attention_backend(args, config)
     _check_padding_free(args, config)
     return config

--- a/swift/megatron/pipelines/train/sft.py
+++ b/swift/megatron/pipelines/train/sft.py
@@ -42,11 +42,9 @@ class MegatronSft(SwiftSft):
         args = self.args
         if apply_mindspeed_patches is not None:
             megatron_args = asdict(self.args)
-            if args.attention_backend != 'local':
-                # MindSpeed requires passing `use_flash_attn` to Megatron
-                # to enable flash attention on Ascend NPU.
-                args.use_flash_attn = True
-                megatron_args['use_flash_attn'] = True
+            # MindSpeed requires passing `use_flash_attn` to Megatron to select the attention implementation.
+            args.use_flash_attn = args.attention_backend.name != 'local'
+            megatron_args['use_flash_attn'] = args.use_flash_attn
             apply_mindspeed_patches(megatron_args)
         template_cls = args.template_meta.template_cls
         if args.model_meta.is_multimodal and template_cls and template_cls.use_model:

--- a/swift/megatron/pipelines/train/sft.py
+++ b/swift/megatron/pipelines/train/sft.py
@@ -43,7 +43,7 @@ class MegatronSft(SwiftSft):
         if apply_mindspeed_patches is not None:
             megatron_args = asdict(self.args)
             # MindSpeed requires passing `use_flash_attn` to Megatron to select the attention implementation.
-            args.use_flash_attn = args.attention_backend.name != 'local'
+            args.use_flash_attn = args.attention_backend.name not in {'local', 'unfused'}
             megatron_args['use_flash_attn'] = args.use_flash_attn
             apply_mindspeed_patches(megatron_args)
         template_cls = args.template_meta.template_cls

--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -356,7 +356,7 @@ def _should_use_npu_generated_attention_mask(args) -> bool:
         return False
     if args.task_type != 'causal_lm' or args.padding_free:
         return False
-    if getattr(args, 'attention_backend', None) == 'local':
+    if getattr(args.attention_backend, 'name', args.attention_backend) == 'local':
         return False
     return bool(getattr(args, 'use_flash_attn', False))
 

--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -356,7 +356,7 @@ def _should_use_npu_generated_attention_mask(args) -> bool:
         return False
     if args.task_type != 'causal_lm' or args.padding_free:
         return False
-    if getattr(args.attention_backend, 'name', args.attention_backend) == 'local':
+    if getattr(args.attention_backend, 'name', args.attention_backend) in {'local', 'unfused'}:
         return False
     return bool(getattr(args, 'use_flash_attn', False))
 

--- a/swift/megatron/utils/utils.py
+++ b/swift/megatron/utils/utils.py
@@ -8,6 +8,7 @@ from megatron.core.inference.communication_utils import recv_from_prev_pipeline_
 from megatron.core.models.common.embeddings.language_model_embedding import LanguageModelEmbedding
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.ssm.mamba_context_parallel import _undo_attention_load_balancing
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
 from megatron.core.transformer.moe.router import TopKRouter
 from torch import nn
 from transformers.utils import is_torch_npu_available
@@ -24,7 +25,8 @@ def find_all_linears(model, extra_layers=None):
 
     def _cond(name, module):
         if (extra_layers and isinstance(module, tuple(extra_layers))) or name != 'output_layer' and isinstance(
-                module, (TELinear, TELayerNormColumnParallelLinear, TEGroupedLinear, nn.Linear)):
+                module, (TELinear, TELayerNormColumnParallelLinear, TEGroupedLinear, ColumnParallelLinear,
+                         RowParallelLinear, nn.Linear)):
             return True
         return False
 

--- a/tests/megatron/test_megatron_args.py
+++ b/tests/megatron/test_megatron_args.py
@@ -89,27 +89,31 @@ class TestMegatronArgs(unittest.TestCase):
         for field_name in expected_fields:
             self.assertIn(field_name, field_names, f'MegatronArguments missing field: {field_name}')
 
-    def test_local_attention_disables_padding_free(self):
+    def test_non_flash_attention_disables_padding_free(self):
         self._skip_if_no_megatron()
         from swift.megatron.model.utils import _check_padding_free
 
-        args = SimpleNamespace(padding_free=True)
-        config = SimpleNamespace(attention_backend=SimpleNamespace(name='local'))
-        _check_padding_free(args, config)
-        self.assertFalse(args.padding_free)
+        for attention_backend in ('local', 'unfused'):
+            with self.subTest(attention_backend=attention_backend):
+                args = SimpleNamespace(padding_free=True)
+                config = SimpleNamespace(attention_backend=SimpleNamespace(name=attention_backend))
+                _check_padding_free(args, config)
+                self.assertFalse(args.padding_free)
 
     @patch('transformers.utils.is_torch_npu_available', return_value=True)
-    def test_local_attention_keeps_npu_attention_mask(self, _):
+    def test_non_flash_attention_keeps_npu_attention_mask(self, _):
         self._skip_if_no_megatron()
         from swift.megatron.trainers.utils import _should_use_npu_generated_attention_mask
 
-        args = SimpleNamespace(
-            task_type='causal_lm',
-            padding_free=False,
-            attention_backend=SimpleNamespace(name='local'),
-            use_flash_attn=True,
-        )
-        self.assertFalse(_should_use_npu_generated_attention_mask(args))
+        for attention_backend in ('local', 'unfused'):
+            with self.subTest(attention_backend=attention_backend):
+                args = SimpleNamespace(
+                    task_type='causal_lm',
+                    padding_free=False,
+                    attention_backend=SimpleNamespace(name=attention_backend),
+                    use_flash_attn=True,
+                )
+                self.assertFalse(_should_use_npu_generated_attention_mask(args))
 
 
 if __name__ == '__main__':

--- a/tests/megatron/test_megatron_args.py
+++ b/tests/megatron/test_megatron_args.py
@@ -1,4 +1,6 @@
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 
 class TestMegatronArgs(unittest.TestCase):
@@ -86,6 +88,28 @@ class TestMegatronArgs(unittest.TestCase):
         field_names = {f.name for f in fields(self.MegatronArguments)}
         for field_name in expected_fields:
             self.assertIn(field_name, field_names, f'MegatronArguments missing field: {field_name}')
+
+    def test_local_attention_disables_padding_free(self):
+        self._skip_if_no_megatron()
+        from swift.megatron.model.utils import _check_padding_free
+
+        args = SimpleNamespace(padding_free=True)
+        config = SimpleNamespace(attention_backend=SimpleNamespace(name='local'))
+        _check_padding_free(args, config)
+        self.assertFalse(args.padding_free)
+
+    @patch('transformers.utils.is_torch_npu_available', return_value=True)
+    def test_local_attention_keeps_npu_attention_mask(self, _):
+        self._skip_if_no_megatron()
+        from swift.megatron.trainers.utils import _should_use_npu_generated_attention_mask
+
+        args = SimpleNamespace(
+            task_type='causal_lm',
+            padding_free=False,
+            attention_backend=SimpleNamespace(name='local'),
+            use_flash_attn=True,
+        )
+        self.assertFalse(_should_use_npu_generated_attention_mask(args))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- compare Megatron attention backends through their enum names on Ascend
- keep `use_flash_attn` disabled and reject padding-free mode for the `local` and `unfused` backends
- recognize MCore `ColumnParallelLinear` and `RowParallelLinear` when resolving `all-linear` LoRA targets
- preserve the existing flash/Transformer Engine paths

## Root cause

`attention_backend` is normalized to an enum, but the NPU path compared it with the string `"local"`. The comparison therefore enabled MindSpeed flash attention and generated an NPU flash-attention mask even for local attention. Local MCore attention also does not support padding-free packed sequences.

The same legacy condition treated every backend except `local` as flash attention. On NPU this silently routed the explicit `unfused` backend back through MindSpeed FlashAttention. `unfused` now disables the flash flag and generated flash-attention mask while retaining its distinct backend value.

After selecting a true local MCore layer spec, LoRA target discovery found no modules because it only recognized Transformer Engine linear classes. The local parallel linear classes are now included without changing TE targeting.

## Validation

- pre-commit hooks and Python byte-compilation passed for all changed files
- regression coverage covers local padding-free handling and NPU mask selection
- paired mcore-bridge tests cover spec selection, NPU unfused core selection, local norm-weight mapping, and local LoRA dispatch
- A3 validation used SSH user `dxq`, MindSpeed, Megatron Core 0.16.0, BF16, Qwen3-0.6B, a fixed 500-row dataset, `padding_free=false`, and identical seed/configuration for local and flash runs
- every successful run completed 100 optimizer steps, kept loss/grad metrics finite, and saved `checkpoint-100`

| Path | Backend | Steps | Mean loss | Last-10 mean loss | Final cumulative s/it | End-to-end wall time |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| SFT + LoRA | local | 100 | 1.31381 | 1.04523 | 0.10189 | 45 s |
| SFT + LoRA | flash/TE | 100 | 1.30809 | 1.04592 | 0.07201 | 42 s |
| SFT + LoRA | unfused | 100 | 1.30841 | 1.04521 | 0.10207 | 54 s |
| GKD + LoRA, independent frozen teacher | local | 100 | 0.16752 | 0.15426 | 0.10990 | 45 s |
| GKD + LoRA, independent frozen teacher | flash/TE | 100 | 0.16662 | 0.15193 | 0.08711 | 43 s |
| GKD + LoRA, independent frozen teacher | unfused | 100 | 0.16602 | 0.15295 | 0.10008 | 45 s |

All six valid runs completed 100 optimizer steps. SFT unfused/flash per-step loss correlation was 0.99992 with mean absolute delta 0.00546. GKD unfused/flash total-loss correlation was 0.99912 with mean absolute delta 0.00197; JSD-loss correlation was 0.99419. The GKD runs executed separate student and frozen-teacher forwards on every step and logged total loss, JSD loss, SFT loss, and grad norm.

The A3 image required test-only import shims for unused optional `acl`/FLA paths; these are not repository changes. A separate Qwen3-30B-A3B teacher attempt reached local MoE construction but exposed an existing unsupported `MindSpeedGmmExperts` grouped-weight loading layout. The controlled dense student/teacher comparison above keeps the test focused on the attention and LoRA changes in this PR.

Paired PR: https://github.com/modelscope/mcore-bridge/pull/159
