### PR TITLE
docs(grpo): fix reward model spelling

### DIFF
--- a/docs/source/Instruction/GRPO/DeveloperGuide/reward_model.md
+++ b/docs/source/Instruction/GRPO/DeveloperGuide/reward_model.md
@@ -55,7 +55,7 @@ class RMPlugin(DefaultRMPlugin):
     def __init__(self, model, template):
 
         super().__init__(model, template)
-        # initilize TransformersEngine to infer
+        # initialize TransformersEngine to infer
         self.engine = TransformersEngine(self.model, template=self.template, max_batch_size=0)
 
     def __call__(self, inputs):

--- a/docs/source_en/Instruction/GRPO/DeveloperGuide/reward_model.md
+++ b/docs/source_en/Instruction/GRPO/DeveloperGuide/reward_model.md
@@ -56,7 +56,7 @@ class RMPlugin(DefaultRMPlugin):
     def __init__(self, model, template):
 
         super().__init__(model, template)
-        # initilize TransformersEngine to infer
+        # initialize TransformersEngine to infer
         self.engine = TransformersEngine(self.model, template=self.template, max_batch_size=0)
 
     def __call__(self, inputs):

--- a/swift/rewards/rm_plugin.py
+++ b/swift/rewards/rm_plugin.py
@@ -22,7 +22,7 @@ class DefaultRMPlugin:
     Default Reward Model Plugin
 
     This class implements the default processing logic for reward models.
-    It assumes that `self.model` is a classification model with a value head(output dimmension 1).
+    It assumes that `self.model` is a classification model with a value head (output dimension 1).
     The first logits value from the model's output is used as the reward score.
     """
 
@@ -54,7 +54,7 @@ class GenRMPlugin(DefaultRMPlugin):
     """
 
         super().__init__(model, template)
-        # initilize TransformersEngine to infer
+        # initialize TransformersEngine to infer
         self.engine = TransformersEngine(self.model, template=self.template, max_batch_size=0)  # 0: no limit
         self.request_config = RequestConfig()  # customise your request config here
         self.system = textwrap.dedent("""


### PR DESCRIPTION
# PR type

- [ ] Bug Fix
- [ ] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information

Correct spelling and wording in the GRPO reward model guides and the corresponding reward model plugin documentation.

- Keep the Chinese and English guide examples consistent.
- Correct `initilize` and `dimmension`.
- Add the missing space before the value-head description.

No runtime behavior is changed.

## Experiment results

- `git diff --check`
- Python AST parsing for `swift/rewards/rm_plugin.py`
- Targeted `codespell`