### PR TITLE
Synchronize MuonClip max logits across ranks

### DIFF
--- a/swift/optimizers/muonclip.py
+++ b/swift/optimizers/muonclip.py
@@ -1,6 +1,7 @@
 import math
 import threading
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
 from contextlib import suppress
 from torch.optim import Optimizer
@@ -243,6 +244,22 @@ class MuonClip(Optimizer):
     def _is_qk_weight(self, group) -> bool:
         return bool(group.get('is_qk', False))
 
+    def _sync_max_logits(self, max_logits: Optional[float]) -> Optional[float]:
+        if not (dist.is_available() and dist.is_initialized()):
+            return max_logits
+
+        qk_param = next(
+            (p for group in self.param_groups if group.get('qk_clip_enabled', True) and self._is_qk_weight(group)
+             for p in group['params']), None)
+        if qk_param is None:
+            return max_logits
+
+        local_max = -float('inf') if max_logits is None else float(max_logits)
+        max_tensor = torch.tensor(local_max, device=qk_param.device, dtype=torch.float32)
+        dist.all_reduce(max_tensor, op=dist.ReduceOp.MAX)
+        max_logits = float(max_tensor.item())
+        return None if max_logits == -float('inf') else max_logits
+
     @torch.no_grad()
     def step(self, closure=None, max_logits: Optional[float] = None):
         loss = None
@@ -253,6 +270,7 @@ class MuonClip(Optimizer):
         # fallback: collect scalar max_logits from tracker if not provided
         if max_logits is None:
             max_logits = _MaxLogitsTracker.consume()
+        max_logits = self._sync_max_logits(max_logits)
 
         for group in self.param_groups:
             lr = float(group['lr'])


### PR DESCRIPTION
## Summary

- Synchronize MuonClip's per-step maximum attention logit across distributed ranks before QK clipping.
- Keep ranks without a locally captured logit in the collective by contributing negative infinity.

## Root cause

`_MaxLogitsTracker` stores a process-local value, but `MuonClip.step()` previously used it directly to calculate the QK clipping factor. Different data-parallel batches can therefore produce different clipping factors even after DDP synchronizes gradients. Because QK clipping scales both the parameter and its update in place, model parameters diverge immediately across ranks.

## Impact

All distributed ranks now use the global maximum logit and apply the same clipping factor. The collective is only performed when an enabled QK-Clip parameter group exists, so optimizers without active QK clipping do not pay the synchronization cost.

## Validation

- Local two-rank Gloo validation with different local maxima (`120` and `400`) and a missing local value (`None` and `400`).
- `uvx pre-commit run --files swift/optimizers/muonclip.py`
- `git diff --check`
