### PR TITLE
fix: carry rounded seconds in format_time so it never prints '60s'

### DIFF
--- a/swift/utils/utils.py
+++ b/swift/utils/utils.py
@@ -83,10 +83,13 @@ def _get_version(work_dir: str) -> int:
 
 
 def format_time(seconds):
-    days = int(seconds // (24 * 3600))
-    hours = int((seconds % (24 * 3600)) // 3600)
-    minutes = int((seconds % 3600) // 60)
-    seconds = round(seconds % 60)
+    # Round the total first, then decompose, so a rounded-up second carries into
+    # the minute (and cascades) instead of printing an impossible '60s'.
+    total = round(seconds)
+    days = total // (24 * 3600)
+    hours = (total % (24 * 3600)) // 3600
+    minutes = (total % 3600) // 60
+    seconds = total % 60
 
     if days > 0:
         time_str = f'{days}d {hours}h {minutes}m {seconds}s'

--- a/tests/utils/test_format_time.py
+++ b/tests/utils/test_format_time.py
@@ -1,0 +1,24 @@
+import unittest
+
+from swift.utils import format_time
+
+
+class TestFormatTime(unittest.TestCase):
+
+    def test_carries_rounded_seconds(self):
+        # A rounded-up second must carry into the next unit instead of printing
+        # an impossible '60s'.
+        self.assertEqual(format_time(59.7), '1m 0s')
+        self.assertEqual(format_time(119.6), '2m 0s')
+        self.assertEqual(format_time(3599.8), '1h 0m 0s')
+        self.assertEqual(format_time(3659.7), '1h 1m 0s')
+        self.assertEqual(format_time(86399.7), '1d 0h 0m 0s')
+
+    def test_normal_values_unchanged(self):
+        self.assertEqual(format_time(30.2), '30s')
+        self.assertEqual(format_time(90.0), '1m 30s')
+        self.assertEqual(format_time(3600), '1h 0m 0s')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

`format_time` (in `swift/utils/utils.py`) floors the day/hour/minute fields but
rounds the seconds field, so a rounded-up second is never carried into the next
unit and an impossible `60s` is printed:

```python
format_time(59.7)     # '60s'        -> should be '1m 0s'
format_time(119.6)    # '1m 60s'     -> should be '2m 0s'
format_time(3599.8)   # '59m 60s'    -> should be '1h 0m 0s'
format_time(86399.7)  # '23h 59m 60s'-> should be '1d 0h 0m 0s'
```

This is used for the `elapsed_time` / `remaining_time` fields in the training
logs (`swift/trainers/patcher.py`) and the WebUI runtime display.

## Fix

Round the total seconds first, then decompose from the rounded integer, so a
carry into minutes (and up the chain) happens naturally.

## Verification

After the fix all the cases above carry correctly, and normal values are
unchanged (`format_time(90.0) == '1m 30s'`, `format_time(3600) == '1h 0m 0s'`).
Added `tests/utils/test_format_time.py` with cases that fail on the current code
and pass with the fix.
