### PR TITLE
fix(megatron/grpo): clear MegatronGRPOTrainer._metrics per rollout 

### DIFF
--- a/swift/megatron/trainers/grpo_trainer.py
+++ b/swift/megatron/trainers/grpo_trainer.py
@@ -1258,6 +1258,11 @@ class MegatronGRPOTrainer(MegatronRolloutMixin, MegatronRLHFTrainer):
                 for key, val in self._metrics[mode].items()
             }
             avg_metric.update(addition_metrics)
+            # Reward metrics are produced once per rollout, while the same rollout can be
+            # consumed by multiple optimization steps. Once handed to Megatron's logging
+            # aggregator, clear them so they are neither reported repeatedly nor averaged
+            # together with every rollout seen since the start of training.
+            self._metrics[mode].clear()
 
         avg_metric = self._all_reduce_metric(avg_metric)
         reporting_metric = {**avg_metric, **custom_metrics}


### PR DESCRIPTION
MegatronGRPOTrainer._metrics accumulates reward/clip metrics per rollout but was never cleared after being averaged into the reporting dict. Since one rollout is consumed by multiple optimization steps and metrics are appended each step, later log entries mixed the current rollout with every rollout seen since training started, so the reported means drifted toward a running average instead of the per-log-window value.

Clear self._metrics[mode] once its contents have been handed to the Megatron logging aggregator so each log window reflects only the metrics produced within it.



# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

**Problem Cause:** 
    Metrics such as rewards generated by each rollout are continuously appended to self._metrics, but are never cleared after use. This causes subsequent logs to be polluted with historical data accumulated since the beginning of training. Additionally, the same rollout may be counted repeatedly across multiple optimization steps, leading to unbounded growth of the metrics cache.

**Fix:** 
    Immediately after the metrics are copied to Megatron's log-interval aggregator, execute:
    self._metrics[mode].clear()

**Modified File:** grpo_trainer.py (line 1255)

**After the Fix:**
    Metrics for each rollout are counted exactly once.
    logging.jsonl now displays results for the current logging interval instead of cumulative historical values.
    The same fix is applied to reward_std, individual reward functions, teacher_kl, clip ratio, and all other metrics that share the same cache.
    Prevents _metrics from growing indefinitely throughout training.
    Brings logging semantics in line with Transformers-SWIFT.

## Experiment results

Reward metric comparison curve with verl under the same configuration

Green: current Swift curve | Orange: fixed Swift curve | Blue: VERL curve

<img width="2804" height="1624" alt="image" src="https://github.com/user-attachments/assets/cbf9fbfb-a8ca-41fc-969d-4c9adbda9a79" />


