### PR TITLE
fix:change lint chekc to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.13.0
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,10 @@
 repos:
-  - repo: https://github.com/pycqa/flake8.git
-    rev: 7.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
     hooks:
-      - id: flake8
-  - repo: https://github.com/PyCQA/isort.git
-    rev: 8.0.1
-    hooks:
-      - id: isort
-  - repo: https://github.com/google/yapf.git
-    rev: v0.43.0
-    hooks:
-      - id: yapf
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
     rev: v6.0.0
     hooks:
@@ -18,7 +12,6 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
-      - id: double-quote-string-fixer
       - id: check-merge-conflict
       - id: mixed-line-ending
         args: ["--fix=lf"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,16 @@ SWIFT has conventional variable naming conventions and development approaches. P
 3. Choose well-known open-source libraries, avoid using closed-source libraries or unstable open-source libraries, and avoid repeating the existing code.
 
 After the PR is submitted, SWIFT will perform two types of tests:
-- Code Lint Test: A static code compliance check test. please make sure that you have performed code lint locally in advance.
+- Code Lint Test: A static code compliance check test using [ruff](https://docs.astral.sh/ruff/). Please make sure that you have performed code lint locally in advance.
 ```shell
-pip install pre-commit # In the swift folder
-pre-commit run --all-files # Fix the errors reported by pre-commit until all checks are successful
+pip install pre-commit ruff  # In the swift folder
+pre-commit run --all-files   # Fix the errors reported by pre-commit until all checks are successful
+
+# You can also run ruff directly:
+ruff check .                 # Check lint issues (read-only)
+ruff check --fix .            # Check and auto-fix lint issues
+ruff format --check .        # Check formatting (read-only)
+ruff format .                # Format code
 ```
 - CI Tests: Smoke tests and unit tests, please refer to the next section.
 

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -49,13 +49,19 @@ SWIFT有约定俗成的变量命名方式和开发方式。在开发中请尽量
 
 SWIFT在PR提交后会进行两类测试：
 
-- Code Lint测试 对代码进行静态规范走查的测试，为保证改测试通过，请保证本地预先进行了Code lint。方法是：
+- Code Lint测试 对代码进行静态规范走查的测试，使用 [ruff](https://docs.astral.sh/ruff/)。为保证该测试通过，请保证本地预先进行了Code lint。方法是：
 
   ```shell
-  pip install pre-commit
+  pip install pre-commit ruff
   # 在swift文件夹内
   pre-commit run --all-files
   # 对pre-commit报的错误进行修改，直到所有的检查都是成功状态
+
+  # 也可以直接使用ruff：
+  ruff check .              # 检查lint问题（只读，不修改文件）
+  ruff check --fix .        # 检查并自动修复lint问题
+  ruff format --check .     # 检查代码格式（只读，不修改文件）
+  ruff format .             # 格式化代码
   ```
 
 - CI Tests 冒烟测试和单元测试，请查看下一章节

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.ruff]
+line-length = 120
+target-version = "py38"
+exclude = ["docs/src", "*.pyi", ".git", "peft.py"]
+
+[tool.ruff.lint]
+select = ["B", "C", "E", "F", "W", "I"]
+ignore = ["F401", "F403", "F405", "F821", "E251"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["swift"]
+known-third-party = ["json", "yaml"]
+no-lines-before = ["standard-library", "local-folder"]
+default-section = "third-party"
+
+[tool.ruff.format]
+quote-style = "double"

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,7 +1,5 @@
 expecttest
-flake8
-isort>=4.3.21
 modelscope
 pre-commit
 pytest
-yapf==0.30.0 # use fix version to ensure consistent auto-styling
+ruff

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,29 +1,7 @@
-[isort]
-line_length = 120
-multi_line_output = 0
-known_standard_library = setuptools
-known_first_party = swift
-known_third_party = json,yaml
-no_lines_before = STDLIB,LOCALFOLDER
-default_section = THIRDPARTY
-
-[yapf]
-BASED_ON_STYLE = pep8
-COLUMN_LIMIT = 120
-BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF = true
-SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
-SPLIT_BEFORE_ARITHMETIC_OPERATOR = true
-
 [codespell]
 skip = *.ipynb
 quiet-level = 3
 ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids
-
-[flake8]
-max-line-length = 120
-select = B,C,E,F,P,T4,W,B9
-ignore = F401,F403,F405,F821,W503,E251,W504,E126
-exclude = docs/src,*.pyi,.git,peft.py
 
 [darglint]
 ignore=DAR101

--- a/tests/megatron/test_ray_gkd.py
+++ b/tests/megatron/test_ray_gkd.py
@@ -192,7 +192,7 @@ def test_megatron_assemble_teacher_outputs_api_topk_rolls_labels():
     """
     try:
         from swift.megatron.trainers.gkd_trainer import MegatronGKDTrainer
-    except Exception as e:  # noqa: megatron-core not installed in this env
+    except Exception as e:  # noqa
         print(f'SKIP test_megatron_assemble_teacher_outputs_api_topk_rolls_labels: {e}')
         return
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix
    The original lint check was replaced with ruff to avoid differences in check performance due to Python version inconsistencies.
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support
