### PR TITLE
Fix padding-free single-token sequence boundaries

### DIFF
--- a/swift/model/patcher.py
+++ b/swift/model/patcher.py
@@ -19,9 +19,9 @@ from transformers.modeling_outputs import SequenceClassifierOutputWithPast
 from types import MethodType
 from typing import Any, Dict, List, Optional, Union
 
-from swift.utils import (HfConfigFactory, deep_getattr, get_device_count, get_dist_setting, get_last_valid_indices,
-                         get_logger, get_position_ids_from_cu_seqlens, is_mp, is_mp_ddp, safe_ddp_context, to_device,
-                         to_float_dtype)
+from swift.utils import (HfConfigFactory, deep_getattr, get_cu_seqlens_from_position_ids, get_device_count,
+                         get_dist_setting, get_last_valid_indices, get_logger, is_mp, is_mp_ddp, safe_ddp_context,
+                         to_device, to_float_dtype)
 
 logger = get_logger()
 
@@ -531,27 +531,14 @@ def revert_padding_free(outputs: Dict[str, Any], inputs: Dict[str, Any], padding
     last_hidden_state = outputs[hidden_state_key]
     last_hidden_state = last_hidden_state.squeeze(dim=0)
     if 'cu_seq_lens_q' in inputs:
-        position_ids = get_position_ids_from_cu_seqlens(inputs['cu_seq_lens_q'])
+        cu_seqlens = inputs['cu_seq_lens_q']
     elif 'position_ids' in inputs and inputs['position_ids'].shape[0] == 1:
-        position_ids = inputs['position_ids']
+        cu_seqlens = get_cu_seqlens_from_position_ids(inputs['position_ids'])
     else:
         raise ValueError(
             "revert_padding_free requires 'cu_seq_lens_q' or 'position_ids' in inputs, but neither was found.")
 
-    seq_lengths = []
-    pos = position_ids[0]
-    resets = torch.where(pos[1:] < pos[:-1])[0] + 1
-
-    if len(resets) == 0:
-        # Only one sequence in this batch item
-        seq_lengths = [pos.max().item() + 1]
-    else:
-        # Multiple sequences
-        start = 0
-        for end in resets:
-            seq_lengths.append(end - start)
-            start = end
-        seq_lengths.append(pos.shape[0] - start)
+    seq_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
 
     max_length = max(seq_lengths)
     unpacked_logits = []

--- a/tests/models/test_patcher.py
+++ b/tests/models/test_patcher.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 
 from swift.model.patcher import revert_padding_free
+from swift.utils import get_cu_seqlens_from_position_ids
 
 
 @pytest.mark.parametrize(
@@ -18,4 +19,30 @@ def test_revert_padding_free_preserves_single_token_sequence(inputs):
     outputs = revert_padding_free({'last_hidden_state': token_states}, inputs, padding_side='right')
 
     expected = torch.tensor([[[1.], [2.], [3.]], [[4.], [0.], [0.]], [[5.], [6.], [7.]]])
+    torch.testing.assert_close(outputs['last_hidden_state'], expected)
+
+
+def test_revert_padding_free_uses_text_position_boundaries_for_mrope():
+    text_position_ids = torch.tensor([[0, 1, 2, 0, 0, 1, 2]])
+    cu_seqlens = get_cu_seqlens_from_position_ids(text_position_ids)
+    mrope_position_ids = torch.full((3, 1, 7), 42)
+    token_states = torch.arange(1, 8, dtype=torch.float32).view(1, 7, 1)
+
+    outputs = revert_padding_free({'last_hidden_state': token_states}, {
+        'position_ids': mrope_position_ids,
+        'cu_seq_lens_q': cu_seqlens,
+    },
+                                  padding_side='left')
+
+    expected = torch.tensor([[[1.], [2.], [3.]], [[0.], [0.], [4.]], [[5.], [6.], [7.]]])
+    torch.testing.assert_close(outputs['last_hidden_state'], expected)
+
+
+def test_revert_padding_free_preserves_consecutive_single_token_sequences():
+    token_states = torch.arange(1, 5, dtype=torch.float32).view(1, 4, 1)
+
+    outputs = revert_padding_free({'last_hidden_state': token_states}, {'position_ids': torch.tensor([[0, 0, 0, 1]])},
+                                  padding_side='right')
+
+    expected = torch.tensor([[[1.], [0.]], [[2.], [0.]], [[3.], [4.]]])
     torch.testing.assert_close(outputs['last_hidden_state'], expected)

--- a/tests/models/test_patcher.py
+++ b/tests/models/test_patcher.py
@@ -1,0 +1,21 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import pytest
+import torch
+
+from swift.model.patcher import revert_padding_free
+
+
+@pytest.mark.parametrize(
+    'inputs', [{
+        'position_ids': torch.tensor([[0, 1, 2, 0, 0, 1, 2]])
+    }, {
+        'cu_seq_lens_q': torch.tensor([0, 3, 4, 7], dtype=torch.int32)
+    }],
+    ids=['position_ids', 'cu_seq_lens_q'])
+def test_revert_padding_free_preserves_single_token_sequence(inputs):
+    token_states = torch.arange(1, 8, dtype=torch.float32).view(1, 7, 1)
+
+    outputs = revert_padding_free({'last_hidden_state': token_states}, inputs, padding_side='right')
+
+    expected = torch.tensor([[[1.], [2.], [3.]], [[4.], [0.], [0.]], [[5.], [6.], [7.]]])
+    torch.testing.assert_close(outputs['last_hidden_state'], expected)


### PR DESCRIPTION
## What changed

- Restore padding-free sequence lengths from `cu_seq_lens_q` directly when it is available.
- Fall back to the existing zero-position based cumulative-length helper for packed `position_ids`.
- Add regression coverage for:
  - a single-token sequence between two longer sequences through both input paths;
  - consecutive single-token sequences;
  - multimodal mRoPE inputs whose explicit cumulative lengths are derived from `text_position_ids`;
  - both left- and right-padding restoration paths.

## Why

`revert_padding_free()` detected sequence boundaries only when the next position ID was smaller than the previous one. A one-token sequence followed by another sequence produces a `0 -> 0` boundary, so the strict-decrease check silently merged both sequences. For embedding training this reduced the number of sentence embeddings and could misalign InfoNCE groups or trigger a zero-negative failure.

Using cumulative sequence lengths preserves every explicit packed boundary without changing the interpretation of multimodal position IDs.

Fixes #9903.
