### PR TITLE
fix(rlhf): reduce sequence-parallel log-prob memory

### DIFF
--- a/swift/rlhf_trainers/rlhf_mixin.py
+++ b/swift/rlhf_trainers/rlhf_mixin.py
@@ -163,7 +163,7 @@ class RLHFTrainerMixin:
             labels = labels.to(logits.device)
             loss_mask = loss_mask.to(logits.device)
             mean_logits = reduce_logits
-            per_token_logps = torch.gather(logits.log_softmax(-1), dim=2, index=labels.unsqueeze(2)).squeeze(2)
+            per_token_logps = selective_log_softmax(logits, labels)
             position_ids = sequence_parallel.real_position_ids
             total_per_token_logps, total_loss_mask = GatherLoss.apply(per_token_logps, loss_mask, 1, position_ids)
             total_mean_logits = sequence_parallel.gather(mean_logits, dim=1, position_ids=position_ids)

--- a/tests/test_align/test_rlhf_loss.py
+++ b/tests/test_align/test_rlhf_loss.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from swift.rlhf_trainers import rlhf_mixin
+
+
+@pytest.mark.parametrize('dtype', [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize('reduction', ['mean', 'sum'])
+def test_sequence_parallel_selective_log_softmax(dtype, reduction):
+    trainer = object.__new__(rlhf_mixin.RLHFTrainerMixin)
+    trainer.template = SimpleNamespace(sequence_parallel_size=2)
+    labels = torch.tensor([[1, 2, -100], [3, 4, 5]])
+    logits = torch.randn(2, 3, 7, dtype=dtype, requires_grad=True)
+    expected_logits = logits.detach().clone().requires_grad_(True)
+    expected_mask = labels != -100
+    expected_labels = labels.masked_fill(~expected_mask, 0)
+    expected_logps = torch.gather(
+        expected_logits.log_softmax(-1), dim=-1, index=expected_labels.unsqueeze(-1)).squeeze(-1) * expected_mask
+    expected_reduced_logits = getattr(expected_logits, reduction)(-1)
+    expected_logps.sum().backward()
+
+    with (
+            patch.object(rlhf_mixin.GatherLoss, 'apply', side_effect=lambda logps, mask, *_: (logps, mask)),
+            patch.object(rlhf_mixin.sequence_parallel, 'gather', side_effect=lambda tensor, **_: tensor),
+            patch.object(rlhf_mixin.sequence_parallel, 'extra_kwargs', {}),
+            patch.object(rlhf_mixin, 'selective_log_softmax', wraps=rlhf_mixin.selective_log_softmax) as
+            selective_log_softmax,
+    ):
+        actual_logps, actual_reduced_logits, actual_mask = trainer.get_per_token_logps(
+            logits, labels, reduction=reduction)
+
+    selective_log_softmax.assert_called_once()
+    torch.testing.assert_close(actual_logps, expected_logps)
+    torch.testing.assert_close(actual_reduced_logits, expected_reduced_logits)
+    torch.testing.assert_close(actual_mask, expected_mask)
+    actual_logps.sum().backward()
+    torch.testing.assert_close(logits.grad, expected_logits.grad)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Use `selective_log_softmax` for sequence-parallel RLHF log probabilities, avoiding the full-vocabulary `log_softmax` tensor.

## Experiment results

- Qwen3-30B-A3B DPO, 20K, SP=4, A100 80GB x8: training step passed; previous implementation OOMed on a 5.72 GiB allocation.

## Tests

1. FP32 + `mean`: log probabilities, reduced logits, padding masks, and gradients match: passed.
2. BF16 + `mean`: log probabilities, reduced logits, padding masks, and gradients match: passed.
3. FP32 + `sum`: log probabilities, reduced logits, padding masks, and gradients match: passed.
4. BF16 + `sum`: log probabilities, reduced logits, padding masks, and gradients match: passed.
