### PR TITLE
fix(deploy): handle reasoning-only stream chunks

### DIFF
--- a/swift/pipelines/infer/deploy.py
+++ b/swift/pipelines/infer/deploy.py
@@ -151,7 +151,7 @@ class SwiftDeploy(SwiftInfer):
 
         is_finished = all(response.choices[i].finish_reason for i in range(len(response.choices)))
         if 'stream' in response.__class__.__name__.lower():
-            request_info['response'] += response.choices[0].delta.content
+            request_info['response'] += response.choices[0].delta.content or ''
         else:
             request_info['response'] = response.choices[0].message.content
         if return_cmpl_response:

--- a/tests/deploy/test_deploy.py
+++ b/tests/deploy/test_deploy.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+from swift.infer_engine.protocol import ChatCompletionResponseStreamChoice, ChatCompletionStreamResponse, DeltaMessage
+from swift.pipelines.infer.deploy import SwiftDeploy
+
+
+def test_post_process_reasoning_only_stream_chunk():
+    deploy = object.__new__(SwiftDeploy)
+    deploy.args = SimpleNamespace()
+    request_info = {'response': ''}
+    response = ChatCompletionStreamResponse(
+        model='test',
+        choices=[
+            ChatCompletionResponseStreamChoice(
+                index=0,
+                delta=DeltaMessage(content=None, reasoning_content='thinking'),
+                finish_reason=None,
+            )
+        ],
+    )
+
+    processed = deploy._post_process(request_info, response)
+
+    assert processed is response
+    assert processed.choices[0].delta.content is None
+    assert processed.choices[0].delta.reasoning_content == 'thinking'
+    assert request_info['response'] == ''


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## What changed

- Treat a missing streaming `delta.content` as an empty string when accumulating the deploy response log.
- Add a unit test covering a reasoning-only stream chunk with `content=None` and non-empty `reasoning_content`.

## Why

Reasoning parsers can emit chunks that contain only `reasoning_content`. `DeltaMessage.content` is optional for these chunks, but `SwiftDeploy._post_process()` previously attempted `str += None`, raising `TypeError` and terminating the stream.

The streamed response is otherwise unchanged, so clients continue receiving the reasoning content while the deploy log only accumulates answer content.

## Experiment results

- `python -m pytest tests/deploy/test_deploy.py -q` — 1 passed
- `flake8 swift/pipelines/infer/deploy.py tests/deploy/test_deploy.py`
- `yapf --diff swift/pipelines/infer/deploy.py tests/deploy/test_deploy.py`
- `isort --check-only swift/pipelines/infer/deploy.py tests/deploy/test_deploy.py`
