### PR TITLE
[Megatron] Fix duplicated GRPO KL gathering

### DIFF
--- a/swift/megatron/trainers/grpo_trainer.py
+++ b/swift/megatron/trainers/grpo_trainer.py
@@ -13,7 +13,7 @@ from swift.infer_engine.protocol import RequestConfig, RolloutInferRequest, Roll
 from swift.megatron.arguments import MegatronArguments
 from swift.megatron.utils import RouterReplayHelper, get_padding_to, set_router_replay_data
 from swift.rl_core.advantage import (compute_advantages, compute_reward_metrics, compute_teacher_kl_per_token,
-                                     expand_advantage_to_per_token)
+                                     expand_advantage_to_per_token, get_local_rollout_values)
 from swift.rl_core.data import GRPOBatch, GRPOSample
 from swift.rl_core.grpo_algorithm import score_completions
 from swift.rl_core.resample import resample_encode_failed_inputs
@@ -308,7 +308,7 @@ class MegatronGRPOTrainer(MegatronRolloutMixin, MegatronRLHFTrainer):
         # Step 2: Compute KL from logps if kl_in_reward is enabled
         kl_values = None
         if self.kl_in_reward and self.beta != 0.0:
-            kl_values = self._compute_kl_from_batches(mini_batch_data)
+            kl_values = self._compute_kl_from_batches(mini_batch_data, len(samples), rollout_group)
 
         # Step 3: Compute the per-sequence base advantage (with ref-KL penalty if kl_in_reward).
         advantages = self._compute_advantages(samples, rewards_per_func, kl_values=kl_values)
@@ -818,7 +818,8 @@ class MegatronGRPOTrainer(MegatronRolloutMixin, MegatronRLHFTrainer):
             tok_sum += grpo_batch.completion_mask.sum().item()
         self._metrics[mode]['teacher_kl'].append(kl_sum / max(tok_sum, 1.0))
 
-    def _compute_kl_from_batches(self, mini_batch_data: List[Dict[str, Any]]) -> torch.Tensor:
+    def _compute_kl_from_batches(self, mini_batch_data: List[Dict[str, Any]], local_num_samples: int,
+                                 rollout_group: torch.distributed.ProcessGroup) -> torch.Tensor:
         """
         Compute per-sample KL divergence from encoded batches for kl_in_reward.
 
@@ -829,6 +830,8 @@ class MegatronGRPOTrainer(MegatronRolloutMixin, MegatronRLHFTrainer):
                 - old_per_token_logps: [batch_size, max_seq_len] in batch format
                 - ref_per_token_logps: [batch_size, max_seq_len] in batch format
                 - completion_mask: [batch_size, max_seq_len] mask for completion tokens
+            local_num_samples: Number of samples owned by the current rank
+            rollout_group: Process group whose samples were concatenated into the batches
 
         Returns:
             kl_values: Per-sample KL values, shape [total_samples]
@@ -845,8 +848,13 @@ class MegatronGRPOTrainer(MegatronRolloutMixin, MegatronRLHFTrainer):
             sample_kl = (per_token_kl * grpo_batch.completion_mask).sum(-1)  # [batch_size]
             kl_list.append(sample_kl)
 
-        # Concatenate all KL values and gather across ranks
+        # mini_batch_data contains the whole rollout group's samples on every rank. Select
+        # only the values originally owned by this rank before the global gather, matching
+        # the ownership and ordering used when rewards are gathered in _compute_advantages.
         kl_values = torch.cat(kl_list, dim=0)
+        sample_counts = gather_object([local_num_samples], group=rollout_group)
+        rollout_rank = torch.distributed.get_rank(group=rollout_group)
+        kl_values = get_local_rollout_values(kl_values, sample_counts, rollout_rank)
         kl_values = gather(kl_values)
 
         return kl_values

--- a/swift/rl_core/advantage.py
+++ b/swift/rl_core/advantage.py
@@ -7,6 +7,16 @@ from typing import Dict, List, Optional, Tuple
 from swift.utils import nanstd
 
 
+def get_local_rollout_values(values: torch.Tensor, sample_counts: List[int], rollout_rank: int) -> torch.Tensor:
+    """Select the values owned by one rank from a rollout-group concatenation."""
+    total_samples = sum(sample_counts)
+    assert values.shape[0] == total_samples, (
+        f'Expected {total_samples} rollout values from sample counts, but got {values.shape[0]}')
+    start_idx = sum(sample_counts[:rollout_rank])
+    end_idx = start_idx + sample_counts[rollout_rank]
+    return values[start_idx:end_idx]
+
+
 def compute_advantages(
     rewards_per_func: torch.Tensor,
     reward_weights: torch.Tensor,

--- a/tests/utils/test_rollout_values.py
+++ b/tests/utils/test_rollout_values.py
@@ -1,0 +1,26 @@
+import torch
+import unittest
+
+from swift.rl_core.advantage import get_local_rollout_values
+
+
+class TestLocalRolloutValues(unittest.TestCase):
+
+    def test_selects_each_ranks_original_values(self):
+        values = torch.arange(10)
+        sample_counts = [2, 3, 1, 4]
+
+        local_values = [
+            get_local_rollout_values(values, sample_counts, rollout_rank) for rollout_rank in range(len(sample_counts))
+        ]
+
+        torch.testing.assert_close(torch.cat(local_values), values)
+        self.assertEqual([value.shape[0] for value in local_values], sample_counts)
+
+    def test_rejects_values_from_a_different_sample_set(self):
+        with self.assertRaisesRegex(AssertionError, 'Expected 4 rollout values'):
+            get_local_rollout_values(torch.arange(8), [2, 2], rollout_rank=0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Slice rollout-group KL values back to the samples owned by the current rank before the global gather.
- Preserve the same global rank ordering used when rewards are gathered for advantage computation.
- Add regression coverage for equal and uneven per-rank rollout sample counts.

## Root cause

Megatron GRPO first gathers local samples across the rollout group (`TP x PP x CP`) and computes KL for that full concatenated sample set on every rank. `_compute_kl_from_batches` then gathered those already group-wide KL values globally.

Rewards follow a different path: each rank scores only its locally owned samples, then gathers those local rewards globally once. As a result, the KL tensor contained replicated rollout-group entries and could be larger than the rewards tensor. With the 4-way parallel configuration reported in #9917, this produced the deterministic `512` versus `2048` mismatch when applying the KL reward penalty.

## Fix

The rollout-group sample counts and rank identify the exact slice originally owned by each process. Only that local KL slice is passed to the existing global gather, so KL and rewards now use identical sample ownership and ordering. The implementation supports non-uniform sample counts within the rollout group and asserts that the concatenated KL tensor matches the gathered counts.
