### PR TITLE
Fix reward model margin broadcasting and alignment

### DIFF
--- a/swift/megatron/trainers/reward_trainer.py
+++ b/swift/megatron/trainers/reward_trainer.py
@@ -16,8 +16,13 @@ class MegatronRewardTrainer(MegatronRLHFTrainer):
         margin = data.pop('margin', None)
         num_samples = output_tensor.shape[0] if packed_seq_params is None else packed_seq_params.seq_lens.shape[0]
         rewards = self.get_last_tokens(output_tensor, packed_seq_params, data.get('attention_mask'))
-        rewards_chosen, rewards_rejected = torch.split(rewards, num_samples // 2, dim=0)
+        batch_size = num_samples // 2
+        rewards_chosen, rewards_rejected = torch.split(rewards, batch_size, dim=0)
         if margin is not None:
+            margin = margin.to(device=rewards_chosen.device, dtype=rewards_chosen.dtype)
+            if margin.numel() != batch_size:
+                raise ValueError(f'Expected {batch_size} margins, got {margin.numel()}.')
+            margin = margin.reshape_as(rewards_chosen)
             loss = -nn.functional.logsigmoid(rewards_chosen - rewards_rejected - margin).mean()
         else:
             loss = -nn.functional.logsigmoid(rewards_chosen - rewards_rejected).mean()

--- a/swift/rlhf_trainers/reward_trainer.py
+++ b/swift/rlhf_trainers/reward_trainer.py
@@ -46,6 +46,10 @@ class RewardTrainer(RLHFTrainerMixin, SwiftMixin, HFRewardTrainer):
         rewards = model(**inputs).logits
         rewards_chosen, rewards_rejected = torch.split(rewards, batch_size, dim=0)
         if margin is not None:
+            margin = margin.to(device=rewards_chosen.device, dtype=rewards_chosen.dtype)
+            if margin.numel() != batch_size:
+                raise ValueError(f'Expected {batch_size} margins, got {margin.numel()}.')
+            margin = margin.reshape_as(rewards_chosen)
             loss = -nn.functional.logsigmoid(rewards_chosen - rewards_rejected - margin).mean()
         else:
             loss = -nn.functional.logsigmoid(rewards_chosen - rewards_rejected).mean()

--- a/swift/template/base.py
+++ b/swift/template/base.py
@@ -1817,8 +1817,9 @@ class Template(ProcessorMixin):
         res = self._data_collator(new_batch, padding_to=padding_to)
 
         # reward modeling
-        margin = [b['margin'] for b in batch if b.get('margin') is not None]
-        if margin:
+        has_margin = any(b.get('margin') is not None for b in batch)
+        if has_margin:
+            margin = [0.0 if b.get('margin') is None else b['margin'] for b in batch]
             res['margin'] = torch.tensor(margin, dtype=torch.float)
 
         return res


### PR DESCRIPTION
## Summary

- keep one reward-model margin per preference pair by filling missing margins with `0.0`
- validate the number of margins before computing the pairwise loss
- reshape margins to match scalar reward outputs in both the Transformers and Megatron reward trainers

## Root cause

The RLHF collator previously dropped samples whose margin was missing, which could misalign the remaining margins with their original preference pairs.

For a standard scalar reward head, chosen and rejected rewards have shape `[B, 1]`, while the collator produced margins with shape `[B]`. Subtracting these tensors broadcasts to `[B, B]`, silently mixing every reward pair with every margin instead of computing one loss term per pair.

## Impact

Reward-model training now applies each margin only to its corresponding chosen/rejected pair. Samples without an explicit margin use a zero margin, preserving the original batch ordering.

## Validation

- CPU in-memory smoke test verified the loss against an explicit `margin[:, None]` calculation
- mixed-margin batch `[0.1, None, 0.3]` produced `[0.1, 0.0, 0.3]`
- project pre-commit checks passed for all three changed files
- `git diff --check` passed
