### PR TITLE
fix(infer): validate explicit tool choices

### DIFF
--- a/swift/infer_engine/protocol.py
+++ b/swift/infer_engine/protocol.py
@@ -247,7 +247,7 @@ class ChatCompletionRequestMixin:
                 self.tools = None
             elif isinstance(self.tool_choice, dict):
                 name = self.tool_choice['function']['name']
-                tool = next(tool for tool in self.tools if tool['function']['name'] == name)
+                tool = next((tool for tool in self.tools if tool['function']['name'] == name), None)
                 if tool is None:
                     raise ValueError(f"Tool choice '{name}' not found in tools.")
                 self.tools = [tool]

--- a/tests/infer/test_protocol.py
+++ b/tests/infer/test_protocol.py
@@ -1,0 +1,57 @@
+import unittest
+
+from swift.infer_engine.protocol import ChatCompletionRequest
+
+
+class TestChatCompletionRequest(unittest.TestCase):
+
+    @staticmethod
+    def _tool(name):
+        return {
+            'type': 'function',
+            'function': {
+                'name': name,
+                'description': f'Call {name}',
+                'parameters': {},
+            },
+        }
+
+    def test_rejects_unknown_explicit_tool_choice(self):
+        with self.assertRaisesRegex(ValueError, "Tool choice 'missing' not found in tools"):
+            ChatCompletionRequest(
+                model='test',
+                messages=[{
+                    'role': 'user',
+                    'content': 'hello',
+                }],
+                tools=[self._tool('weather')],
+                tool_choice={
+                    'type': 'function',
+                    'function': {
+                        'name': 'missing',
+                    },
+                },
+            )
+
+    def test_keeps_only_explicit_tool_choice(self):
+        weather = self._tool('weather')
+        request = ChatCompletionRequest(
+            model='test',
+            messages=[{
+                'role': 'user',
+                'content': 'hello',
+            }],
+            tools=[weather, self._tool('calculator')],
+            tool_choice={
+                'type': 'function',
+                'function': {
+                    'name': 'weather',
+                },
+            },
+        )
+
+        self.assertEqual(request.tools, [weather])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

An explicit `tool_choice` can name a function that is absent from the
request's `tools` list. `ChatCompletionRequestMixin` intended to report this
as a `ValueError`, but `next()` raised `StopIteration` before the validation
branch could run.

This change gives `next()` a `None` default so the existing, actionable error
is raised:

```text
ValueError: Tool choice 'missing' not found in tools.
```

Valid explicit choices retain the existing behavior of narrowing `tools` to
the selected function. Automatic and disabled tool selection are unchanged.

## Experiment results

Before:

```text
StopIteration: <empty message>
```

After:

```text
ValueError: Tool choice 'missing' not found in tools.
```

Verification:

```text
.venv/bin/python tests/run.py --test_dir tests/infer --pattern test_protocol.py
SUCCESS (Runs=2, success=2)

.venv/bin/pre-commit run --files swift/infer_engine/protocol.py tests/infer/test_protocol.py
All hooks passed
```
