### PR TITLE
fix: add set_epoch() to DataLoaderDispatcher for streaming datasets

### DIFF
--- a/swift/dataloader/dispatcher.py
+++ b/swift/dataloader/dispatcher.py
@@ -37,6 +37,11 @@ class DataLoaderDispatcher:
             for _ in tqdm(range(self.skip_batches), dynamic_ncols=True, desc='Skip Batches: '):
                 [next(base_iter) for _ in range(self.world_size)]
 
+    def set_epoch(self, epoch: int):
+        dataset = self.base_dataloader.dataset
+        if hasattr(dataset, 'set_epoch'):
+            dataset.set_epoch(epoch)
+
     def __iter__(self):
         base_iter = iter(self.base_dataloader)
         self._skip_batches(base_iter)

--- a/swift/dataset/packing.py
+++ b/swift/dataset/packing.py
@@ -205,6 +205,10 @@ class IterablePackingDataset(IterableDataset):
             for x in iterable:
                 yield x
 
+    def set_epoch(self, epoch: int):
+        if hasattr(self.dataset, 'set_epoch'):
+            self.dataset.set_epoch(epoch)
+
     def __iter__(self):
         try:
             next(iter(self.dataset))

--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -269,6 +269,8 @@ class BaseMegatronTrainer(ABC):
         while True:
             if not is_finished:
                 logger.info(f'The training of Epoch {epoch} starts...')
+            if hasattr(iterable, 'set_epoch'):
+                iterable.set_epoch(epoch)
             for x in iterable:
                 yield x
             # streaming


### PR DESCRIPTION
# Fix: Streaming Dataset Missing `set_epoch()` Causes Identical Data Order Across Epochs

## Summary

`DataLoaderDispatcher` does not call `datasets.IterableDataset.set_epoch()` for streaming datasets, causing every epoch to iterate over data in exactly the same order. This contradicts the semantics of multi-epoch training and manifests as a reproducible loss/grad-norm spike at epoch boundaries.

<img width="1212" height="658" alt="image (1)" src="https://github.com/user-attachments/assets/95b0a47e-ee16-4ea0-a5f0-7685eabb80d2" />

<img width="1182" height="658" alt="image" src="https://github.com/user-attachments/assets/86d66bb9-39cf-409d-98ad-95f6e1416f69" />

## Reproduction

### Minimal config to reproduce

```bash
megatron pt \
    --streaming true \
    --packing true \
    --shuffle_buffer_size 1000 \
    --num_train_epochs 3 \
    --dataset /path/to/single_large_file.jsonl
```

### Observed symptoms

| Scenario | Loss at epoch boundary | Grad norm at epoch boundary |
|---|---|---|
| PT + streaming + packing | Spike upward (plateau) | Spike |
| SFT + streaming + packing | Spike downward (plateau) | Spike |
| Streaming disabled | No spike | No spike |
| Reduced `shuffle_buffer_size` | Higher spike | Higher spike |

## Root Cause

### The missing `set_epoch()` call

`datasets` library provides `IterableDataset.set_epoch(epoch)` which triggers two operations during the next `__iter__()`:

1. `shuffle_data_sources(epoch)` — shuffle shard order using epoch as seed
2. `shift_ex_examples_rngs(epoch)` — shift internal RNG state by epoch

These are designed to ensure each epoch sees a different data order. However, ms-swift's `DataLoaderDispatcher` never calls `set_epoch()`, so `self._epoch` remains 0 and the above logic is never triggered.

## Fix

Three files need modification:

### 1. `swift/dataloader/dispatcher.py` — `DataLoaderDispatcher`

Add `set_epoch()` to propagate the call to the underlying dataset:

```python
def set_epoch(self, epoch: int):
    dataset = self.base_dataloader.dataset
    if hasattr(dataset, 'set_epoch'):
        dataset.set_epoch(epoch)
```

### 2. `swift/dataset/packing.py` — `IterablePackingDataset`

Add `set_epoch()` to pass through the packing wrapper:

```python
def set_epoch(self, epoch: int):
    if hasattr(self.dataset, 'set_epoch'):
        self.dataset.set_epoch(epoch)
```

### 3. `swift/megatron/trainers/base.py` — `cyclic_iter`

Call `set_epoch()` at the start of each epoch in the Megatron training loop:

```python
for x in iterable:
    if hasattr(iterable, 'set_epoch'):
        iterable.set_epoch(epoch)
    # ... rest of loop
```

## Experiments

### 1. Confirmed: identical samples at epoch boundaries

Logged `input_ids[:10]` of the first 3 packed samples per epoch:

```
epoch 0: sample#0 = [3710, 1510, 9911, ...], sample#1 = [3710, 1510, 9911, ...]
epoch 1: sample#0 = [3710, 1510, 9911, ...], sample#1 = [3710, 1510, 9911, ...]
```

→ Identical samples across epochs. Confirmed the bug.

### 2. Confirmed: `set_epoch()` + multi-shard fixes the issue

Split dataset into multiple files, enabled `set_epoch()`：

| Step | `set_epoch` | `shuffle_buffer_size` | Result |
|---|---|---|---|
| 1 | Disabled | 100 (< shard size) | Spike reproduced |
| 2 | Enabled | 100 (< shard size) | Spike eliminated, sample IDs different |
