### PR TITLE
Optimize logprob computation in Transformers inference and GRPO

### DIFF
--- a/swift/infer_engine/transformers_engine.py
+++ b/swift/infer_engine/transformers_engine.py
@@ -206,21 +206,38 @@ class TransformersEngine(InferEngine):
     @staticmethod
     def preprocess_logits(batched_logits: Optional[List[torch.Tensor]], batched_generate_ids: torch.Tensor,
                           top_logprobs: Optional[int]):
-        top_logprobs = top_logprobs or 1
         batch_size = batched_generate_ids.shape[0]
         if batched_logits is None:
             return None
-        batched_logprobs = []
-        for i in range(batch_size):
-            logprobs_list = []
-            generate_ids = batched_generate_ids[i]
-            for j, logits in enumerate(batched_logits):
-                token = generate_ids[j].item()
-                logprobs = torch.log_softmax(logits[i], -1)
-                tokens = [token] + logprobs.argsort(descending=True, dim=-1)[:top_logprobs].tolist()
-                logprobs_list.append({token: logprobs[token].item() for token in tokens})
-            batched_logprobs.append(logprobs_list)
-        return batched_logprobs
+        if not batched_logits:
+            return [[] for _ in range(batch_size)]
+
+        # Keep the existing internal contract: the sampled token and at least the top-1 token are retained.
+        num_top_logprobs = max(top_logprobs or 1, 0)
+        num_top_logprobs = min(num_top_logprobs, batched_logits[0].shape[-1])
+        token_ids_list = []
+        logprobs_list = []
+        for i, logits in enumerate(batched_logits):
+            sampled_ids = batched_generate_ids[:, i].to(logits.device)
+            logprobs = torch.log_softmax(logits, dim=-1)
+            sampled_logprobs = logprobs.gather(-1, sampled_ids[:, None]).squeeze(-1)
+
+            if num_top_logprobs:
+                top_logprob_values, top_ids = torch.topk(logprobs, num_top_logprobs, dim=-1)
+                sampled_ids = torch.cat((sampled_ids[:, None], top_ids), dim=-1)
+                sampled_logprobs = torch.cat((sampled_logprobs[:, None], top_logprob_values), dim=-1)
+            else:
+                sampled_ids = sampled_ids[:, None]
+                sampled_logprobs = sampled_logprobs[:, None]
+            token_ids_list.append(sampled_ids)
+            # The result is converted to Python values below, so retaining an autograd graph only wastes memory.
+            logprobs_list.append(sampled_logprobs.detach())
+
+        # Transfer only the selected token ids and logprobs instead of synchronizing once per token.
+        token_ids_list = torch.stack(token_ids_list, dim=1).cpu().tolist()
+        logprobs_list = torch.stack(logprobs_list, dim=1).cpu().tolist()
+        return [[dict(zip(token_ids, logprobs)) for token_ids, logprobs in zip(batch_ids, batch_logprobs)]
+                for batch_ids, batch_logprobs in zip(token_ids_list, logprobs_list)]
 
     @staticmethod
     def _update_batched_logprobs(batched_logprobs: List[torch.Tensor], logits_streamer: Optional[LogitsStreamer],

--- a/swift/rlhf_trainers/grpo_trainer.py
+++ b/swift/rlhf_trainers/grpo_trainer.py
@@ -764,6 +764,14 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
                 if is_opsd:
                     teacher_model_inputs, teacher_grpo_batch = self._collate_teacher_opsd_batch(batch, template)
 
+            need_local_teacher = should_compute_local_teacher_logps(
+                has_teacher_explicit=self._has_teacher_explicit(),
+                is_dynamic_self_distillation=self._is_dynamic_self_distillation,
+                use_teacher_api=self.use_teacher_api,
+                has_opsd_batch=is_opsd,
+            )
+            need_old_policy = self._needs_old_per_token_logps(grpo_batch, need_local_teacher)
+
             model_inputs.pop('labels', None)
             batch_encoded_inputs = {'model_inputs': model_inputs, 'grpo_batch': grpo_batch}
             if self.dynamic_num_samples and self.is_multimodal:
@@ -774,10 +782,16 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
                 batch_encoded_inputs['_chunk_samples'] = batch
             origin_data = batch if (self.dynamic_num_samples and self.is_multimodal) else None
 
-            with torch.no_grad(), disable_gradient_checkpointing(self.model, self.args.gradient_checkpointing_kwargs):
-                grpo_batch.old_per_token_logps = (
-                    self._get_per_token_logps_and_entropies(
-                        self.model, model_inputs, grpo_batch, origin_data=origin_data)[0])
+            need_student_inference = need_old_policy or (self.beta != 0.0 and self.ref_model is None)
+            student_inference_context = (disable_gradient_checkpointing(
+                self.model, self.args.gradient_checkpointing_kwargs) if need_student_inference else nullcontext())
+            with torch.no_grad(), student_inference_context:
+                if need_old_policy:
+                    grpo_batch.old_per_token_logps = (
+                        self._get_per_token_logps_and_entropies(
+                            self.model, model_inputs, grpo_batch, origin_data=origin_data)[0])
+                else:
+                    grpo_batch.old_per_token_logps = None
                 if self.beta == 0.0:
                     ref_per_token_logps = None
                 elif self.ref_model is not None:
@@ -792,12 +806,7 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
                                 self.model, model_inputs, grpo_batch, origin_data=origin_data)[0]
                 grpo_batch.ref_per_token_logps = ref_per_token_logps
                 # OPD-RL: local teacher logp on the sampled tokens (API path filled later).
-                if should_compute_local_teacher_logps(
-                        has_teacher_explicit=self._has_teacher_explicit(),
-                        is_dynamic_self_distillation=self._is_dynamic_self_distillation,
-                        use_teacher_api=self.use_teacher_api,
-                        has_opsd_batch=is_opsd,
-                ):
+                if need_local_teacher:
                     grpo_batch.teacher_per_token_logps = self._compute_teacher_logps(
                         model_inputs,
                         grpo_batch,
@@ -1820,12 +1829,28 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
         return super().training_step(model, inputs, num_items_in_batch)
 
     def old_policy(self):
-        if self.template.sequence_parallel_size == 1:
-            return (self.num_iterations > 1
-                    or self.args.gradient_accumulation_steps % self.args.steps_per_generation != 0)
-        else:
-            return (self.num_iterations > 1 or self.args.gradient_accumulation_steps %
-                    (self.args.steps_per_generation * sequence_parallel.world_size) != 0)
+        if not self.model.training:
+            return False
+
+        # gradient_accumulation_steps is SP-scaled in __init__, so both values
+        # below are expressed in the trainer's internal micro-step unit.
+        generate_every = (self.args.steps_per_generation * self.template.sequence_parallel_size
+                          * self.num_iterations)
+        return self.args.gradient_accumulation_steps % generate_every != 0
+
+    def _needs_old_per_token_logps(self, grpo_batch: GRPOBatch, need_local_teacher: bool) -> bool:
+        """Whether ``old_per_token_logps`` must exist before the training loss forward."""
+        need_liger_rollout_old = False
+        liger_rollout_correction_enabled = (self.use_liger_loss
+                                            and self.rollout_importance_sampling_mode is not None
+                                            and not self.disable_rollout_importance_sampling)
+        if liger_rollout_correction_enabled:
+            local_has_rollout_logps = grpo_batch.rollout_per_token_logps is not None
+            need_liger_rollout_old = all(gather_object([local_has_rollout_logps]))
+
+        need_old_policy = (self.old_policy() or (self.kl_in_reward and self.beta != 0.0) or need_local_teacher
+                           or (self._has_teacher and self.use_teacher_api) or need_liger_rollout_old)
+        return need_old_policy
 
     @contextmanager
     def offload_context(self):

--- a/tests/infer/test_transformers_engine_logprobs_unit.py
+++ b/tests/infer/test_transformers_engine_logprobs_unit.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+
+
+def _assert_preprocessed_logprobs(result, batched_logits, sampled_ids, top_logprobs):
+    for step, logits in enumerate(batched_logits):
+        expected = torch.log_softmax(logits, dim=-1)
+        k = min(top_logprobs or 1, logits.shape[-1])
+        expected_top_ids = torch.topk(expected, k, dim=-1).indices
+        for batch in range(logits.shape[0]):
+            sampled_id = sampled_ids[batch, step].item()
+            expected_ids = {sampled_id}
+            expected_ids.update(expected_top_ids[batch].tolist())
+
+            assert result[batch][step].keys() == expected_ids
+            for token_id, logprob in result[batch][step].items():
+                assert logprob == pytest.approx(expected[batch, token_id].item(), abs=1e-6)
+
+
+@pytest.mark.parametrize('dtype', [torch.float16, torch.float64])
+@pytest.mark.parametrize('top_logprobs', [None, 0, 2, 10])
+def test_preprocess_logits_matches_log_softmax(top_logprobs, dtype):
+    from swift.infer_engine import TransformersEngine
+
+    batched_logits = [
+        torch.tensor([[0.1, 0.2, 2.0, -1.0], [3.0, 0.5, -0.5, 1.0]], dtype=dtype),
+        torch.tensor([[1.5, -1.0, 0.0, 2.5], [-2.0, 1.0, 2.0, 0.5]], dtype=dtype),
+    ]
+    # Cover sampled tokens both inside and outside the requested top-k.
+    sampled_ids = torch.tensor([[0, 3], [3, 0]])
+
+    result = TransformersEngine.preprocess_logits(batched_logits, sampled_ids, top_logprobs)
+
+    _assert_preprocessed_logprobs(result, batched_logits, sampled_ids, top_logprobs)
+
+
+def test_preprocess_logits_handles_missing_and_empty_logits():
+    from swift.infer_engine import TransformersEngine
+
+    sampled_ids = torch.empty((2, 0), dtype=torch.long)
+    assert TransformersEngine.preprocess_logits(None, sampled_ids, 2) is None
+    assert TransformersEngine.preprocess_logits([], sampled_ids, 2) == [[], []]


### PR DESCRIPTION
## Summary

- Vectorize `TransformersEngine` logprob post-processing with batched `topk`, gather, and host transfer operations.
- Skip GRPO old-policy logprob forwards when the rollout lifecycle is aligned with optimizer updates.
- Preserve eager old-policy logprobs only for pre-forward consumers: reward KL, teacher/OPSD paths, and enabled Liger rollout correction.
- Avoid toggling gradient checkpointing when no student inference forward is required.

## Motivation

The Transformers rollout path previously sorted the full vocabulary and synchronized individual token values to the host. GRPO also computed old-policy logprobs unconditionally, even when the policy could not change during the rollout lifecycle and the loss can reuse detached current-policy logprobs.

The new GRPO gate uses the full generation interval:

```text
steps_per_generation * sequence_parallel_size * num_iterations
```

and keeps the extra forward only when the interval can cross an optimizer update or another consumer needs old logprobs before the training forward.

## Impact

On a controlled RTX A1000 BF16 benchmark with a 33.6M-parameter Qwen2 model, batch size 4 and sequence length 512, removing the redundant old-policy forward improved effective policy-training throughput by:

- 32.5% for `num_iterations=1`
- 16.1% for `num_iterations=2`
- 8.0% for `num_iterations=4`

The improvement decreases as expected when the single old-policy forward is amortized over more training iterations.

## Validation

- `pytest -q tests/infer/test_transformers_engine_logprobs_unit.py`
- Local GRPO old-policy gate matrix: 5 tests and 5 subtests passed
- Teacher/OPSD routing suite: 27 tests passed
- `git diff --check`
