### PR TITLE
test(template): cover MiMo audio placeholders

### DIFF
--- a/tests/general/test_mimo_template.py
+++ b/tests/general/test_mimo_template.py
@@ -1,0 +1,36 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from swift.template.template_inputs import StdTemplateInputs
+from swift.template.templates.mimo import MiMoV2Template
+
+
+class TestMiMoV2Template(unittest.TestCase):
+
+    def setUp(self):
+        self.template = object.__new__(MiMoV2Template)
+        self.inputs = StdTemplateInputs(
+            messages=[{
+                'role': 'user',
+                'content': '<audio>Transcribe this clip.'
+            }], audios=['sample.wav'])
+
+    def test_audio_placeholder_preserves_input(self):
+        expected = ['<|mimo_audio_start|><|audio_pad|><|mimo_audio_end|>']
+        qwen_vl_utils = SimpleNamespace(fetch_image=None, fetch_video=None)
+        with patch.dict(sys.modules, {'qwen_vl_utils': qwen_vl_utils}):
+            for mode in ['transformers', 'vllm', 'sglang', 'lmdeploy']:
+                with self.subTest(mode=mode):
+                    self.template.mode = mode
+                    self.assertEqual(self.template.replace_tag('audio', 0, self.inputs), expected)
+                    self.assertEqual(self.inputs.audios, ['sample.wav'])
+
+    def test_audio_placeholder_is_protected_from_truncation(self):
+        self.assertIn('<|audio_pad|>', self.template.placeholder_tokens)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Follow-up regression coverage for the MiMo-V2.5 audio support merged by the maintainer in #9898, based on the original discovery and tests in this PR.

## Changes

- Verify the official `<|mimo_audio_start|><|audio_pad|><|mimo_audio_end|>` placeholder across the existing inference modes.
- Verify placeholder generation preserves the raw audio input for backend/model processing.
- Verify `<|audio_pad|>` remains protected by template truncation handling.
- Stub the unrelated `qwen_vl_utils` import so this focused unit test remains CPU-only and self-contained.

No production code is changed; the implementation and documentation remain owned by #9898.

## Verification

- `uv run --no-project python tests/run.py --test_dir tests/general --pattern test_mimo_template.py` -> `SUCCESS (Runs=2, success=2)`
- `.venv/bin/pre-commit run --files tests/general/test_mimo_template.py` -> all applicable hooks passed
- `git diff --check origin/main...HEAD` -> passed

## Experiment results

Before #9898, MiMo audio inputs lacked the required placeholder handling. After #9898, these regression tests pass on current `main` and protect the merged behavior.