### PR TITLE
Keep SGLang and LMDeploy streaming response IDs stable

### DIFF
--- a/swift/infer_engine/lmdeploy_engine.py
+++ b/swift/infer_engine/lmdeploy_engine.py
@@ -23,7 +23,8 @@ from swift.utils import get_logger, get_seed, safe_snapshot_download
 from .infer_engine import InferEngine
 from .patch import patch_auto_config, patch_auto_tokenizer
 from .protocol import (ChatCompletionResponse, ChatCompletionResponseChoice, ChatCompletionResponseStreamChoice,
-                       ChatCompletionStreamResponse, ChatMessage, DeltaMessage, InferRequest, RequestConfig)
+                       ChatCompletionStreamResponse, ChatMessage, DeltaMessage, InferRequest, RequestConfig,
+                       random_uuid)
 from .utils import InferStreamer
 
 try:
@@ -194,6 +195,7 @@ class LmdeployEngine(InferEngine):
         generation_config: LmdeployGenerationConfig,
         request_config: RequestConfig,
     ) -> AsyncIterator[ChatCompletionStreamResponse]:
+        request_id = f'chatcmpl-{random_uuid()}'
         session_id = time.time_ns()
         kwargs = {'stream_output': True, 'gen_config': generation_config, 'sequence_start': True, 'sequence_end': True}
         if version.parse(lmdeploy.__version__) >= version.parse('0.6.5'):
@@ -236,7 +238,8 @@ class LmdeployEngine(InferEngine):
                         finish_reason=finish_reason,
                         logprobs=logprobs)
                 ]
-                yield ChatCompletionStreamResponse(model=self.model_name, choices=choices, usage=usage_info)
+                yield ChatCompletionStreamResponse(
+                    model=self.model_name, choices=choices, usage=usage_info, id=request_id)
 
     async def _infer_full_async(
         self,

--- a/swift/infer_engine/sglang_engine.py
+++ b/swift/infer_engine/sglang_engine.py
@@ -268,17 +268,19 @@ class SglangEngine(InferEngine):
 
     async def _infer_stream_async(self, inputs: Dict[str, Any], generation_config: Dict[str, Any],
                                   **kwargs) -> AsyncIterator[ChatCompletionStreamResponse]:
+        request_id = f'chatcmpl-{random_uuid()}'
         engine_inputs = {k: v for k, v in inputs.items() if k != 'template_inputs'}
         result_generator = await self.engine.async_generate(
             **engine_inputs, sampling_params=generation_config, stream=True)
         infer_streamer = InferStreamer(self.template, template_inputs=inputs['template_inputs'])
         async for output in result_generator:
-            res = self._create_chat_completion_stream_response(output, infer_streamer)
+            res = self._create_chat_completion_stream_response(output, infer_streamer, request_id)
             if res is None:
                 continue
             yield res
 
-    def _create_chat_completion_stream_response(self, output, infer_streamer) -> Optional[ChatCompletionStreamResponse]:
+    def _create_chat_completion_stream_response(self, output, infer_streamer,
+                                                request_id) -> Optional[ChatCompletionStreamResponse]:
         assert output is not None
         meta_info = output['meta_info']
         finish_reason = meta_info['finish_reason']
@@ -299,4 +301,4 @@ class SglangEngine(InferEngine):
             delta=DeltaMessage(role='assistant', content=delta_text, tool_calls=toolcall),
             finish_reason=finish_reason,
             logprobs=None)
-        return ChatCompletionStreamResponse(model=self.model_name, choices=[choice], usage=usage_info)
+        return ChatCompletionStreamResponse(model=self.model_name, choices=[choice], usage=usage_info, id=request_id)


### PR DESCRIPTION
## Summary

- Generate one chat completion response ID when an SGLang stream starts and reuse it for every chunk.
- Do the same for LMDeploy streaming responses.
- Keep the ID format consistent with the Transformers backend: `chatcmpl-<uuid>`.

## Root cause

`ChatCompletionStreamResponse.id` has a `default_factory` that calls `random_uuid()`. Both SGLang and LMDeploy constructed a new `ChatCompletionStreamResponse` for every emitted chunk without passing an explicit ID.

As a result, one logical request produced unrelated response IDs:

```text
chunk 1: chatcmpl-abc
chunk 2: chatcmpl-def
chunk 3: chatcmpl-ghi
```

Streaming clients use the response ID to correlate chunks that belong to the same completion. Changing it on every chunk breaks that identity and makes aggregation, tracing, and request-level accounting unreliable.

The Transformers backend already creates one `request_id_list` before streaming and passes the corresponding ID to every `ChatCompletionStreamResponse`, which establishes the intended repository behavior.

## Fix

Each affected backend now creates one `chatcmpl-<uuid>` at the beginning of `_infer_stream_async()`:

- SGLang passes that ID into `_create_chat_completion_stream_response()` for every chunk.
- LMDeploy closes over the same ID when yielding each chunk.

Non-streaming responses and other inference backends are unchanged.
