### PR TITLE
fix: 修复 Megatron GRPO 多模态缓存失配

### DIFF
--- a/examples/megatron/grpo/dense_colocate.sh
+++ b/examples/megatron/grpo/dense_colocate.sh
@@ -6,6 +6,7 @@
 # generation_batch_size = global_batch_size * steps_per_generation (128 * 4 = 512)
 # num_of_prompt_to_rollout = generation_batch_size / num_generations (512 / 8 = 64)
 # num_of_prompt_to_train = generation_batch_size / num_generations (128 / 8 = 16)
+# Disable the multimodal processor cache to avoid mismatches across iterations.
 
 CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
 NPROC_PER_NODE=8 \
@@ -29,6 +30,7 @@ megatron rlhf \
     --use_vllm true \
     --vllm_mode colocate \
     --vllm_gpu_memory_utilization 0.7 \
+    --vllm_mm_processor_cache_gb 0 \
     --vllm_max_model_len 10240 \
     --max_length 8192 \
     --max_completion_length 2048 \


### PR DESCRIPTION
## 修改内容

- 在 Megatron GRPO 多模态 dense colocate 示例中禁用 vLLM multimodal processor cache。
- 添加简短注释，说明该设置用于避免不同迭代之间的多模态 processor cache 失配。

## 原因

维护者在 #9863 中给出了将 vllm_mm_processor_cache_gb 设为 0 的 workaround。本 PR 将该设置补充到对应的官方多模态示例，不修改参数默认值或训练器实现。

## 验证

- bash 语法检查通过
- 目标文件 pre-commit 检查通过
- 已确认参数由 Megatron 参数定义和 rollout 调用链支持
- 未运行需要 8 张 GPU 的完整训练示例

Closes #9863