### PR TITLE
[Infer] Fix transformers streaming logprobs

### DIFF
--- a/swift/infer_engine/transformers_engine.py
+++ b/swift/infer_engine/transformers_engine.py
@@ -255,7 +255,8 @@ class TransformersEngine(InferEngine):
 
         logits_streamer = None
         if generation_config.output_logits:
-            generate_kwargs['logits_processor'] = LogitsProcessorList([LogitsStreamer()])
+            logits_streamer = LogitsStreamer()
+            generate_kwargs['logits_processor'] = LogitsProcessorList([logits_streamer])
 
         def _model_generate(**kwargs):
             if is_torch_npu_available():


### PR DESCRIPTION
## Summary

- retain the `LogitsStreamer` instance used by PT/Transformers generation so streaming responses can consume its logits

## Root cause

The PT streaming path constructed `LogitsStreamer()` inline inside `LogitsProcessorList`, while the local `logits_streamer` variable remained `None`. The collection path therefore returned early for every streamed chunk, and `logprobs` was serialized as `null`.

## Impact

Requests using the Transformers backend with both `stream=true` and `logprobs=true` now return populated logprobs. Non-streaming inference and streaming requests without logprobs are unchanged.

## Validation

- `python -m py_compile swift/infer_engine/transformers_engine.py`
- `git diff --check upstream/main...HEAD`
