### PR TITLE
[Infer] Optimize Transformers logprobs top-k

### DIFF
--- a/swift/infer_engine/transformers_engine.py
+++ b/swift/infer_engine/transformers_engine.py
@@ -206,21 +206,38 @@ class TransformersEngine(InferEngine):
     @staticmethod
     def preprocess_logits(batched_logits: Optional[List[torch.Tensor]], batched_generate_ids: torch.Tensor,
                           top_logprobs: Optional[int]):
-        top_logprobs = top_logprobs or 1
         batch_size = batched_generate_ids.shape[0]
         if batched_logits is None:
             return None
-        batched_logprobs = []
-        for i in range(batch_size):
-            logprobs_list = []
-            generate_ids = batched_generate_ids[i]
-            for j, logits in enumerate(batched_logits):
-                token = generate_ids[j].item()
-                logprobs = torch.log_softmax(logits[i], -1)
-                tokens = [token] + logprobs.argsort(descending=True, dim=-1)[:top_logprobs].tolist()
-                logprobs_list.append({token: logprobs[token].item() for token in tokens})
-            batched_logprobs.append(logprobs_list)
-        return batched_logprobs
+        if not batched_logits:
+            return [[] for _ in range(batch_size)]
+
+        # Keep the existing internal contract: the sampled token and at least the top-1 token are retained.
+        num_top_logprobs = max(top_logprobs or 1, 0)
+        num_top_logprobs = min(num_top_logprobs, batched_logits[0].shape[-1])
+        token_ids_list = []
+        logprobs_list = []
+        for i, logits in enumerate(batched_logits):
+            sampled_ids = batched_generate_ids[:, i].to(logits.device)
+            logprobs = torch.log_softmax(logits, dim=-1)
+            sampled_logprobs = logprobs.gather(-1, sampled_ids[:, None]).squeeze(-1)
+
+            if num_top_logprobs:
+                top_logprob_values, top_ids = torch.topk(logprobs, num_top_logprobs, dim=-1)
+                sampled_ids = torch.cat((sampled_ids[:, None], top_ids), dim=-1)
+                sampled_logprobs = torch.cat((sampled_logprobs[:, None], top_logprob_values), dim=-1)
+            else:
+                sampled_ids = sampled_ids[:, None]
+                sampled_logprobs = sampled_logprobs[:, None]
+            token_ids_list.append(sampled_ids)
+            # The result is converted to Python values below, so retaining an autograd graph only wastes memory.
+            logprobs_list.append(sampled_logprobs.detach())
+
+        # Transfer only the selected token ids and logprobs instead of synchronizing once per token.
+        token_ids_list = torch.stack(token_ids_list, dim=1).cpu().tolist()
+        logprobs_list = torch.stack(logprobs_list, dim=1).cpu().tolist()
+        return [[dict(zip(token_ids, logprobs)) for token_ids, logprobs in zip(batch_ids, batch_logprobs)]
+                for batch_ids, batch_logprobs in zip(token_ids_list, logprobs_list)]
 
     @staticmethod
     def _update_batched_logprobs(batched_logprobs: List[torch.Tensor], logits_streamer: Optional[LogitsStreamer],

--- a/tests/infer/test_transformers_engine_logprobs_unit.py
+++ b/tests/infer/test_transformers_engine_logprobs_unit.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+
+
+def _assert_preprocessed_logprobs(result, batched_logits, sampled_ids, top_logprobs):
+    for step, logits in enumerate(batched_logits):
+        expected = torch.log_softmax(logits, dim=-1)
+        k = min(top_logprobs or 1, logits.shape[-1])
+        expected_top_ids = torch.topk(expected, k, dim=-1).indices
+        for batch in range(logits.shape[0]):
+            sampled_id = sampled_ids[batch, step].item()
+            expected_ids = {sampled_id}
+            expected_ids.update(expected_top_ids[batch].tolist())
+
+            assert result[batch][step].keys() == expected_ids
+            for token_id, logprob in result[batch][step].items():
+                assert logprob == pytest.approx(expected[batch, token_id].item(), abs=1e-6)
+
+
+@pytest.mark.parametrize('dtype', [torch.float16, torch.float64])
+@pytest.mark.parametrize('top_logprobs', [None, 0, 2, 10])
+def test_preprocess_logits_matches_log_softmax(top_logprobs, dtype):
+    from swift.infer_engine import TransformersEngine
+
+    batched_logits = [
+        torch.tensor([[0.1, 0.2, 2.0, -1.0], [3.0, 0.5, -0.5, 1.0]], dtype=dtype),
+        torch.tensor([[1.5, -1.0, 0.0, 2.5], [-2.0, 1.0, 2.0, 0.5]], dtype=dtype),
+    ]
+    # Cover sampled tokens both inside and outside the requested top-k.
+    sampled_ids = torch.tensor([[0, 3], [3, 0]])
+
+    result = TransformersEngine.preprocess_logits(batched_logits, sampled_ids, top_logprobs)
+
+    _assert_preprocessed_logprobs(result, batched_logits, sampled_ids, top_logprobs)
+
+
+def test_preprocess_logits_handles_missing_and_empty_logits():
+    from swift.infer_engine import TransformersEngine
+
+    sampled_ids = torch.empty((2, 0), dtype=torch.long)
+    assert TransformersEngine.preprocess_logits(None, sampled_ids, 2) is None
+    assert TransformersEngine.preprocess_logits([], sampled_ids, 2) == [[], []]


### PR DESCRIPTION
## Summary

- replace full-vocabulary `argsort` with `topk` in Transformers logprob preprocessing
- vectorize preprocessing across the batch for each generation step
- gather sampled-token logprobs in batch and transfer only compact sampled/top-k results to CPU
- add focused unit coverage for dtype, top-k boundary, sampled-token, and empty-input behavior

## Root cause

`preprocess_logits` applied `argsort` to the entire vocabulary for every batch item and generated token even when only a small top-k was requested. It also called `.item()` and `.tolist()` repeatedly inside the per-token loop, introducing fine-grained GPU-to-CPU synchronization.

## Implementation

The optimized path keeps the existing fused `log_softmax` calculation to preserve FP16 numerical behavior. It applies `topk` to each `[B, V]` generation-step tensor, gathers sampled-token logprobs across the batch, accumulates only the selected values, and converts them to Python objects after GPU work is complete.

The implementation deliberately processes the existing list of `[B, V]` tensors by generation step instead of materializing an additional full `[B, T, V]` tensor.

## Impact

Both streaming and non-streaming Transformers logprob preprocessing avoid full-vocabulary sorting and per-token synchronization while preserving the existing result structure.

A synthetic FP16 benchmark with a 151,936-token vocabulary measured 1.6x to 7.25x faster preprocessing across the tested batch/sequence shapes.

## Validation

- `python -m pytest -q tests/infer/test_transformers_engine_logprobs_unit.py` — 9 passed
- old/new output equality on random FP16, FP32, and FP64 inputs
- `ruff check --select E,F --line-length 120 swift/infer_engine/transformers_engine.py tests/infer/test_transformers_engine_logprobs_unit.py`
- `yapf --style setup.cfg --diff swift/infer_engine/transformers_engine.py tests/infer/test_transformers_engine_logprobs_unit.py`
- `python -m py_compile swift/infer_engine/transformers_engine.py tests/infer/test_transformers_engine_logprobs_unit.py`
- `git diff --check upstream/main...HEAD`
