### PR TITLE
fix: handle tool messages in last round loss scaling

### DIFF
--- a/swift/template/utils.py
+++ b/swift/template/utils.py
@@ -166,17 +166,7 @@ def split_str_parts_by(text: str, delimiters: List[str], regex_mode: bool = Fals
 
 
 def get_last_user_round(messages):
-    """Get the index of the last round's user or tool message.
-
-    A round is a (query, assistant) pair; the query role is 'user' or 'tool'.
-    For agent / tool-call data the last round's query is usually a
-    tool response, so 'tool' must be counted here too -- otherwise the last
-    round is mis-identified and 'last_round' loss scaling ends up training on
-    every assistant turn instead of only the final one. Consecutive tools are
-    already merged into one message by ``_swift_prepare_inputs`` (which runs
-    before this is called from ``LossScale.__call__``), so parallel tool calls
-    count as a single round-start.
-    """
+    """Get the index of the last user or tool message."""
     for i in range(len(messages) - 1, -1, -1):
         if messages[i]['role'] in ('user', 'tool'):
             return i

--- a/swift/template/utils.py
+++ b/swift/template/utils.py
@@ -166,9 +166,19 @@ def split_str_parts_by(text: str, delimiters: List[str], regex_mode: bool = Fals
 
 
 def get_last_user_round(messages):
-    """Get the index of the last occurrence of user role"""
+    """Get the index of the last round's user or tool message.
+
+    A round is a (query, assistant) pair; the query role is 'user' or 'tool'.
+    For agent / tool-call data the last round's query is usually a
+    tool response, so 'tool' must be counted here too -- otherwise the last
+    round is mis-identified and 'last_round' loss scaling ends up training on
+    every assistant turn instead of only the final one. Consecutive tools are
+    already merged into one message by ``_swift_prepare_inputs`` (which runs
+    before this is called from ``LossScale.__call__``), so parallel tool calls
+    count as a single round-start.
+    """
     for i in range(len(messages) - 1, -1, -1):
-        if messages[i]['role'] == 'user':
+        if messages[i]['role'] in ('user', 'tool'):
             return i
     return -1
 

--- a/tests/loss_scale/test_last_user_round.py
+++ b/tests/loss_scale/test_last_user_round.py
@@ -5,10 +5,22 @@ from swift.template import get_last_user_round
 
 def test_get_last_user_round_accepts_tool_message():
     messages = [
-        {'role': 'user', 'content': 'question 1'},
-        {'role': 'assistant', 'content': 'answer 1'},
-        {'role': 'tool', 'content': 'tool result'},
-        {'role': 'assistant', 'content': 'final answer'},
+        {
+            'role': 'user',
+            'content': 'question 1'
+        },
+        {
+            'role': 'assistant',
+            'content': 'answer 1'
+        },
+        {
+            'role': 'tool',
+            'content': 'tool result'
+        },
+        {
+            'role': 'assistant',
+            'content': 'final answer'
+        },
     ]
 
     assert get_last_user_round(messages) == 2

--- a/tests/loss_scale/test_last_user_round.py
+++ b/tests/loss_scale/test_last_user_round.py
@@ -1,0 +1,14 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+
+from swift.template import get_last_user_round
+
+
+def test_get_last_user_round_accepts_tool_message():
+    messages = [
+        {'role': 'user', 'content': 'question 1'},
+        {'role': 'assistant', 'content': 'answer 1'},
+        {'role': 'tool', 'content': 'tool result'},
+        {'role': 'assistant', 'content': 'final answer'},
+    ]
+
+    assert get_last_user_round(messages) == 2


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix incorrect `last_round` loss scaling for agent conversations containing tool responses.

Previously, `get_last_user_round` only recognized messages with the `user` role. In tool-call conversations, a `tool` message starts the final query-response round, so the last round could be identified incorrectly and loss scaling could be applied to earlier assistant responses.

This change treats both `user` and `tool` messages as valid round-start messages. It also adds a regression test for a conversation ending with a tool response followed by the final assistant response.

## Experiment results

- Added regression test: `tests/loss_scale/test_last_user_round.py`
- `git diff --check` passed.