### PR TITLE
fix(template): keep MiMo dependencies optional

### DIFF
--- a/swift/template/templates/mimo.py
+++ b/swift/template/templates/mimo.py
@@ -1,7 +1,6 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import torch
 from dataclasses import dataclass, field
-from qwen_vl_utils import fetch_image, fetch_video
 from typing import Any, Dict, List, Optional
 
 from ..base import Template
@@ -32,6 +31,8 @@ class MiMoV2Template(Template):
     norm_bbox = 'none'
 
     def replace_tag(self, media_type, index, inputs: StdTemplateInputs) -> List[Context]:
+        from qwen_vl_utils import fetch_image, fetch_video
+
         assert media_type in {'image', 'video'}
         kwargs = {'image_patch_size': self.processor.image_processor.patch_size}
         if media_type == 'image':

--- a/tests/general/test_optional_template_dependencies.py
+++ b/tests/general/test_optional_template_dependencies.py
@@ -1,0 +1,29 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import subprocess
+import sys
+import unittest
+
+
+class TestOptionalTemplateDependencies(unittest.TestCase):
+
+    def test_template_import_without_qwen_vl_utils(self):
+        code = """
+import builtins
+
+original_import = builtins.__import__
+
+
+def import_without_qwen_vl_utils(name, *args, **kwargs):
+    if name == 'qwen_vl_utils' or name.startswith('qwen_vl_utils.'):
+        raise ModuleNotFoundError("No module named 'qwen_vl_utils'")
+    return original_import(name, *args, **kwargs)
+
+
+builtins.__import__ = import_without_qwen_vl_utils
+import swift.template
+"""
+        subprocess.run([sys.executable, '-c', code], check=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

MiMo-V2.5 support added `qwen_vl_utils` as a module-level import in
`swift.template.templates.mimo`. Because all template modules are registered
when `swift.template` is imported, environments without that model-specific
optional dependency could no longer import unrelated template, dataset,
inference, trainer, or export modules.

This is visible in the NPU job for #9880, where 34 test modules failed during
collection with:

```text
ModuleNotFoundError: No module named 'qwen_vl_utils'
```

The dependency is already declared in the MiMo model's `requires` list. This
change follows the existing Qwen, Llava, Dots, and Valley template pattern by
importing `fetch_image` and `fetch_video` only when MiMo media is actually
processed. MiMo users still receive the dependency error at the relevant
feature boundary, while unrelated imports remain available.

A subprocess regression test explicitly blocks every `qwen_vl_utils` import
and verifies that `swift.template` still imports successfully.

## Experiment results

Before:

```text
.venv/bin/python -m unittest tests.general.test_optional_template_dependencies
ModuleNotFoundError: No module named 'qwen_vl_utils'
FAILED (errors=1)
```

After:

```text
.venv/bin/python tests/run.py \
  --test_dir tests/general \
  --pattern test_optional_template_dependencies.py
SUCCESS (Runs=1, success=1)

.venv/bin/python -m unittest tests.general.test_model
Ran 1 test
OK

.venv/bin/pre-commit run --all-files
All hooks passed
```

The local environment does not have `qwen-vl-utils` installed, so the direct
`swift.template`, `swift.infer_engine.protocol`, and `swift.dataset` imports
also verify the real missing-dependency path.
