### PR TITLE
Add --dataloader_multiprocessing_context to work around Python 3.14 incompatibility

### DIFF
--- a/swift/megatron/arguments/megatron_args.py
+++ b/swift/megatron/arguments/megatron_args.py
@@ -514,6 +514,7 @@ class MegatronArguments(RLHFMegatronArgumentsMixin, MegatronTunerMixin):
     seed: int = 42
     train_dataloader_shuffle: bool = True
     dataloader_num_workers: int = 4
+    dataloader_multiprocessing_context: Optional[Literal['fork', 'spawn', 'forkserver']] = None
     dataloader_pin_memory: bool = True
     dataloader_persistent_workers: bool = False
     dataloader_prefetch_factor: int = 2

--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -1014,6 +1014,7 @@ class BaseMegatronTrainer(ABC):
             pin_memory=args.dataloader_pin_memory,
             persistent_workers=args.dataloader_persistent_workers if args.dataloader_num_workers > 0 else False,
             prefetch_factor=args.dataloader_prefetch_factor if args.dataloader_num_workers > 0 else None,
+            multiprocessing_context=args.dataloader_multiprocessing_context,
             collate_fn=self.data_collator,
         )
         return dataloader

--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -343,7 +343,7 @@ def build_streaming_dataloader(args, dataset, collate_fn):
         batch_size=args.micro_batch_size,
         prefetch_factor=args.dataloader_prefetch_factor if args.dataloader_num_workers > 0 else None,
         persistent_workers=args.dataloader_persistent_workers if args.dataloader_num_workers > 0 else False,
-    )
+        multiprocessing_context=args.dataloader_multiprocessing_context)
     return MegatronDataLoaderDispatcher(base_dataloader)
 
 

--- a/swift/rlhf_trainers/utils.py
+++ b/swift/rlhf_trainers/utils.py
@@ -1545,6 +1545,7 @@ def get_chord_sft_dataloader(trainer,
         'batch_size': batch_size,
         'collate_fn': data_collator,
         'num_workers': trainer.args.dataloader_num_workers,
+        'multiprocessing_context': trainer.args.dataloader_multiprocessing_context,
         'pin_memory': trainer.args.dataloader_pin_memory,
         'persistent_workers': trainer.args.dataloader_persistent_workers,
     }

--- a/swift/trainers/arguments.py
+++ b/swift/trainers/arguments.py
@@ -48,6 +48,9 @@ class TrainArgumentsMixin:
             to ['tensorboard']. If you specify `--report_to wandb`, you can set the project name through `WANDB_PROJECT`
             and specify the API KEY corresponding to your account through `WANDB_API_KEY`.
         dataloader_num_workers (Optional[int]): The number of subprocesses to use for data loading. Defaults to None.
+        dataloader_multiprocessing_context (Optional[Literal['fork', 'spawn', 'forkserver']]): The multiprocessing
+            context to use for data loading workers. If None, the default multiprocessing context is used. Defaults to
+            None.
         dataloader_persistent_workers (bool): If True, the data loader workers will not be shut down after a dataset
             has been consumed once. Defaults to False.
         dataloader_prefetch_factor (Optional[int]): The number of batches loaded in advance by each worker. Defaults
@@ -148,6 +151,7 @@ class TrainArgumentsMixin:
     lr_scheduler_kwargs: Optional[Union[dict, str]] = None
     report_to: List[str] = field(default_factory=lambda: ['tensorboard'])
     dataloader_num_workers: Optional[int] = None
+    dataloader_multiprocessing_context: Optional[Literal['fork', 'spawn', 'forkserver']] = None
     dataloader_persistent_workers: bool = False
     dataloader_prefetch_factor: Optional[int] = None
     use_liger_kernel: bool = False

--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -39,7 +39,7 @@ try:
 except ImportError:
     sort_checkpoints = None
 from types import MethodType
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, override
 
 from swift.callbacks import callbacks_map
 from swift.dataloader import BatchSamplerShard, DataLoaderDispatcher, DataLoaderShard
@@ -1266,6 +1266,7 @@ class DataLoaderMixin:
                 'num_workers': self.args.dataloader_num_workers,
                 'pin_memory': self.args.dataloader_pin_memory,
                 'persistent_workers': self.args.dataloader_persistent_workers,
+                'multiprocessing_context': self.args.dataloader_multiprocessing_context
             }
 
             if not isinstance(dataset, torch.utils.data.IterableDataset):
@@ -1284,6 +1285,7 @@ class DataLoaderMixin:
                 'num_workers': self.args.dataloader_num_workers,
                 'pin_memory': self.args.dataloader_pin_memory,
                 'persistent_workers': self.args.dataloader_persistent_workers,
+                'multiprocessing_context': self.args.dataloader_multiprocessing_context,
                 'prefetch_factor': self.args.dataloader_prefetch_factor
             }
             if dist.is_initialized() and dataloader_params['prefetch_factor']:
@@ -1309,6 +1311,7 @@ class DataLoaderMixin:
                 'num_workers': args.dataloader_num_workers,
                 'pin_memory': args.dataloader_pin_memory,
                 'persistent_workers': args.dataloader_persistent_workers,
+                'multiprocessing_context': args.dataloader_multiprocessing_context,
                 'prefetch_factor': args.dataloader_prefetch_factor
             }
             batch_sampler_params = {
@@ -1352,6 +1355,15 @@ class DataLoaderMixin:
             yield
         finally:
             self.args.group_by_length = group_by_length
+
+    @override
+    def _get_dataloader(self, *args, **kwargs):
+        # Fix multiprocessing context here since Transformers doesn't (yet—recent main does) provide an option
+        dataloader = super()._get_dataloader(*args, **kwargs)
+        base = getattr(dataloader, 'base_dataloader', dataloader)
+        if (hasattr(base, 'multiprocessing_context') and base.multiprocessing_context is None):
+            base.multiprocessing_context = self.args.dataloader_multiprocessing_context
+        return dataloader
 
     def get_eval_dataloader(self, eval_dataset=None):
         dataloader = None


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [X] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Background

In Python 3.14, the default multiprocessing method on Linux changed from `fork` to the much safer `forkserver`. This, however, exposes a latent issue in swift (see https://github.com/modelscope/ms-swift/issues/4586): The data loader has a reference to the entire model, which Python tries to pickle and send to the workers.

 It seems someone has previously taken care to not serialize the entire model:

https://github.com/modelscope/ms-swift/blob/302b074dd4e8886ba98d7797899fcd993f41ae14/swift/pipelines/train/sft.py#L309

This protects one serialization path, but after restoring `template.model`, `__post_process_datasets()`, wraps the dataset using `template.encode` as a bound method which makes the model reachable again:

https://github.com/modelscope/ms-swift/blob/302b074dd4e8886ba98d7797899fcd993f41ae14/swift/pipelines/train/sft.py#L137

This was bad already before Python 3.14; CUDA and `fork` do not go well together. However, it has worked in practice because the data loader doesn't touch anything CUDA.

In practice, when using Python 3.14, I have used `--dataloader_num_workers 0` to work around this problem; however, that's obviously not ideal.

## What would a proper fix look like

I think a proper fix would ensure that the model is not reachable from the DataLoader so that it can be properly pickled. Perhaps distinguishing a *worker template* from a *model-bound training template*; conceptually

```
training template
    processor
    template logic
    model ──────────────> live CUDA model

worker template
    processor
    template logic
    model = None
```

The DataLoader's dataset and collator get the worker-safe one. Model-dependent `_post_encode` happens in the main training process with the real one.

## What this PR does

I am hesitant to do bigger refactorings of a code base I do not understand well enough, so this PR provides what I consider a minimal reasonable workaround for the current state of things: It allows specifying an optional parameter `--dataloader_multiprocessing_context`, with valid options `fork`, `forkserver`, `spawn`, defaulting to `None`, which I believe is the reasonable safe choice as this really only papers over a bug. Now, with `--dataloader_multiprocessing_context fork` my training runs work on Python 3.14.

There's a wart: Transformers do not, in released versions, expose a parameter to do this; hence, the PR overrides `_get_dataloader` and changes the loader's held context. In `main`, transformers has adopted this parameter:

https://github.com/huggingface/transformers/blob/f9b76f2dfc44fdc6109468925bf0e1856fd34278/src/transformers/training_args.py#L1318

## Reflections

I'm sending this hope it's useful. I would be more than happy if someone actually fixed the underlying issue of the data loader having a reference to the model (and thus being unpickleable) instead. I hope this at least demonstrates what the issue is even if deemed too hacky to merge.