### PR TITLE
Fix alpha UMI Next loss scale

### DIFF
--- a/swift/loss_scale/config/alpha_umi.json
+++ b/swift/loss_scale/config/alpha_umi.json
@@ -4,5 +4,5 @@
     "Thought:": [1.0, 1.0],
     "Final Answer:": [1.0, 1.0],
     "Observation:": [2.0, 0.0],
-    "Next:": [2,0, 2.0]
+    "Next:": [2.0, 2.0]
 }


### PR DESCRIPTION
## Summary

- Fix the malformed `Next:` entry in the alpha UMI loss-scale configuration.

## Root cause

The first `2.0` was written as `2,0`, which made the value a three-element list. Exact-string loss-scale entries require two values: one for the keyword and one for the following content.

## Impact

`--loss_scale alpha_umi` now assigns a weight of `2.0` to both the `Next:` keyword and its following content, as intended.

## Validation

- Parsed the updated file with `jq`.
- Ran a focused loss-scale regression check (`1 passed`).
- Ran `git diff --check`.
