### PR TITLE
feat(npu): Add FSDP2 LoRA example for Qwen3.8-27B for Ascend NPU

### DIFF
--- a/examples/ascend/train/qwen3_8/qwen3_8_27b_fsdp2.json
+++ b/examples/ascend/train/qwen3_8/qwen3_8_27b_fsdp2.json
@@ -1,0 +1,22 @@
+{
+    "compute_environment": "LOCAL_MACHINE",
+    "debug": false,
+    "distributed_type": "FSDP",
+    "downcast_bf16": "no",
+    "mixed_precision": "bf16",
+    "num_machines": 1,
+    "num_processes": 16,
+    "machine_rank": 0,
+    "rdzv_backend": "static",
+    "same_network": true,
+    "use_cpu": false,
+    "fsdp_config": {
+      "fsdp_version": 2,
+      "fsdp_auto_wrap_policy": "TRANSFORMER_BASED_WRAP",
+      "fsdp_transformer_layer_cls_to_wrap": "Qwen3_5DecoderLayer",
+      "fsdp_reshard_after_forward": true,
+      "fsdp_state_dict_type": "FULL_STATE_DICT",
+      "fsdp_cpu_ram_efficient_loading": false,
+      "fsdp_offload_params": false
+    }
+  }

--- a/examples/ascend/train/qwen3_8/qwen3_8_27b_lora_fsdp2.sh
+++ b/examples/ascend/train/qwen3_8/qwen3_8_27b_lora_fsdp2.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Atlas 800T A3 Ascend NPU. FSDP2 + LoRA SFT.
+# Run from ms-swift repo root:
+#   bash examples/ascend/train/qwen3_8/qwen3_8_27b_lora_fsdp2.sh
+# Override model path: MODEL=Qwen/Qwen3.8-27B bash ...
+
+set -euo pipefail
+
+export TASK_QUEUE_ENABLE=2
+export CPU_AFFINITY_CONF=2
+export USE_MCORE_GDN=0
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-.triton_cache}"
+if [ "${CLEAR_TRITON_CACHE:-0}" = "1" ]; then
+    rm -rf "${TRITON_CACHE_DIR}"
+fi
+mkdir -p "${TRITON_CACHE_DIR}"
+
+MODEL="${MODEL:-Qwen/Qwen3.8-27B}"
+
+ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 \
+accelerate launch --config_file "./examples/ascend/train/qwen3_8/qwen3_8_27b_fsdp2.json" \
+    swift/cli/sft.py \
+    --model "${MODEL}" \
+    --tuner_type lora \
+    --lora_rank 8 \
+    --lora_alpha 32 \
+    --target_modules all-linear \
+    --dataset 'AI-ModelScope/alpaca-gpt4-data-zh' \
+              'AI-ModelScope/alpaca-gpt4-data-en' \
+              'swift/self-cognition' \
+    --load_from_cache_file true \
+    --torch_dtype bfloat16 \
+    --per_device_train_batch_size 2 \
+    --gradient_accumulation_steps 1 \
+    --gradient_checkpointing true \
+    --gradient_checkpointing_kwargs '{"use_reentrant": false}' \
+    --learning_rate 1e-4 \
+    --warmup_ratio 0.05 \
+    --max_length 4096 \
+    --num_train_epochs 1 \
+    --eval_strategy no \
+    --save_strategy steps \
+    --save_steps 500 \
+    --logging_strategy steps \
+    --logging_steps 1 \
+    --dataloader_num_workers 16 \
+    --dataset_num_proc 16 \
+    --save_only_model true \
+    --output_dir output/Qwen3.8-27B-lora-fsdp2 \
+    --report_to tensorboard \
+    --attn_impl flash_attention_2 \
+    --packing true

--- a/examples/ascend/train/qwen3_8/qwen3_8_27b_lora_fsdp2.sh
+++ b/examples/ascend/train/qwen3_8/qwen3_8_27b_lora_fsdp2.sh
@@ -22,6 +22,7 @@ ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 \
 accelerate launch --config_file "./examples/ascend/train/qwen3_8/qwen3_8_27b_fsdp2.json" \
     swift/cli/sft.py \
     --model "${MODEL}" \
+    --model_type qwen3_5 \
     --tuner_type lora \
     --lora_rank 8 \
     --lora_alpha 32 \
@@ -31,13 +32,14 @@ accelerate launch --config_file "./examples/ascend/train/qwen3_8/qwen3_8_27b_fsd
               'swift/self-cognition' \
     --load_from_cache_file true \
     --torch_dtype bfloat16 \
-    --per_device_train_batch_size 2 \
+    --per_device_train_batch_size 4 \
     --gradient_accumulation_steps 1 \
     --gradient_checkpointing true \
     --gradient_checkpointing_kwargs '{"use_reentrant": false}' \
     --learning_rate 1e-4 \
     --warmup_ratio 0.05 \
-    --max_length 4096 \
+    --max_length 2048 \
+    --max_steps 50 \
     --num_train_epochs 1 \
     --eval_strategy no \
     --save_strategy steps \


### PR DESCRIPTION
# Add Qwen3.8-27B Ascend NPU FSDP2 LoRA Training Example

`ms-swift` + `flash-linear-attention` NPU adaptation 
- @sunyi0505 
- @addsubmuldiv
- @ChengQianqian
- @hazelduan 
- @xvxuopop
- @OsirisDuan

## Summary

Qwen3.8 and Qwen3.5 share a similar architecture—both use GDN—so this PR is primarily about demonstrating that `ms-swif`t + `flash-linear-attention` works on Ascend NPU.

The main advantage of this setup is that no extra NPU training stack is required: both `ms-swift` and `flash-linear-attention` provide native NPU support.

Timeline for this PR:

- [x] Aug 14 — Qwen3.8 open-sourced; swap in the Qwen3.8 model name, verify training, and open the PR
- [x] Aug 13 — Environment setup; validate end-to-end training with Qwen3.5 first
- [x] Early Aug — `ms-swift` + `flash-linear-attention` fully working on Qwen3.5
- [x] Early Jul — `flash-linear-attention` NPU adaptation
- [x] `ms-swift` NPU adaptation

## PR Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [x] More Models or Datasets Support

## Description

Adds an **FSDP2 + LoRA SFT** training example for **Qwen3.8-27B** on Ascend NPU, ready for post-release NPU adaptation.

**New files**

- `examples/ascend/train/qwen3_8/qwen3_8_27b_lora_fsdp2.sh` — training entry script
- `examples/ascend/train/qwen3_8/qwen3_8_27b_fsdp2.json` — Accelerate FSDP2 config

**Key points**

- Transformers path + FLA GDN (`USE_MCORE_GDN=0`), with `packing=true` and `max_length=2048`
- Requires explicit `--model_type qwen3_5` (Qwen3.8 config also matches `ovis_ocr2`, so auto-detection fails)
- flash-linear-attention commit: `ab181c671576fd9cdeed678d216a6273185be700`

**Environment setup**

```python
pip install torch==2.7.1 torch_npu==2.7.1.post4 torchvision==0.22.1 torchaudio==2.7.1
pip install triton-ascend==3.2.1 --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi
source /home/cann/cann9.1.0/ascend-toolkit/set_env.sh

git clone https://github.com/fla-org/flash-linear-attention.git
pip install -e ./ --no-deps

git clone https://github.com/modelscope/ms-swift.git
pip install -e ./
```

**Usage**

```python
bash examples/ascend/train/qwen3_8/qwen3_8_27b_lora_fsdp2.sh

# Use local weights
MODEL=/path/to/Qwen3.8-27B bash examples/ascend/train/qwen3_8/qwen3_8_27b_lora_fsdp2.sh
```

## Results

<img width="1500" height="750" alt="loss" src="https://github.com/user-attachments/assets/8fdfb093-b3b1-4e56-ab47-46d2d76e4466" />

<img width="1500" height="750" alt="grad_norm" src="https://github.com/user-attachments/assets/86bb6d89-625a-4206-b461-f6573b40a128" />

<img width="1500" height="750" alt="memory_gib" src="https://github.com/user-attachments/assets/ccf7ef08-11a8-442a-9e34-215966dba313" />


<img width="1500" height="750" alt="token_acc" src="https://github.com/user-attachments/assets/27315f41-13a3-4944-923a-c26bf1ccc1da" />

<img width="1500" height="750" alt="train_speed" src="https://github.com/user-attachments/assets/9305727c-efbf-46d0-b75c-84da6a2a9a3b" />

<img width="1500" height="750" alt="learning_rate" src="https://github.com/user-attachments/assets/0310ce94-9c39-46d0-84dd-c41ea96de204" />
