### PR TITLE
fix(grpo): make revert_runtime_names_to_checkpoint idempotent to avoid double-expanding prefix renamings during vLLM weight sync

### DIFF
--- a/swift/rlhf_trainers/utils.py
+++ b/swift/rlhf_trainers/utils.py
@@ -1191,6 +1191,21 @@ def revert_runtime_names_to_checkpoint(model, state_dict):
     for name, param in state_dict.items():
         try:
             new_name, _ = rename_source_key(name, reverse_renamings, [])
+            # Guard against over-matching reverse rules. Prefix-anchored
+            # renamings such as ``^model.language_model <-> model`` invert to
+            # ``^model -> model.language_model``; that reverse rule ALSO matches
+            # runtime names that are already in checkpoint form (e.g. Qwen3.5-MoE
+            # ``model.language_model.layers...``), re-expanding the prefix into
+            # ``model.language_model.language_model...`` and corrupting every key.
+            # A genuine runtime->checkpoint revert is idempotent: re-applying the
+            # reverse rules must not change the name again. If it keeps growing,
+            # the name was already a checkpoint name and must be left untouched,
+            # otherwise vLLM weight sync fails with KeyError on e.g.
+            # 'language_model.language_model...experts.w13_weight'.
+            if new_name != name:
+                reapplied, _ = rename_source_key(new_name, reverse_renamings, [])
+                if reapplied != new_name:
+                    new_name = name
         except Exception:
             new_name = name
         new_state_dict[new_name] = param


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## What does this PR do?

Fixes a crash in GRPO online weight sync (colocated vLLM) for models whose
transformers>=5 `WeightRenaming` rule is a **prefix substitution** — most
notably **Qwen3.5-MoE** (`qwen3_5_moe`).

`revert_runtime_names_to_checkpoint()` applies the *reversed* renaming rule
unconditionally. For prefix-anchored renames the reversed rule also matches
names that are **already in checkpoint form**, re-expanding the prefix a second
time and corrupting every parameter name. The corrupted names then fail to load
into vLLM.

GRPO training of Qwen3.5-MoE currently crashes on the first rollout weight sync
(before any optimization step), for both LoRA and full tuning:

```
KeyError: 'language_model.language_model.layers.0.mlp.experts.w13_weight'
```

## Root cause

`_build_reverse_renamings(model)` inverts each transformers `WeightRenaming` via
`reverse_transform()`. For Qwen3.5-MoE the forward rule is:

```
source: ^model.language_model   ->   target: model
```

so the reversed rule becomes:

```
^model   ->   model.language_model
```

At weight-sync time the runtime `state_dict` already carries checkpoint-form
names such as `model.language_model.layers.0.mlp.experts.gate_up_proj`. Applying
the reversed rule `^model -> model.language_model` to a name that *already*
begins with `model.language_model` matches the leading `model` and re-expands it:

```
model.language_model.layers.0...   ->   model.language_model.language_model.layers.0...
```

After vLLM's `hf_to_vllm_mapper` (`model.language_model. -> language_model.model.`)
this reaches the vLLM model as `language_model.language_model...experts.w13_weight`,
and the fused-expert loader's `params_dict[name]` lookup raises `KeyError`.

The current loop applies the reverse rule blindly, with no protection against
over-matching:

```python
new_state_dict = {}
for name, param in state_dict.items():
    try:
        new_name, _ = rename_source_key(name, reverse_renamings, [])
    except Exception:
        new_name = name
    new_state_dict[new_name] = param
return new_state_dict
```

This regression was introduced together with the function in #9572
("fix gemma4-12b weight sync"). It is correct for gemma4's 1:1 rename
(`model.vision_embedder ↔ model.embed_vision`, which is idempotent under the
reverse rule) but breaks on prefix-anchored renames.

## The fix

A legitimate runtime→checkpoint revert is **idempotent**: applying the reverse
rules to a name that is already in checkpoint form must be a no-op. We detect
over-matching by re-applying the reverse rules once — if the name keeps changing,
it was already a checkpoint name and we keep the original.

```python
new_state_dict = {}
for name, param in state_dict.items():
    try:
        new_name, _ = rename_source_key(name, reverse_renamings, [])
        # Guard against over-matching reverse rules. Prefix-anchored renamings
        # such as ``^model.language_model <-> model`` invert to
        # ``^model -> model.language_model``; that reverse rule ALSO matches
        # runtime names that are already in checkpoint form (e.g. Qwen3.5-MoE
        # ``model.language_model.layers...``), re-expanding the prefix into
        # ``model.language_model.language_model...`` and corrupting every key.
        # A genuine runtime->checkpoint revert is idempotent: re-applying the
        # reverse rules must not change the name again. If it keeps growing,
        # the name was already a checkpoint name and must be left untouched,
        # otherwise vLLM weight sync fails with KeyError on e.g.
        # 'language_model.language_model...experts.w13_weight'.
        if new_name != name:
            reapplied, _ = rename_source_key(new_name, reverse_renamings, [])
            if reapplied != new_name:
                new_name = name
    except Exception:
        new_name = name
    new_state_dict[new_name] = param
return new_state_dict
```

The change is fully localized to `revert_runtime_names_to_checkpoint()` and does
not touch the reverse-rule construction, the vLLM mapper, or the MoE weight
loaders.

## Affected file

- `swift/rlhf_trainers/utils.py` — `revert_runtime_names_to_checkpoint()`

## How was it tested?

- **Unit**: applying the reverse rule to `model.language_model.*` names is now a
  no-op (idempotent), whereas before it produced `model.language_model.language_model.*`.
- **End-to-end (CPU / meta device, no accelerator required)**: the full pipeline
  `revert_runtime_names_to_checkpoint → hf_to_vllm_mapper → AutoWeightsLoader →
  fused-expert lookup` loads every Qwen3.5-MoE weight with no `KeyError`.
  Before the fix the same pipeline raises
  `KeyError: language_model.language_model...w13_weight`.
- **Regression**: gemma4-style 1:1 renames (`embed_vision ↔ vision_embedder`) are
  unchanged — the guard only reverts names that would otherwise be over-expanded,
  and idempotent renames never trigger it.
- Repro command: `swift rlhf --rlhf_type grpo --model_type qwen3_5_moe
  --vllm_mode colocate ...` (both LoRA and full fail identically without the fix,
  confirming the bug is tuner-independent and lives in the shared weight-sync path).

## Related work (non-overlapping)

- #9572 (merged) — introduced `revert_runtime_names_to_checkpoint` for gemma4;
  did not consider prefix-anchored renames.
- #9589, #9800 (merged) — fix NPU Qwen3.5 GRPO issues in the MoE expert weight
  loaders / vLLM-Ascend patches; **neither modifies the revert loop**, so this
  bug remains present on `main`.

## Checklist

- [x] Bug reproduced on `main`
- [x] Fix is minimal and localized to `revert_runtime_names_to_checkpoint`
- [x] No behavior change for models with idempotent (1:1) renames
- [x] Fixes Qwen3.5-MoE / prefix-anchored renamed models under GRPO weight sync
