### PR TITLE
Fix MathORM false positives on parse failures

### DIFF
--- a/swift/rewards/orm.py
+++ b/swift/rewards/orm.py
@@ -422,7 +422,11 @@ class MathORM(ORM):
     @staticmethod
     def compare_consecutive(first, second):
         cleaned_list = [MathORM.clean_latex(latex) for latex in [first, second]]
+        if cleaned_list[0] == cleaned_list[1]:
+            return True
         parsed_exprs = [MathORM.parse_expression(latex) for latex in cleaned_list]
+        if any(expr is None for expr in parsed_exprs):
+            return False
         if hasattr(parsed_exprs[0], 'equals') and hasattr(parsed_exprs[1], 'equals'):
             value = parsed_exprs[0].equals(parsed_exprs[1])
         else:

--- a/tests/utils/test_rewards.py
+++ b/tests/utils/test_rewards.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 
 class TestMathAccuracy(unittest.TestCase):
@@ -254,6 +255,19 @@ class TestMathAccuracy(unittest.TestCase):
 
         self.assertEqual(len(rewards), 1)
         self.assertEqual(rewards[0], 1.0)
+
+
+class TestMathORM(unittest.TestCase):
+
+    def test_different_values_are_rejected_when_parsing_fails(self):
+        from swift.rewards.orm import MathORM
+        with patch.object(MathORM, 'parse_expression', return_value=None):
+            self.assertFalse(MathORM.compare_consecutive('not-a-number', '42'))
+
+    def test_identical_cleaned_values_are_accepted_when_parsing_fails(self):
+        from swift.rewards.orm import MathORM
+        with patch.object(MathORM, 'parse_expression', return_value=None):
+            self.assertTrue(MathORM.compare_consecutive('{42}', '42'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Bug

`MathORM.compare_consecutive` in the original implementation returns `True` for two different answers when both answers fail to parse.

`MathORM.parse_expression` uses `None` to represent a parse failure:

```python
@staticmethod
def parse_expression(latex_str):
    try:
        ...
    except Exception:
        return None
```

The original comparison code does not handle this sentinel value:

```python
parsed_exprs = [MathORM.parse_expression(latex) for latex in cleaned_list]
if hasattr(parsed_exprs[0], 'equals') and hasattr(parsed_exprs[1], 'equals'):
    value = parsed_exprs[0].equals(parsed_exprs[1])
else:
    value = parsed_exprs[0] == parsed_exprs[1]
```

If both parser calls fail, this executes:

```python
None == None  # True
```

As a result, an incorrect or truncated model response can be treated as mathematically equivalent to the ground truth. `MathORM.__call__` converts that result to `float`, so the incorrect response receives reward `1.0`.

## Reproduction on the original implementation

```bash
python - <<'PY'
from unittest.mock import patch

from swift.rewards.orm import MathORM

prediction = 'truncated response without an answer'
ground_truth = '42'

with patch.object(MathORM, 'parse_expression', return_value=None):
    result = MathORM.compare_consecutive(prediction, ground_truth)

print(result)
PY
```

Actual result before this PR:

```text
True
```

Expected result:

```text
False
```

The mock makes the parse-failure condition deterministic. In normal use, the same condition occurs with malformed/truncated generated text or when the SymPy LaTeX parser raises an exception.

## Real workflow impact

The bug was found in an RFT sampling smoke with four math prompts and `max_new_tokens=16`. Four generated responses were truncated before producing an answer.

Before the fix:

```text
correct reference responses retained: 4
truncated generated responses incorrectly retained: 4
```

For each incorrect response, both parser results were `None`, so the original comparator returned `True` and the response was accepted by the math ORM.

After the fix:

```text
accepted_scores: [1.0, 1.0, 1.0, 1.0]
rejected_scores: [0.0, 0.0, 0.0, 0.0]
```

## Fix

- Return `True` when the cleaned answer strings are exactly equal.
- Return `False` when the strings differ and either expression failed to parse.
- Preserve the existing symbolic-equivalence comparison when both expressions parse successfully.

## Tests

Added regression tests for both outcomes:

1. Different values with two parse failures return `False`.
2. Identical cleaned values with two parse failures return `True`.

```text
python -m unittest tests.utils.test_rewards -v
Ran 24 tests in 4.094s
OK
```

```text
pre-commit run --files swift/rewards/orm.py tests/utils/test_rewards.py
flake8...................................................................Passed
isort....................................................................Passed
yapf.....................................................................Passed
trim trailing whitespace.................................................Passed
fix end of files..........................................................Passed
fix double quoted strings................................................Passed
check for merge conflicts................................................Passed
mixed line ending........................................................Passed
```

## Compatibility

There is no public API change. Successfully parsed expressions continue to use the existing symbolic-equivalence logic. Only the parse-failure fallback changes, preventing different unparsable answers from receiving a false-positive reward.