### PR TITLE
fix(qwen3.5): add Torch fallback for Qwen3.5 linear attention SP

### DIFF
--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1228,6 +1228,18 @@ def _get_qwen3_5_cu_seqlens_q():
     return None
 
 
+def _has_multiple_sequences(cu_seqlens) -> bool:
+    """Return whether cumulative sequence lengths describe an actual packed batch."""
+    if cu_seqlens is None:
+        return False
+    if torch.is_tensor(cu_seqlens):
+        return cu_seqlens.numel() > 2
+    try:
+        return len(cu_seqlens) > 2
+    except TypeError:
+        return False
+
+
 def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
     mod: torch.nn.Module,
     hidden_states: torch.Tensor,
@@ -1383,8 +1395,10 @@ def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
             attention_mask: Optional[torch.Tensor] = None,
             **kwargs,
         ):
-            # Transformers may propagate optional FlashAttention kwargs with None values in non-packing paths.
-            if not sequence_parallel.enabled() and kwargs.get('cu_seq_lens_q') is None:
+            # A single sequence can carry degenerate varlen metadata [0, seq_len]. It does not need the Swift
+            # padding-free kernels, which may be unavailable on platforms where the Transformers path still works.
+            cu_seqlens = kwargs.get('cu_seq_lens_q')
+            if not sequence_parallel.enabled() and not _has_multiple_sequences(cu_seqlens):
                 kwargs = {}
                 if 'cache_position' in parameters:
                     kwargs['cache_position'] = cache_position

--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1183,15 +1183,6 @@ def _get_local_padding_mask(attention_mask: torch.Tensor, local_seq_len: int):
     return sequence_parallel.split(attention_mask, dim=1, position_ids=real_position_ids)
 
 
-def _ensure_linear_attention_kernels(mod: torch.nn.Module) -> None:
-    _try_import_flash_linear_attention_kernels()
-    mod._swift_fla_causal_conv1d_fn = causal_conv1d
-    mod.chunk_gated_delta_rule = getattr(mod, 'chunk_gated_delta_rule', None) or chunk_gated_delta_rule
-    if mod.chunk_gated_delta_rule is None or mod._swift_fla_causal_conv1d_fn is None:
-        raise ImportError('Qwen3.5 linear attention padding free/sequence parallel requires flash-linear-attention. '
-                          'Install: https://github.com/fla-org/flash-linear-attention#installation')
-
-
 def _get_local_conv_weights(mod: torch.nn.Module, *, sp_rank: int, local_num_k_heads: int, local_num_v_heads: int):
     conv_weight = mod.conv1d.weight.squeeze(1)
     conv_bias = getattr(mod.conv1d, 'bias', None)
@@ -1240,6 +1231,47 @@ def _has_multiple_sequences(cu_seqlens) -> bool:
         return False
 
 
+def _get_linear_attention_kernels(mod: torch.nn.Module, cu_seqlens):
+    _try_import_flash_linear_attention_kernels()
+    torch_or_fla_chunk_gated_delta_rule = (
+        chunk_gated_delta_rule or getattr(mod.__class__, '_swift_torch_chunk_gated_delta_rule', None)
+        or getattr(mod, 'chunk_gated_delta_rule', None))
+    if torch_or_fla_chunk_gated_delta_rule is None:
+        raise ImportError('Qwen3.5 linear attention requires a gated delta rule implementation. Please install '
+                          'flash-linear-attention or use a transformers version that provides the torch fallback.')
+    if _has_multiple_sequences(cu_seqlens) and (causal_conv1d is None or chunk_gated_delta_rule is None):
+        raise ImportError('Qwen3.5 linear attention packing/padding-free with multiple sequences requires '
+                          'flash-linear-attention; the torch fallback does not support packed sequence boundaries. '
+                          'Install: https://github.com/fla-org/flash-linear-attention#installation')
+    return causal_conv1d, torch_or_fla_chunk_gated_delta_rule
+
+
+def _run_qwen3_5_causal_conv1d(mixed_qkv, conv_weight, conv_bias, activation, cu_seqlens, causal_conv1d_fn):
+    if causal_conv1d_fn is not None:
+        result = causal_conv1d_fn(
+            x=mixed_qkv,
+            weight=conv_weight,
+            bias=conv_bias,
+            activation=activation,
+            cu_seqlens=cu_seqlens,
+        )
+        return result[0] if isinstance(result, tuple) else result
+
+    logger.warning_once('Qwen3.5 linear attention is using the torch causal convolution fallback because '
+                        'flash-linear-attention is unavailable. Training may be slower.')
+    input_dtype = mixed_qkv.dtype
+    mixed_qkv = mixed_qkv.transpose(1, 2)
+    seq_len = mixed_qkv.shape[-1]
+    mixed_qkv = F.conv1d(
+        mixed_qkv.to(conv_weight.dtype),
+        conv_weight.unsqueeze(1),
+        bias=conv_bias,
+        padding=conv_weight.shape[-1] - 1,
+        groups=conv_weight.shape[0],
+    )[..., :seq_len]
+    return F.silu(mixed_qkv).transpose(1, 2).to(input_dtype)
+
+
 def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
     mod: torch.nn.Module,
     hidden_states: torch.Tensor,
@@ -1249,7 +1281,6 @@ def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
     attention_mask: Optional[torch.Tensor] = None,
     **kwargs,
 ) -> torch.Tensor:
-    _ensure_linear_attention_kernels(mod)
     apply_mask_to_padding_states = mod.__class__._apply_mask_to_padding_states
 
     local_attention_mask = attention_mask
@@ -1307,21 +1338,14 @@ def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
         conv_weight = mod.conv1d.weight.squeeze(1)
         conv_bias = getattr(mod.conv1d, 'bias', None)
 
-    if sp_enabled:
-        cu_seqlens = _get_qwen3_5_cu_seqlens_q()
-    else:
-        cu_seqlens = kwargs.get('cu_seq_lens_q')
+    cu_seqlens = _get_qwen3_5_cu_seqlens_q() if sp_enabled else kwargs.get('cu_seq_lens_q')
+    causal_conv1d_fn, selected_chunk_gated_delta_rule = _get_linear_attention_kernels(mod, cu_seqlens)
 
     if cache_params is not None:
         cache_params.conv_states[mod.layer_idx] = F.pad(
             mixed_qkv.transpose(1, 2).contiguous(), (mod.conv_kernel_size - mixed_qkv.shape[1], 0))
-    mixed_qkv, _ = mod._swift_fla_causal_conv1d_fn(
-        x=mixed_qkv,
-        weight=conv_weight,
-        bias=conv_bias,
-        activation=mod.activation,
-        cu_seqlens=cu_seqlens,
-    )
+    mixed_qkv = _run_qwen3_5_causal_conv1d(mixed_qkv, conv_weight, conv_bias, mod.activation, cu_seqlens,
+                                           causal_conv1d_fn)
     if mixed_qkv.dim() == 2:
         mixed_qkv = mixed_qkv.unsqueeze(0)
     if mixed_qkv.dim() != 3:
@@ -1350,9 +1374,10 @@ def _run_qwen3_5_gated_delta_net_sequence_parallel_forward(
         'output_final_state': cache_params is not None,
         'use_qk_l2norm_in_kernel': True,
     }
-    if cu_seqlens is not None:
+    # transformers==5.2 torch_chunk_gated_delta_rule has no **kwargs, and later torch fallbacks ignore cu_seqlens.
+    if cu_seqlens is not None and selected_chunk_gated_delta_rule is chunk_gated_delta_rule:
         chunk_kwargs['cu_seqlens'] = cu_seqlens
-    core_attn_out, last_recurrent_state = mod.chunk_gated_delta_rule(query, key, value, **chunk_kwargs)
+    core_attn_out, last_recurrent_state = selected_chunk_gated_delta_rule(query, key, value, **chunk_kwargs)
 
     if cache_params is not None:
         cache_params.recurrent_states[mod.layer_idx] = last_recurrent_state
@@ -1375,15 +1400,18 @@ def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
             modeling_module = import_module(module_name)
             gated_delta_net_cls = getattr(modeling_module, class_name)
             apply_mask_to_padding_states = getattr(modeling_module, 'apply_mask_to_padding_states')
-            gated_delta_net_specs.append((gated_delta_net_cls, apply_mask_to_padding_states))
+            torch_chunk_gated_delta_rule = getattr(modeling_module, 'torch_chunk_gated_delta_rule', None)
+            gated_delta_net_specs.append(
+                (gated_delta_net_cls, apply_mask_to_padding_states, torch_chunk_gated_delta_rule))
         except Exception:
             pass
 
-    def patch_gated_delta_net(gated_delta_net_cls, apply_mask_to_padding_states):
+    def patch_gated_delta_net(gated_delta_net_cls, apply_mask_to_padding_states, torch_chunk_gated_delta_rule):
         if getattr(gated_delta_net_cls, '_ms_swift_sp_linear_patched', False):
             return
 
         gated_delta_net_cls._apply_mask_to_padding_states = apply_mask_to_padding_states
+        gated_delta_net_cls._swift_torch_chunk_gated_delta_rule = torch_chunk_gated_delta_rule
         origin_forward = gated_delta_net_cls.forward
         parameters = inspect.signature(origin_forward).parameters
 
@@ -1428,8 +1456,8 @@ def _patch_qwen3_5_linear_attention_sequence_parallel() -> None:
         gated_delta_net_cls.forward = sp_linear_forward
         gated_delta_net_cls._ms_swift_sp_linear_patched = True
 
-    for gated_delta_net_cls, apply_mask_to_padding_states in gated_delta_net_specs:
-        patch_gated_delta_net(gated_delta_net_cls, apply_mask_to_padding_states)
+    for gated_delta_net_cls, apply_mask_to_padding_states, torch_chunk_gated_delta_rule in gated_delta_net_specs:
+        patch_gated_delta_net(gated_delta_net_cls, apply_mask_to_padding_states, torch_chunk_gated_delta_rule)
 
 
 class Qwen3_5MoeLoader(Qwen3VLLoader):


### PR DESCRIPTION

# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Qwen3.5 开启 Sequence Parallel 后，即使没有使用真实 packing，也会强制依赖 FLA。在 FLA 不可用的平台上会直接报错。

本 PR 主要修改：

- 区分单序列退化 varlen 和真实多序列 packing。
- 未开启 SP 且只有单序列时，回到 Transformers 原始 forward。
- SP 非 packing 场景下，FLA 不可用时使用 Torch causal-conv 和 Transformers Torch gated-delta。
- 兼容 Transformers 5.2–5.14 和 5.15-dev 的 gated-delta 接口。
- 真实 packing 缺少 FLA 时明确报错，避免不同样本之间发生状态污染。
- FLA 可用时继续使用原有高性能路径。

## Experiment results

| ID | Transformers | FLA | SP size | padding_free | packing | Batch | 预期 | 结果 |
|---|---|---:|---:|---:|---:|---:|---|---|
| T1 | 5.2.0 | 无 | 1 | false | false | 1 | 退化 varlen 回到原始 forward | 通过 |
| T2 | 5.2.0 | 无 | 2 | false | false | 1 | SP 使用 Torch fallback | 通过 |
| T3 | 5.15-dev | 无 | 2 | false | false | 1 | 使用模块级 Torch gated-delta | 通过 |
| T4 | 5.14.1 | 无 | 1 | true | false | 2 | 明确抛出 packing 需要 FLA 的异常 | 通过 |
| T5 | 5.14.1 | 完整 | 2 | true | false | 2 | SP + varlen 使用 FLA 正常训练 | 通过 |

## no sp
{"loss": 3.17615938, "grad_norm": 22.90113068, "learning_rate": 5e-06, "token_acc": 0.37837838, "epoch": 0.00925926, "global_step/max_steps": "1/2", "elapsed_time": "3s", "remaining_time": "3s", "memory(GiB)": 2.11, "train_speed(s/it)": 2.854934}
{"loss": 1.44239843, "grad_norm": 12.0806818, "learning_rate": 0.0, "token_acc": 0.72727273, "epoch": 0.01851852, "global_step/max_steps": "2/2", "elapsed_time": "4s", "remaining_time": "0s", "memory(GiB)": 2.31, "train_speed(s/it)": 2.022513}
{"train_runtime": 4.0563, "train_samples_per_second": 0.493, "train_steps_per_second": 0.493, "total_flos": 412006097664.0, "train_loss": 2.30927891, "epoch": 0.01851852, "global_step/max_steps": "2/2", "elapsed_time": "4s", "remaining_time": "0s", "memory(GiB)": 2.31, "train_speed(s/it)": 2.025727}
{"model_parameter_info": "PeftModelForCausalLM: 858.3972M Params (5.4113M Trainable [0.6304%]), 0.0001M Buffers.", "last_model_checkpoint": null, "best_model_checkpoint": null, "best_metric": null, "global_step": 2, "log_history": [{"loss": 3.176159381866455, "grad_norm": 22.90113067626953, "learning_rate": 5e-06, "token_acc": 0.3783783783783784, "epoch": 0.009259259259259259, "step": 1}, {"loss": 1.4423984289169312, "grad_norm": 12.080681800842285, "learning_rate": 0.0, "token_acc": 0.7272727272727273, "epoch": 0.018518518518518517, "step": 2}, {"train_runtime": 4.0563, "train_samples_per_second": 0.493, "train_steps_per_second": 0.493, "total_flos": 412006097664.0, "train_loss": 2.309278905391693, "epoch": 0.018518518518518517, "step": 2}], "memory": 2.306640625}
## sp
{"loss": 3.17615938, "grad_norm": 22.89281654, "learning_rate": 5e-06, "token_acc": 0.37837838, "epoch": 0.00925926, "global_step/max_steps": "1/2", "elapsed_time": "4s", "remaining_time": "4s", "memory(GiB)": 2.72, "train_speed(s/it)": 3.965917}
{"loss": 1.44452775, "grad_norm": 12.14474583, "learning_rate": 0.0, "token_acc": 0.75, "epoch": 0.01851852, "global_step/max_steps": "2/2", "elapsed_time": "5s", "remaining_time": "0s", "memory(GiB)": 2.78, "train_speed(s/it)": 2.708679}
{"train_runtime": 5.4753, "train_samples_per_second": 0.731, "train_steps_per_second": 0.365, "total_flos": 824012210176.0, "train_loss": 2.31034356, "epoch": 0.01851852, "global_step/max_steps": "2/2", "elapsed_time": "5s", "remaining_time": "0s", "memory(GiB)": 2.78, "train_speed(s/it)": 2.714195}
{"model_parameter_info": "PeftModelForCausalLM: 858.3972M Params (5.4113M Trainable [0.6304%]), 0.0001M Buffers.", "last_model_checkpoint": null, "best_model_checkpoint": null, "best_metric": null, "global_step": 2, "log_history": [{"loss": 3.176159381866455, "grad_norm": 22.8928165435791, "learning_rate": 5e-06, "token_acc": 0.3783783783783784, "epoch": 0.009259259259259259, "step": 1}, {"loss": 1.4445277452468872, "grad_norm": 12.144745826721191, "learning_rate": 0.0, "token_acc": 0.75, "epoch": 0.018518518518518517, "step": 2}, {"train_runtime": 5.4753, "train_samples_per_second": 0.731, "train_steps_per_second": 0.365, "total_flos": 824012210176.0, "train_loss": 2.310343563556671, "epoch": 0.018518518518518517, "step": 2}], "memory": 2.775390625}
