### PR TITLE
Support MOSS-VL

### DIFF
--- a/docs/source/Instruction/Supported-models-and-datasets.md
+++ b/docs/source/Instruction/Supported-models-and-datasets.md
@@ -733,6 +733,8 @@
 ### 多模态大模型
 | Model ID | Model Type | Default Template | Default Agent Template | Requires | Support Megatron | Tags | HF Model ID |
 | -------- | -----------| ---------------- | ---------------------- | -------- | ---------------- | ---- | ----------- |
+|[openmoss/MOSS-VL-Instruct-0708](https://modelscope.cn/models/openmoss/MOSS-VL-Instruct-0708)|moss_vl|moss_vl|hermes|transformers>=4.57.1,<5, torchcodec, joblib|&#x2718;|vision, video|[OpenMOSS-Team/MOSS-VL-Instruct-0708](https://huggingface.co/OpenMOSS-Team/MOSS-VL-Instruct-0708)|
+|[openmoss/MOSS-VL-Base-0708](https://modelscope.cn/models/openmoss/MOSS-VL-Base-0708)|moss_vl|moss_vl|hermes|transformers>=4.57.1,<5, torchcodec, joblib|&#x2718;|vision, video|[OpenMOSS-Team/MOSS-VL-Base-0708](https://huggingface.co/OpenMOSS-Team/MOSS-VL-Base-0708)|
 |[Qwen/Qwen-VL-Chat](https://modelscope.cn/models/Qwen/Qwen-VL-Chat)|qwen_vl|qwen_vl||-|&#x2718;|vision|[Qwen/Qwen-VL-Chat](https://huggingface.co/Qwen/Qwen-VL-Chat)|
 |[Qwen/Qwen-VL](https://modelscope.cn/models/Qwen/Qwen-VL)|qwen_vl|qwen_vl||-|&#x2718;|vision|[Qwen/Qwen-VL](https://huggingface.co/Qwen/Qwen-VL)|
 |[Qwen/Qwen-VL-Chat-Int4](https://modelscope.cn/models/Qwen/Qwen-VL-Chat-Int4)|qwen_vl|qwen_vl||-|&#x2718;|vision|[Qwen/Qwen-VL-Chat-Int4](https://huggingface.co/Qwen/Qwen-VL-Chat-Int4)|

--- a/docs/source_en/Instruction/Supported-models-and-datasets.md
+++ b/docs/source_en/Instruction/Supported-models-and-datasets.md
@@ -734,6 +734,8 @@ The table below introduces the models integrated with ms-swift:
 ### Multimodal large models
 | Model ID | Model Type | Default Template | Default Agent Template | Requires | Support Megatron | Tags | HF Model ID |
 | -------- | -----------| ---------------- | ---------------------- | -------- | ---------------- | ---- | ----------- |
+|[openmoss/MOSS-VL-Instruct-0708](https://modelscope.cn/models/openmoss/MOSS-VL-Instruct-0708)|moss_vl|moss_vl|hermes|transformers>=4.57.1,<5, torchcodec, joblib|&#x2718;|vision, video|[OpenMOSS-Team/MOSS-VL-Instruct-0708](https://huggingface.co/OpenMOSS-Team/MOSS-VL-Instruct-0708)|
+|[openmoss/MOSS-VL-Base-0708](https://modelscope.cn/models/openmoss/MOSS-VL-Base-0708)|moss_vl|moss_vl|hermes|transformers>=4.57.1,<5, torchcodec, joblib|&#x2718;|vision, video|[OpenMOSS-Team/MOSS-VL-Base-0708](https://huggingface.co/OpenMOSS-Team/MOSS-VL-Base-0708)|
 |[Qwen/Qwen-VL-Chat](https://modelscope.cn/models/Qwen/Qwen-VL-Chat)|qwen_vl|qwen_vl||-|&#x2718;|vision|[Qwen/Qwen-VL-Chat](https://huggingface.co/Qwen/Qwen-VL-Chat)|
 |[Qwen/Qwen-VL](https://modelscope.cn/models/Qwen/Qwen-VL)|qwen_vl|qwen_vl||-|&#x2718;|vision|[Qwen/Qwen-VL](https://huggingface.co/Qwen/Qwen-VL)|
 |[Qwen/Qwen-VL-Chat-Int4](https://modelscope.cn/models/Qwen/Qwen-VL-Chat-Int4)|qwen_vl|qwen_vl||-|&#x2718;|vision|[Qwen/Qwen-VL-Chat-Int4](https://huggingface.co/Qwen/Qwen-VL-Chat-Int4)|

--- a/examples/models/moss_vl/full.sh
+++ b/examples/models/moss_vl/full.sh
@@ -1,0 +1,42 @@
+# 8 * 80GiB
+# MOSS-VL requires non-reentrant gradient checkpointing and does not support packing/padding-free training.
+pip install "transformers>=4.57.1,<5" joblib
+pip install torchcodec==0.7.0  # match your torch version: 0.7.x for torch 2.8
+
+VIDEO_MIN_PIXELS=256 \
+VIDEO_MAX_PIXELS=16384 \
+FPS=1 \
+FPS_MAX_FRAMES=256 \
+NPROC_PER_NODE=8 \
+CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+swift sft \
+    --model OpenMOSS-Team/MOSS-VL-Instruct-0708 \
+    --dataset 'lmms-lab/VideoChatGPT:Generic#1000' \
+    --use_hf true \
+    --split_dataset_ratio 0.01 \
+    --tuner_type full \
+    --torch_dtype bfloat16 \
+    --num_train_epochs 1 \
+    --per_device_train_batch_size 1 \
+    --per_device_eval_batch_size 1 \
+    --attn_impl eager \
+    --packing false \
+    --learning_rate 1e-5 \
+    --freeze_llm false \
+    --freeze_vit false \
+    --freeze_aligner false \
+    --gradient_accumulation_steps 2 \
+    --gradient_checkpointing true \
+    --vit_gradient_checkpointing true \
+    --gradient_checkpointing_kwargs '{"use_reentrant": false}' \
+    --eval_steps 50 \
+    --save_steps 50 \
+    --save_total_limit 2 \
+    --logging_steps 5 \
+    --max_length 4096 \
+    --max_pixels 262144 \
+    --output_dir output/moss_vl_full \
+    --warmup_ratio 0.05 \
+    --deepspeed zero3 \
+    --dataset_num_proc 4 \
+    --dataloader_num_workers 4

--- a/examples/models/moss_vl/lora.sh
+++ b/examples/models/moss_vl/lora.sh
@@ -1,0 +1,42 @@
+# 1 * 80GiB
+# MOSS-VL requires non-reentrant gradient checkpointing and does not support packing/padding-free training.
+pip install "transformers>=4.57.1,<5" joblib
+pip install torchcodec==0.7.0  # match your torch version: 0.7.x for torch 2.8
+
+VIDEO_MIN_PIXELS=256 \
+VIDEO_MAX_PIXELS=16384 \
+FPS=1 \
+FPS_MAX_FRAMES=256 \
+CUDA_VISIBLE_DEVICES=0 \
+swift sft \
+    --model OpenMOSS-Team/MOSS-VL-Instruct-0708 \
+    --dataset 'lmms-lab/VideoChatGPT:Generic#1000' \
+    --use_hf true \
+    --split_dataset_ratio 0.01 \
+    --tuner_type lora \
+    --torch_dtype bfloat16 \
+    --num_train_epochs 1 \
+    --per_device_train_batch_size 1 \
+    --per_device_eval_batch_size 1 \
+    --attn_impl eager \
+    --packing false \
+    --learning_rate 1e-4 \
+    --lora_rank 8 \
+    --lora_alpha 32 \
+    --target_modules all-linear \
+    --freeze_vit true \
+    --freeze_aligner true \
+    --gradient_accumulation_steps 16 \
+    --gradient_checkpointing true \
+    --vit_gradient_checkpointing false \
+    --gradient_checkpointing_kwargs '{"use_reentrant": false}' \
+    --eval_steps 50 \
+    --save_steps 50 \
+    --save_total_limit 2 \
+    --logging_steps 5 \
+    --max_length 4096 \
+    --max_pixels 262144 \
+    --output_dir output/moss_vl_lora \
+    --warmup_ratio 0.05 \
+    --dataset_num_proc 4 \
+    --dataloader_num_workers 4

--- a/swift/model/constant.py
+++ b/swift/model/constant.py
@@ -137,6 +137,7 @@ class RMModelType:
 
 
 class MLLMModelType:
+    moss_vl = 'moss_vl'
     qwen_vl = 'qwen_vl'
     qwen_audio = 'qwen_audio'
     qwen2_vl = 'qwen2_vl'

--- a/swift/model/model_arch.py
+++ b/swift/model/model_arch.py
@@ -25,6 +25,7 @@ class LLMModelArch:
 
 
 class MLLMModelArch:
+    moss_vl = 'moss_vl'
     qwen_vl = 'qwen_vl'
     qwen_audio = 'qwen_audio'
     qwen2_vl = 'qwen2_vl'
@@ -593,6 +594,15 @@ else:
             vision_tower='visual',
             mlp='model.layers.{}.mlp',
         ))
+
+register_model_arch(
+    MultiModelKeys(
+        MLLMModelArch.moss_vl,
+        language_model=['model.language_model', 'lm_head'],
+        aligner=['model.visual.merger', 'model.separator_token'],
+        vision_tower='model.visual',
+        mlp='model.language_model.layers.{}.mlp',
+    ))
 
 register_model_arch(
     MultiModelKeys(

--- a/swift/model/models/__init__.py
+++ b/swift/model/models/__init__.py
@@ -1,3 +1,3 @@
 from . import (baai, baichuan, baidu, bert, codefuse, deepseek, gemma, glm, internlm, llama, llava, llm, mamba,
-               microsoft, minicpm, minimax, mistral, mllm, moonshot, mplug, nvidia, openbuddy, qwen, seed, skywork,
-               stepfun, telechat, tencent, valley, yi)
+               microsoft, minicpm, minimax, mistral, mllm, moonshot, moss, mplug, nvidia, openbuddy, qwen, seed,
+               skywork, stepfun, telechat, tencent, valley, yi)

--- a/swift/model/models/moss.py
+++ b/swift/model/models/moss.py
@@ -1,0 +1,44 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+
+from transformers import PretrainedConfig, PreTrainedModel
+
+from swift.template import TemplateType
+from ..constant import MLLMModelType
+from ..model_arch import ModelArch
+from ..model_meta import Model, ModelGroup, ModelMeta
+from ..register import ModelLoader, register_model
+
+
+def _patch_separator_token_property(model) -> None:
+    """Expose `separator_token` on the top-level model class as a BC property.
+
+    `MossVLForConditionalGeneration` ships `visual`/`language_model` BC properties but not
+    `separator_token`, so generic code resolving arch paths by attribute (e.g. the lora_llm
+    tuner's unfreeze loop) gets None for it. Add the missing accessor, mirroring `visual`.
+    """
+    if not hasattr(type(model), 'separator_token'):
+        type(model).separator_token = property(lambda self: self.model.separator_token)
+
+
+class MossVLLoader(ModelLoader):
+
+    def get_model(self, model_dir: str, config: PretrainedConfig, processor, model_kwargs) -> PreTrainedModel:
+        model = super().get_model(model_dir, config, processor, model_kwargs)
+        _patch_separator_token_property(model)
+        return model
+
+
+register_model(
+    ModelMeta(
+        MLLMModelType.moss_vl, [
+            ModelGroup([
+                Model('openmoss/MOSS-VL-Instruct-0708', 'OpenMOSS-Team/MOSS-VL-Instruct-0708'),
+                Model('openmoss/MOSS-VL-Base-0708', 'OpenMOSS-Team/MOSS-VL-Base-0708'),
+            ]),
+        ],
+        loader=MossVLLoader,
+        template=TemplateType.moss_vl,
+        model_arch=ModelArch.moss_vl,
+        architectures=['MossVLForConditionalGeneration'],
+        requires=['transformers>=4.57.1,<5', 'torchcodec', 'joblib'],
+        tags=['vision', 'video']))

--- a/swift/template/constant.py
+++ b/swift/template/constant.py
@@ -137,6 +137,7 @@ class RMTemplateType:
 
 
 class MLLMTemplateType:
+    moss_vl = 'moss_vl'
     qwen_vl = 'qwen_vl'
     qwen_audio = 'qwen_audio'
     qwen2_vl = 'qwen2_vl'

--- a/swift/template/templates/__init__.py
+++ b/swift/template/templates/__init__.py
@@ -1,3 +1,3 @@
 from . import (baai, baidu, bert, deepseek, dots, gemma, glm, idefics3, internlm, internvl, kwai, llama, llava, llm,
-               megrez, microsoft, midashenglm, mimo, minicpm, minimax, minimind, mistral, molmo, moonshot, mplug,
+               megrez, microsoft, midashenglm, mimo, minicpm, minimax, minimind, mistral, molmo, moonshot, moss, mplug,
                museglimmer, openbuddy, pixtral, qwen, seed, stepfun, tencent, valley, yi)

--- a/swift/template/templates/moss.py
+++ b/swift/template/templates/moss.py
@@ -1,0 +1,263 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import os
+import torch
+import torch.nn.functional as F
+from copy import deepcopy
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+from swift.utils import get_env_args
+from ..base import MaxLengthError, Template
+from ..constant import MLLMTemplateType
+from ..register import register_template
+from ..template_inputs import StdTemplateInputs
+from ..utils import Context
+from .utils import ChatmlTemplateMeta
+
+
+class MossVLTemplate(Template):
+    placeholder_tokens = ['<|image_pad|>', '<|video_pad|>']
+    support_padding_free = False
+    _vision_tokens = ('<|image_pad|>', '<|vision_start|>', '<|vision_end|>')
+    _processor_runtime_keys = {
+        'min_pixels',
+        'max_pixels',
+        'video_fps',
+        'min_frames',
+        'max_frames',
+        'num_extract_threads',
+    }
+    _processor_env_keys = {
+        'video_min_pixels': ('video_min_pixels', int),
+        'video_max_pixels': ('video_max_pixels', int),
+        'video_fps': ('fps', float),
+        'min_frames': ('fps_min_frames', int),
+        'max_frames': ('fps_max_frames', int),
+        'num_extract_threads': ('num_extract_threads', int),
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.sequence_parallel_size > 1:
+            raise NotImplementedError('MOSS-VL does not support sequence parallel yet.')
+        if self.truncation_strategy == 'split':
+            raise ValueError(
+                'MOSS-VL does not support truncation_strategy="split" because multimodal tensors cannot be split '
+                'with the generic text-only path. Use "left", "right", or "raise" instead.')
+
+    def replace_tag(self, media_type: Literal['image', 'video', 'audio'], index: int,
+                    inputs: StdTemplateInputs) -> List[Context]:
+        if media_type == 'image':
+            return ['<|image|>']
+        if media_type == 'video':
+            return ['<|video|>']
+        raise ValueError(f'MOSS-VL does not support media_type={media_type!r}.')
+
+    def _is_binary_loss(self) -> bool:
+        is_binary = self.is_binary_loss_scale
+        if is_binary is None:
+            is_binary = self.loss_scale.is_binary_loss_scale
+        return is_binary
+
+    def _context_to_text(self, context: Context) -> str:
+        if isinstance(context, str):
+            return context
+        if isinstance(context, dict):
+            context = context['token_ids']
+        return self.tokenizer.decode(context, skip_special_tokens=False, clean_up_tokenization_spaces=False)
+
+    def _render_text_and_spans(self, inputs: StdTemplateInputs) -> Tuple[str, List[List[int]]]:
+        inputs.messages = deepcopy(inputs.messages)
+        self._swift_prepare_inputs(inputs)
+        if self.template_backend == 'jinja':
+            if self.is_training:
+                raise ValueError('MOSS-VL SFT requires template_backend="swift" to build labels_spans.')
+            context_list, loss_scale_list, _ = self._jinja_encode(inputs)
+        else:
+            context_list, loss_scale_list, _ = self._swift_encode(inputs)
+        context_list, loss_scale_list = self._simplify_context_list(context_list, loss_scale_list, inputs)
+
+        if self.is_training and not self._is_binary_loss():
+            raise ValueError('MOSS-VL currently supports binary loss-scale strategies only. '
+                             f'Current loss_scale={self._loss_scale!r}.')
+        if any(loss_weight not in {0, 1} for loss_weight in loss_scale_list):
+            raise ValueError(f'MOSS-VL labels_spans cannot represent non-binary loss weights: {loss_scale_list}.')
+
+        parts = []
+        spans = []
+        offset = 0
+        for context, loss_weight in zip(context_list, loss_scale_list):
+            text = self._context_to_text(context)
+            parts.append(text)
+            if self.is_training and loss_weight == 1 and text:
+                spans.append([offset, offset + len(text)])
+            offset += len(text)
+        rendered = ''.join(parts)
+
+        # Native MOSS-VL supervises every assistant <|im_end|>, but not the following newline.
+        for span in spans:
+            if rendered[span[1]:].startswith('<|im_end|>'):
+                span[1] += len('<|im_end|>')
+            if rendered[span[0]:span[1]].endswith('<|im_end|>\n'):
+                span[1] -= 1
+
+        merged_spans = []
+        for span in spans:
+            if merged_spans and span[0] <= merged_spans[-1][1]:
+                merged_spans[-1][1] = max(merged_spans[-1][1], span[1])
+            elif span[0] < span[1]:
+                merged_spans.append(span)
+        return rendered, merged_spans
+
+    def _encode(self, inputs: StdTemplateInputs) -> Dict[str, Any]:
+        rendered, labels_spans = self._render_text_and_spans(inputs)
+        processor_kwargs = dict(inputs.mm_processor_kwargs)
+        runtime_kwargs = {**self.chat_template_kwargs, **inputs.chat_template_kwargs}
+        for key, (env_name, type_func) in self._processor_env_keys.items():
+            if key not in runtime_kwargs and os.getenv(env_name.upper()) is not None:
+                runtime_kwargs[key] = get_env_args(env_name, type_func, None)
+        if self.max_pixels is not None:
+            processor_kwargs.setdefault('max_pixels', self.max_pixels)
+        for key in self._processor_runtime_keys:
+            if key in runtime_kwargs:
+                processor_kwargs.setdefault(key, runtime_kwargs[key])
+
+        # MossVLProcessor does not route video_max_pixels to its video processor.
+        # Translate the common runtime knobs to the nested native `size` contract.
+        video_min_pixels = processor_kwargs.pop('video_min_pixels', runtime_kwargs.get('video_min_pixels'))
+        video_max_pixels = processor_kwargs.pop('video_max_pixels', runtime_kwargs.get('video_max_pixels'))
+        if video_min_pixels is not None or video_max_pixels is not None:
+            videos_kwargs = dict(processor_kwargs.get('videos_kwargs') or {})
+            size = dict(videos_kwargs.get('size') or getattr(self.processor.video_processor, 'size', {}) or {})
+            if video_min_pixels is not None:
+                size['shortest_edge'] = video_min_pixels
+            if video_max_pixels is not None:
+                size['longest_edge'] = video_max_pixels
+            videos_kwargs['size'] = size
+            processor_kwargs['videos_kwargs'] = videos_kwargs
+        vision_chunked_length = int(
+            processor_kwargs.pop(
+                'vision_chunked_length',
+                runtime_kwargs.get(
+                    'vision_chunked_length',
+                    get_env_args('mossvl_vision_chunked_length', int, 64),
+                ),
+            ))
+        processor_kwargs.update({
+            'text': [rendered],
+            'padding': False,
+            'return_tensors': 'pt',
+        })
+        if inputs.images:
+            processor_kwargs['images'] = inputs.images
+        if inputs.videos:
+            processor_kwargs['videos'] = inputs.videos
+        if self.is_training:
+            processor_kwargs['labels_spans'] = [labels_spans]
+
+        processor_outputs = self.processor(**processor_kwargs)
+        encoded = {
+            'input_ids': processor_outputs['input_ids'][0].tolist(),
+            'pixel_values': processor_outputs['pixel_values'],
+            'grid_thw': processor_outputs['grid_thw'],
+            'cross_attention_mask': processor_outputs['cross_attention_mask'],
+            'media_nums_per_sample': list(processor_outputs['media_nums_per_sample']),
+            'vision_chunked_length': vision_chunked_length,
+        }
+        if self.is_training:
+            encoded['labels'] = processor_outputs['labels'][0].tolist()
+        else:
+            encoded['labels'] = None
+        encoded['loss_scale'] = None
+        return encoded
+
+    def _vision_signature(self, input_ids: List[int]) -> Tuple[int, ...]:
+        token_ids = []
+        for token in self._vision_tokens:
+            token_id = self.tokenizer.convert_tokens_to_ids(token)
+            if token_id is not None and token_id != self.tokenizer.unk_token_id and token_id not in token_ids:
+                token_ids.append(token_id)
+        return tuple(input_ids.count(token_id) for token_id in token_ids)
+
+    def _truncate(self, input_ids: List[int], labels: Optional[List[int]], encoded: Dict[str, Any],
+                  truncation_strategy: Literal['left', 'right']):
+        if truncation_strategy == 'right':
+            text_slice = slice(0, self.max_length)
+        else:
+            text_slice = slice(len(input_ids) - self.max_length, len(input_ids))
+        truncated_input_ids = input_ids[text_slice]
+
+        if self._vision_signature(input_ids) != self._vision_signature(truncated_input_ids):
+            raise MaxLengthError(
+                'MOSS-VL truncation removed vision special/frame tokens while media tensors are still present. '
+                'Reduce media size/frame count, increase max_length, or change the truncation boundary.')
+
+        cross_attention_mask = encoded.get('cross_attention_mask')
+        if cross_attention_mask is not None:
+            if cross_attention_mask.shape[-2] != len(input_ids):
+                raise ValueError(
+                    'MOSS-VL cross_attention_mask text dimension does not match input_ids before truncation: '
+                    f'{cross_attention_mask.shape[-2]} != {len(input_ids)}.')
+            encoded['cross_attention_mask'] = cross_attention_mask[..., text_slice, :]
+
+        if labels is not None:
+            labels = labels[text_slice]
+            if labels:
+                labels[0] = -100
+        return truncated_input_ids, labels
+
+    def _data_collator_mm_data(self, batch: List[Dict[str, Any]]) -> Dict[str, Any]:
+        res = super()._data_collator_mm_data(batch)
+        grid_thw = self.concat_tensor(batch, 'grid_thw', 0)
+        if grid_thw is not None:
+            res['grid_thw'] = grid_thw
+
+        media_nums_per_sample = []
+        for row in batch:
+            media_nums_per_sample.extend(row.get('media_nums_per_sample') or [])
+        if media_nums_per_sample:
+            res['media_nums_per_sample'] = media_nums_per_sample
+
+        chunk_lengths = [row.get('vision_chunked_length') for row in batch]
+        chunk_lengths = [length for length in chunk_lengths if length is not None]
+        if chunk_lengths:
+            if len(set(chunk_lengths)) != 1:
+                raise ValueError(f'vision_chunked_length must be identical within a batch: {chunk_lengths}.')
+            res['vision_chunked_length'] = chunk_lengths[0]
+        return res
+
+    def _data_collator(self, batch: List[Dict[str, Any]], *, padding_to: Optional[int] = None) -> Dict[str, Any]:
+        res = super()._data_collator(batch, padding_to=padding_to)
+        masks = [row.get('cross_attention_mask') for row in batch]
+        if not all(mask is not None for mask in masks):
+            raise ValueError('Every MOSS-VL sample must contain cross_attention_mask, including text-only samples.')
+
+        target_text_length = res['input_ids'].shape[1]
+        target_frame_length = max(mask.shape[-1] for mask in masks)
+        padding_right = (self.padding_side if self.is_training else 'left') == 'right'
+        padded_masks = []
+        for row, mask in zip(batch, masks):
+            if mask.ndim == 4:
+                if mask.shape[0] != 1:
+                    raise ValueError(f'Expected a single-sample cross_attention_mask, got shape={tuple(mask.shape)}.')
+                mask = mask[0]
+            if mask.shape[-2] != len(row['input_ids']):
+                raise ValueError('MOSS-VL cross_attention_mask text dimension does not match input_ids in collator: '
+                                 f'{mask.shape[-2]} != {len(row["input_ids"])}.')
+            text_padding = target_text_length - mask.shape[-2]
+            frame_padding = target_frame_length - mask.shape[-1]
+            if padding_right:
+                pad = (0, frame_padding, 0, text_padding)
+            else:
+                pad = (0, frame_padding, text_padding, 0)
+            padded_masks.append(F.pad(mask.to(torch.bool), pad, value=True))
+        res['cross_attention_mask'] = torch.stack(padded_masks)
+        return res
+
+
+register_template(
+    ChatmlTemplateMeta(
+        MLLMTemplateType.moss_vl,
+        template_cls=MossVLTemplate,
+        default_system=None,
+        agent_template='hermes',
+    ))

--- a/swift/tuner_plugin/lora_llm.py
+++ b/swift/tuner_plugin/lora_llm.py
@@ -17,7 +17,10 @@ if TYPE_CHECKING:
 
 def is_vit_aligner_param(model_arch, parameter_name: str) -> bool:
     for module_prefix in model_arch.vision_tower + model_arch.aligner:
-        if f'.{module_prefix}.' in parameter_name:
+        # An aligner entry may be a bare `nn.Parameter` (not a module), whose name
+        # terminates at the prefix itself; the leading dot keeps the match on exact
+        # dotted-name boundaries for both wrapped and unwrapped models.
+        if f'.{module_prefix}.' in parameter_name or f'.{parameter_name}'.endswith(f'.{module_prefix}'):
             return True
     return False
 

--- a/swift/utils/transformers_utils.py
+++ b/swift/utils/transformers_utils.py
@@ -239,6 +239,9 @@ def get_multimodal_target_regex(
         if sub_module is None:
             logger.warning(f'module: {module} is None')
             continue
+        if not isinstance(sub_module, nn.Module):
+            logger.debug(f'Skip non-module LoRA target path: {module} ({type(sub_module).__name__}).')
+            continue
         if isinstance(sub_module, nn.Linear) and module.endswith('lm_head'):
             target_modules = []
         else:

--- a/tests/general/test_moss_vl.py
+++ b/tests/general/test_moss_vl.py
@@ -1,0 +1,350 @@
+import os
+import torch
+import unittest
+from torch import nn
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class _FakeMossVLProcessor:
+
+    def __init__(self):
+        self.video_processor = SimpleNamespace(size={'shortest_edge': 4096, 'longest_edge': 201326592})
+        self.kwargs = None
+
+    def __call__(self, **kwargs):
+        self.kwargs = kwargs
+        return {
+            'input_ids': torch.tensor([[1, 2]]),
+            'labels': torch.tensor([[-100, 2]]),
+            'pixel_values': torch.zeros(60, 768),
+            'grid_thw': torch.tensor([[1, 6, 10]]),
+            'cross_attention_mask': torch.ones(1, 1, 2, 1, dtype=torch.bool),
+            'media_nums_per_sample': [1],
+        }
+
+
+class TestMossVLRegistration(unittest.TestCase):
+
+    def test_registration(self):
+        from swift.model import MODEL_MAPPING, MLLMModelType
+        from swift.model.models.moss import MossVLLoader
+        from swift.template import TEMPLATE_MAPPING, TemplateType
+
+        model_meta = MODEL_MAPPING[MLLMModelType.moss_vl]
+        self.assertIs(model_meta.loader, MossVLLoader)
+        self.assertEqual(model_meta.template, TemplateType.moss_vl)
+        self.assertEqual(model_meta.model_arch.arch_name, 'moss_vl')
+        self.assertIn('MossVLForConditionalGeneration', model_meta.architectures)
+        self.assertIn(TemplateType.moss_vl, TEMPLATE_MAPPING)
+
+        model_ids = [model.hf_model_id for group in model_meta.model_groups for model in group.models]
+        self.assertIn('OpenMOSS-Team/MOSS-VL-Instruct-0708', model_ids)
+        self.assertIn('OpenMOSS-Team/MOSS-VL-Base-0708', model_ids)
+
+
+class TestMossVLTemplate(unittest.TestCase):
+
+    def test_template_state_and_unsupported_modes(self):
+        from swift.template import TEMPLATE_MAPPING, TemplateType
+        from swift.template.base import Template
+        from swift.template.templates.moss import MossVLTemplate
+
+        self.assertIn('placeholder_tokens', MossVLTemplate.__dict__)
+        self.assertIsNot(MossVLTemplate.placeholder_tokens, Template.placeholder_tokens)
+
+        template_meta = TEMPLATE_MAPPING[TemplateType.moss_vl]
+        with self.assertRaisesRegex(ValueError, 'truncation_strategy="split"'):
+            MossVLTemplate(None, template_meta, truncation_strategy='split')
+        with self.assertRaisesRegex(NotImplementedError, 'does not support sequence parallel'):
+            MossVLTemplate(None, template_meta, sequence_parallel_size=2)
+        template = MossVLTemplate(None, template_meta)
+        self.assertEqual(template.sequence_parallel_size, 1)
+
+    def test_video_pixel_limits_are_routed_to_video_processor(self):
+        from swift.template.templates.moss import MossVLTemplate
+
+        processor = _FakeMossVLProcessor()
+        template = object.__new__(MossVLTemplate)
+        template.processor = processor
+        template.chat_template_kwargs = {}
+        template.mode = 'train'
+        template.max_pixels = 1024
+        inputs = SimpleNamespace(
+            mm_processor_kwargs={},
+            chat_template_kwargs={
+                'video_min_pixels': 256,
+                'video_max_pixels': 16384,
+                'video_fps': 1.0,
+                'max_frames': 32,
+            },
+            images=[],
+            videos=['video.mp4'],
+        )
+
+        # Isolate the host environment so the default vision_chunked_length (64) is not
+        # overridden by a MOSSVL_VISION_CHUNKED_LENGTH set on the host.
+        env = {k: v for k, v in os.environ.items() if k.lower() != 'mossvl_vision_chunked_length'}
+        with patch.dict(os.environ, env, clear=True), \
+                patch.object(MossVLTemplate, '_render_text_and_spans', return_value=('prompt', [[0, 6]])):
+            encoded = template._encode(inputs)
+
+        self.assertNotIn('video_min_pixels', processor.kwargs)
+        self.assertNotIn('video_max_pixels', processor.kwargs)
+        self.assertEqual(processor.kwargs['max_pixels'], 1024)
+        self.assertEqual(processor.kwargs['video_fps'], 1.0)
+        self.assertEqual(processor.kwargs['max_frames'], 32)
+        self.assertEqual(processor.kwargs['videos_kwargs']['size'], {
+            'shortest_edge': 256,
+            'longest_edge': 16384,
+        })
+        self.assertEqual(encoded['input_ids'], [1, 2])
+        self.assertEqual(encoded['vision_chunked_length'], 64)
+
+    def test_video_environment_limits_are_supported(self):
+        from swift.template.templates.moss import MossVLTemplate
+
+        processor = _FakeMossVLProcessor()
+        template = object.__new__(MossVLTemplate)
+        template.processor = processor
+        template.chat_template_kwargs = {}
+        template.mode = 'train'
+        template.max_pixels = None
+        inputs = SimpleNamespace(
+            mm_processor_kwargs={},
+            chat_template_kwargs={},
+            images=[],
+            videos=['video.mp4'],
+        )
+        environment = {
+            'VIDEO_MIN_PIXELS': '256',
+            'VIDEO_MAX_PIXELS': '16384',
+            'FPS': '1.0',
+            'FPS_MAX_FRAMES': '32',
+        }
+
+        with patch.dict(os.environ, environment, clear=True), \
+                patch.object(MossVLTemplate, '_render_text_and_spans', return_value=('prompt', [[0, 6]])):
+            template._encode(inputs)
+
+        self.assertEqual(processor.kwargs['video_fps'], 1.0)
+        self.assertEqual(processor.kwargs['max_frames'], 32)
+        self.assertEqual(processor.kwargs['videos_kwargs']['size'], {
+            'shortest_edge': 256,
+            'longest_edge': 16384,
+        })
+
+    def test_truncation_preserves_media_contract(self):
+        from swift.template.base import MaxLengthError
+        from swift.template.templates.moss import MossVLTemplate
+
+        class FakeTokenizer:
+            unk_token_id = -1
+            token_ids = {'<|image_pad|>': 20, '<|vision_start|>': 10, '<|vision_end|>': 30}
+
+            def convert_tokens_to_ids(self, token):
+                return self.token_ids[token]
+
+        template = object.__new__(MossVLTemplate)
+        template.processor = FakeTokenizer()
+        template.max_length = 4
+        input_ids = [10, 20, 30, 40, 50, 60]
+        labels = [-100, -100, -100, 40, 50, 60]
+        encoded = {'cross_attention_mask': torch.zeros(1, 1, 6, 2, dtype=torch.bool)}
+
+        truncated_ids, truncated_labels = template._truncate(input_ids, labels, encoded, 'right')
+        self.assertEqual(truncated_ids, [10, 20, 30, 40])
+        self.assertEqual(truncated_labels, [-100, -100, -100, 40])
+        self.assertEqual(tuple(encoded['cross_attention_mask'].shape), (1, 1, 4, 2))
+
+        with self.assertRaises(MaxLengthError):
+            template._truncate(input_ids, labels, {'cross_attention_mask': torch.zeros(1, 1, 6, 2)}, 'left')
+
+    def test_cross_attention_masks_are_padded(self):
+        from swift.template.base import Template
+        from swift.template.templates.moss import MossVLTemplate
+
+        template = object.__new__(MossVLTemplate)
+        template.mode = 'train'
+        template.padding_side = 'right'
+        template.sequence_parallel_size = 1
+        batch = [
+            {
+                'input_ids': [1, 2],
+                'cross_attention_mask': torch.zeros(1, 1, 2, 1, dtype=torch.bool),
+            },
+            {
+                'input_ids': [1, 2, 3, 4],
+                'cross_attention_mask': torch.zeros(1, 1, 4, 3, dtype=torch.bool),
+            },
+        ]
+        base_result = {
+            'input_ids': torch.tensor([[1, 2, 0, 0], [1, 2, 3, 4]]),
+        }
+
+        with patch.object(Template, '_data_collator', return_value=base_result):
+            result = template._data_collator(batch)
+
+        mask = result['cross_attention_mask']
+        self.assertEqual(tuple(mask.shape), (2, 1, 4, 3))
+        self.assertFalse(mask[0, 0, :2, 0].any())
+        self.assertTrue(mask[0, 0, :2, 1:].all())
+        self.assertTrue(mask[0, 0, 2:, :].all())
+        self.assertFalse(mask[1].any())
+
+    def test_inference_cross_attention_masks_are_left_padded(self):
+        from swift.template.base import Template
+        from swift.template.templates.moss import MossVLTemplate
+
+        template = object.__new__(MossVLTemplate)
+        template.mode = 'transformers'
+        template.padding_side = 'right'
+        template.sequence_parallel_size = 1
+        batch = [
+            {
+                'input_ids': [1, 2],
+                'cross_attention_mask': torch.zeros(1, 1, 2, 2, dtype=torch.bool),
+            },
+            {
+                'input_ids': [1, 2, 3, 4],
+                'cross_attention_mask': torch.zeros(1, 1, 4, 3, dtype=torch.bool),
+            },
+        ]
+        base_result = {
+            'input_ids': torch.tensor([[0, 0, 1, 2], [1, 2, 3, 4]]),
+            'attention_mask': torch.tensor([[0, 0, 1, 1], [1, 1, 1, 1]]),
+        }
+
+        with patch.object(Template, '_data_collator', return_value=base_result):
+            result = template._data_collator(batch)
+
+        mask = result['cross_attention_mask']
+        self.assertEqual(tuple(mask.shape), (2, 1, 4, 3))
+        self.assertTrue(mask[0, 0, :2].all())
+        self.assertFalse(mask[0, 0, 2:, :2].any())
+        self.assertTrue(mask[0, 0, 2:, 2].all())
+        self.assertFalse(mask[1].any())
+
+    def test_media_metadata_is_collated(self):
+        from swift.template.base import Template
+        from swift.template.templates.moss import MossVLTemplate
+
+        template = object.__new__(MossVLTemplate)
+        batch = [
+            {
+                'grid_thw': torch.tensor([[1, 2, 3]]),
+                'media_nums_per_sample': [1],
+                'vision_chunked_length': 64,
+            },
+            {
+                'grid_thw': torch.tensor([[2, 3, 4], [1, 1, 1]]),
+                'media_nums_per_sample': [2],
+                'vision_chunked_length': 64,
+            },
+        ]
+
+        with patch.object(Template, '_data_collator_mm_data', return_value={}):
+            result = template._data_collator_mm_data(batch)
+
+        self.assertEqual(result['grid_thw'].tolist(), [[1, 2, 3], [2, 3, 4], [1, 1, 1]])
+        self.assertEqual(result['media_nums_per_sample'], [1, 2])
+        self.assertEqual(result['vision_chunked_length'], 64)
+
+    def test_mixed_media_and_text_only_batch_contract(self):
+        from swift.template.base import Template
+        from swift.template.templates.moss import MossVLTemplate
+
+        template = object.__new__(MossVLTemplate)
+        template.mode = 'train'
+        template.padding_side = 'right'
+        template.sequence_parallel_size = 1
+        batch = [
+            {
+                'input_ids': [1, 2, 3],
+                'grid_thw': torch.tensor([[1, 8, 8], [8, 6, 10]]),
+                'media_nums_per_sample': [2],
+                'vision_chunked_length': 64,
+                'cross_attention_mask': torch.zeros(1, 1, 3, 5, dtype=torch.bool),
+            },
+            {
+                'input_ids': [4, 5],
+                # Text-only sample in the native contract: the processor injects a blank
+                # image, so media_nums_per_sample is [1] and the cross_attention_mask is
+                # fully masked (all True).
+                'grid_thw': torch.tensor([[1, 8, 8]]),
+                'media_nums_per_sample': [1],
+                'vision_chunked_length': 64,
+                'cross_attention_mask': torch.ones(1, 1, 2, 1, dtype=torch.bool),
+            },
+        ]
+        with patch.object(Template, '_data_collator_mm_data', return_value={}):
+            mm_result = template._data_collator_mm_data(batch)
+        base_result = {
+            **mm_result,
+            'input_ids': torch.tensor([[1, 2, 3], [4, 5, 0]]),
+        }
+
+        with patch.object(Template, '_data_collator', return_value=base_result):
+            result = template._data_collator(batch)
+
+        self.assertEqual(result['media_nums_per_sample'], [2, 1])
+        self.assertEqual(result['grid_thw'].tolist(), [[1, 8, 8], [8, 6, 10], [1, 8, 8]])
+        self.assertEqual(result['vision_chunked_length'], 64)
+        self.assertEqual(tuple(result['cross_attention_mask'].shape), (2, 1, 3, 5))
+        self.assertTrue(result['cross_attention_mask'][1].all())
+
+
+class TestMossVLLoRATargets(unittest.TestCase):
+
+    def test_non_module_aligner_parameter_is_not_scanned_for_lora(self):
+        from swift.utils import get_multimodal_target_regex
+
+        class DummyModel(nn.Module):
+
+            def __init__(self):
+                super().__init__()
+                self.separator_token = nn.Parameter(torch.zeros(1))
+                self.model_meta = SimpleNamespace(
+                    model_arch=SimpleNamespace(language_model=[], vision_tower=[], aligner=['separator_token']))
+                self.model_info = SimpleNamespace(is_moe_model=False)
+
+        regex = get_multimodal_target_regex(DummyModel(), freeze_llm=True, freeze_vit=True, freeze_aligner=False)
+        self.assertEqual(regex, '^()$')
+
+    def test_bare_aligner_parameter_name_is_matched(self):
+        from swift.tuner_plugin.lora_llm import is_vit_aligner_param
+
+        model_arch = SimpleNamespace(vision_tower=['model.visual'], aligner=['model.separator_token'])
+        self.assertTrue(is_vit_aligner_param(model_arch, 'model.separator_token'))
+        self.assertTrue(is_vit_aligner_param(model_arch, 'base_model.model.model.separator_token'))
+        self.assertFalse(is_vit_aligner_param(model_arch, 'model.language_model.embed_tokens.weight'))
+
+    def test_separator_token_bc_property(self):
+        from swift.model.models.moss import _patch_separator_token_property
+
+        class Inner(nn.Module):
+
+            def __init__(self):
+                super().__init__()
+                self.separator_token = nn.Parameter(torch.zeros(1))
+
+        class Outer(nn.Module):
+
+            def __init__(self):
+                super().__init__()
+                self.model = Inner()
+
+        outer = Outer()
+        _patch_separator_token_property(outer)
+        # `outer.separator_token` must resolve to the inner parameter, so that attribute-path
+        # lookups (e.g. the lora_llm unfreeze loop) reach it through the wrapper.
+        self.assertIs(outer.separator_token, outer.model.separator_token)
+        outer.separator_token.requires_grad_(True)
+        self.assertTrue(outer.model.separator_token.requires_grad)
+        # Idempotent and does not clobber a class that already provides the accessor.
+        _patch_separator_token_property(outer)
+        self.assertIs(outer.separator_token, outer.model.separator_token)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/general/test_moss_vl_align.py
+++ b/tests/general/test_moss_vl_align.py
@@ -1,0 +1,137 @@
+import os
+import torch
+import unittest
+from functools import lru_cache
+
+# NOTE: All tests here only load the processor (tokenizer + vision processor) and the
+# remote-code python files via `get_model_processor` (i.e. `load_model=False`), so
+# *.safetensors / *.bin weight shards are NOT downloaded (see `safe_snapshot_download`,
+# which appends ['*.bin', '*.safetensors'] to `ignore_patterns` when `download_model=False`).
+# The template `encode`/official processor `__call__` paths are pure tokenization +
+# image/video preprocessing and never run a model forward, so no weights are required.
+
+MODEL = os.getenv('MOSS_VL_TEST_MODEL', 'OpenMOSS-Team/MOSS-VL-Instruct-0708')
+VIDEO = 'https://modelscope-open.oss-cn-hangzhou.aliyuncs.com/images/baby.mp4'
+
+
+@lru_cache(maxsize=1)
+def _get_processor():
+    from swift.model import get_model_processor
+    _, processor = get_model_processor(MODEL, load_model=False)
+    return processor
+
+
+def _get_template(mode='transformers'):
+    from swift.template import get_template
+    template = get_template(_get_processor())
+    template.set_mode(mode)
+    return template
+
+
+@lru_cache(maxsize=1)
+def _get_video():
+    video = os.getenv('MOSS_VL_TEST_VIDEO', VIDEO)
+    if video.startswith(('http://', 'https://')):
+        from swift.utils import download_file
+        video = download_file(video)
+    return video
+
+
+def _assert_processor_outputs_equal(reference, encoded):
+    assert reference['input_ids'][0].tolist() == encoded['input_ids']
+    for key in ('pixel_values', 'grid_thw', 'cross_attention_mask'):
+        assert torch.equal(reference[key], encoded[key]), key
+    assert reference['media_nums_per_sample'] == encoded['media_nums_per_sample']
+
+
+class TestMossVLProcessorAlignment(unittest.TestCase):
+
+    def test_text(self):
+        from swift import InferRequest
+        processor = _get_processor()
+        template = _get_template()
+        messages = [{'role': 'user', 'content': 'Hello!'}]
+        text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        reference = processor(text=[text], padding=False, return_tensors='pt')
+        encoded = template.encode(InferRequest(messages=messages))
+        _assert_processor_outputs_equal(reference, encoded)
+
+    def test_image(self):
+        from PIL import Image
+
+        from swift import InferRequest
+        processor = _get_processor()
+        template = _get_template()
+        image = Image.new('RGB', (128, 96), (255, 0, 0))
+        content = [{'type': 'image', 'image': image}, {'type': 'text', 'text': 'Describe the image.'}]
+        native_messages = [{'role': 'user', 'content': content}]
+        text = processor.apply_chat_template(native_messages, tokenize=False, add_generation_prompt=True)
+        reference = processor(text=[text], images=[image], padding=False, return_tensors='pt')
+        encoded = template.encode(
+            InferRequest(messages=[{
+                'role': 'user',
+                'content': '<image>Describe the image.'
+            }], images=[image]))
+        _assert_processor_outputs_equal(reference, encoded)
+
+    def test_video(self):
+        from swift import InferRequest
+        processor = _get_processor()
+        template = _get_template()
+        video = _get_video()
+        content = [{'type': 'video', 'video': video}, {'type': 'text', 'text': 'Describe the video.'}]
+        native_messages = [{'role': 'user', 'content': content}]
+        text = processor.apply_chat_template(native_messages, tokenize=False, add_generation_prompt=True)
+        reference = processor(text=[text], videos=[video], padding=False, return_tensors='pt')
+        encoded = template.encode(
+            InferRequest(messages=[{
+                'role': 'user',
+                'content': '<video>Describe the video.'
+            }], videos=[video]))
+        _assert_processor_outputs_equal(reference, encoded)
+
+    def test_training_labels(self):
+        from PIL import Image
+
+        from swift import InferRequest
+        processor = _get_processor()
+        template = _get_template('train')
+        image = Image.new('RGB', (128, 96), (0, 128, 255))
+        content = [{'type': 'image', 'image': image}, {'type': 'text', 'text': 'What color is it?'}]
+        native_messages = [
+            {
+                'role': 'user',
+                'content': content
+            },
+            {
+                'role': 'assistant',
+                'content': 'It is blue.'
+            },
+        ]
+        text = processor.apply_chat_template(native_messages, tokenize=False, add_generation_prompt=False)
+        response_start = text.index('It is blue.')
+        response_end = response_start + len('It is blue.<|im_end|>')
+        reference = processor(
+            text=[text],
+            images=[image],
+            labels_spans=[[[response_start, response_end]]],
+            padding=False,
+            return_tensors='pt')
+        encoded = template.encode(
+            InferRequest(
+                messages=[{
+                    'role': 'user',
+                    'content': '<image>What color is it?'
+                }, {
+                    'role': 'assistant',
+                    'content': 'It is blue.'
+                }],
+                images=[image]))
+        _assert_processor_outputs_equal(reference, encoded)
+        self.assertEqual(reference['labels'][0].tolist(), encoded['labels'])
+        supervised = processor.tokenizer.decode([token for token in encoded['labels'] if token != -100])
+        self.assertEqual(supervised, 'It is blue.<|im_end|>')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] More Models or Datasets Support

# PR information

Add [MOSS-VL](https://huggingface.co/OpenMOSS-Team/MOSS-VL-Instruct-0708) (8B, `model_type=moss_vl`) as a first-class multimodal model for the Transformers backend. The model ships as remote code (48-layer LLM with vision cross-attention every 4 layers, 27-layer ViT with deep-stack features, merger, and a bare `nn.Parameter` separator token); this PR integrates it without copying the model implementation.

**Supported**

- `swift infer` (image/video) and `swift sft`: LoRA (`target_modules=all-linear`) and full-parameter
- Single/multi-image, single/multi-video, mixed media, text-only (native blank-image contract), multi-turn, batch size > 1
- `freeze_vit` / `freeze_aligner` / `freeze_llm` on the real module boundaries; LoRA target scanning skips the bare `separator_token`, LoRA-LLM saves it by exact name (and the loader exposes it through a BC property so the generic unfreeze path can reach it)
- Non-reentrant gradient checkpointing, language + vision tower (the reentrant mode is not supported: it double-backwards through the vision deep-stack/shared compute graph)
- Supervision via the native processor's `labels_spans` (binary strategies only; non-binary loss-scale raises explicitly)
- Controlled truncation: text-only truncation updates all text-axis fields; truncation that breaks the vision token/media metadata contract raises `MaxLengthError`
- Full/merged checkpoints reload standalone (remote code + processor + chat template saved); LoRA checkpoints load as base model + adapter and support merge/resume

**Non-goals for this PR**: sequence parallel (`--sequence_parallel_size > 1` raises explicitly; support is planned as a follow-up PR), `packing=true` / padding-free, Megatron/TP/PP/CP, RLHF, vLLM/lmdeploy/SGLang, quantization, streaming video.

**Generic changes, and why each is required by this model**

Both are behavior-preserving for existing models and carry regression tests.

- `find_all_linears` skips non-Module paths when scanning LoRA targets: MOSS-VL's `separator_token` is a bare `nn.Parameter` (not an `nn.Module`); the previous scan crashed on it.
- `lora_llm` matches aligner parameters whose names terminate at the prefix (`f'.{name}'.endswith(f'.{prefix}')`): required to save the trainable bare `separator_token` in LoRA-LLM checkpoints — the old `f'.{prefix}.' in name` match never hits leaf parameters, silently dropping them from `vit.safetensors`. Strictly additive: parameters under module-type prefixes always extend past the prefix, so existing models match exactly as before.

**Tests**: 16 lightweight tests (no 8B weight download): registration, template/processor golden alignment, collator padding, mixed-media batches, truncation contract, LoRA scanning, `lora_llm` name matching, SP rejection. `pre-commit run --all-files` passes.

Requires: `transformers>=4.57.1,<5`, `torchcodec` (0.7.x for torch 2.8), `joblib`.

## Experiment results

- Field-level golden alignment (text/tokens/labels/media order/grid/cross-attention mask) with the native processor on text/image/video/mixed/multi-turn samples
- H200 GPU smoke: LoRA and full SFT converge with finite loss/gradients; checkpoint save/resume/merge verified (resume loss bit-exact vs continuous run)
- `--freeze_aligner false` with LoRA trains cleanly; `lora_llm` trains with ViT/aligner unfrozen, saves `separator_token` into `vit.safetensors`, and a zero-LR resume reproduces it bit-exactly
- Full SFT ZeRO-3 on 8×H200: finite loss/grad norm
- Examples use public IDs (`OpenMOSS-Team/MOSS-VL-Instruct-0708`, `lmms-lab/VideoChatGPT`)
