### PR TITLE
The ViT gradient checkpoint was incorrectly turned off during multimodal model training.

### DIFF
--- a/docs/source/Instruction/Frequently-asked-questions.md
+++ b/docs/source/Instruction/Frequently-asked-questions.md
@@ -329,6 +329,71 @@ TypeError: __init__() got an unexpected keyword argument 'corda_config'
 --target_regex ".*audio.*"   # 只匹配包含 audio 的模块
 ```
 
+### Q52: Qwen3.5支持cp吗？
+支持，具体相关可以查看[Qwen3.5最佳实践](https://swift.readthedocs.io/zh-cn/latest/BestPractices/Qwen3_8-Best-Practice.html)。
+
+### Q53: gkd能否像opsd一样支持teacher和student使用不一样的系统提示词？
+支持。
+
+### Q54: MoE模型可以使用deepspeed zero3训练吗？
+可以，但是会较慢。
+
+### Q55: megatron swift支持显卡B300吗？
+支持。
+
+### Q56: megatron stf和swift stf跑MoE模型结果不太相同怎么办？
+MoE模型尽量使用megatron跑，megatron+MoE相对成熟，transformers的MoE训练是5.0版本之后才开始支持，不一定稳定。
+
+### Q57: 什么情况下训练要开启think模式？
+如果你的训练数据涉及CoT，建议开启think模式。
+
+### Q58: 带 `<think></think> `的数据在训练时都需要开启think模式吗？
+这个需要看具体训练场景，如果数据的逻辑推理不是特别多，可以使用no-think。
+
+### Q59: 训练qwenvl-2.5时出现报错
+```shell
+[rankØ]: Original Traceback (most recent call last):
+[rank0]:
+File "/apdcephfs_qy3/share_300998916/weituchong/miniforge3/envs/qwen/lib/python3.10/site-packages/torch/utils/data/_utils/worker.py", line 349, in _worker_loop
+[rank0] :
+data = fetcher. fetch index)
+type: ignore [possibly-undefined]
+[rank0]:
+File"/apdcephfs_qy3/share_300998916/weituchong/miniforge3/envs/qwen/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py", line 52, in fetch
+[rankø]:
+data = [self-dataset [idx] for idx in possibly_batched_index]
+[rankø]:
+File"/apdcephfs_qy3/share_300998916/weituchong/miniforge3/envs/qwen/Lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py", line 52, in
+[rankø] :
+data = [self dataset [idx] for idx in possibly_batched_index]
+[rank0]:
+File "/apdcephfs_qy3/share_300998916/weituchong/miniforge3/envs/qwen/lib/python3.10/site-packages/swift/llm/dataset/utils-py", line 191, in _getitem
+[rank0]:
+raise ValueError( 'Failed to retrieve the dataset. You can avoid this issue by increasing
+'max_length'
+or "
+[rankø]: ValueError: Failed to retrieve the dataset. You can avoid this issue by increasing 'max_length' or modifying the 'truncation_strategy -
+```
+如果上面无其他报错信息，则是数据集超长，把`--max_length`提高，只要不OOM就没问题。
+
+### Q60: 训练多模态模型时，如何做图像样本的动态数据增强，即在每个batch输入模型前都会对数据增强一次？
+Swift目前没有开箱即用的动态数据增强支持，可以根据需要自行扩展源码。
+
+### Q61: grpo训练一般需要多少样本数据？
+几千就会有效果，多一些效果更好。
+
+### Q62: Swift可以做视觉模型的预训练吗？
+可以，需要自己调节学习率，详见[教程文档](https://swift.readthedocs.io/zh-cn/latest/BestPractices/Rapidly-Training-VL-model.html)。
+
+### Q63: magetron支持像Swift一样通过`--loss_type my_loss`使用自定义函数吗？
+megatron 目前需要改动 trainer 里的 loss_func, 未来会支持更简单的自定义逻辑。
+
+### Q64: Swift框架支持Agentic RL训练吗？
+支持，具体参考[多轮训练](https://swift.readthedocs.io/zh-cn/latest/Instruction/GRPO/DeveloperGuide/multi_turn.html)。
+
+### Q65: 如何在ROCm/MI300X上使用megatron-swift训练Qwen3-Omni？
+可以参考这个[最佳实践](https://swift.readthedocs.io/zh-cn/latest/BestPractices/AMD-support.html)。
+
 ## 推理
 
 SWIFT支持python脚本、命令行、ui界面推理，详见[推理和部署](https://swift.readthedocs.io/zh-cn/latest/Instruction/Inference-and-deployment.html)。
@@ -561,3 +626,6 @@ swift eval不支持DDP方式启动。
 ### Q13: 哪里可以看到swift评测的时候送入的query除了问题之外还有哪些额外的字段呢？
 最简单的方法是看输出的reviews文件中的input字段，是输入给模型的内容转换后的Markdown格式。<br>
 如果backend是opencompass的话没有这些输出，就需要用native backend。
+
+### Q14: pip安装evalscope的时候一直卡在preparing metadata(pyproject.toml)
+这一过程是在安装评估依赖，可能会比较慢。

--- a/docs/source_en/Instruction/Frequently-asked-questions.md
+++ b/docs/source_en/Instruction/Frequently-asked-questions.md
@@ -328,6 +328,71 @@ Use `--target_regex` to match only the module paths you want to train. For examp
 --target_regex ".*audio.*"    # Only match modules containing audio
 ```
 
+### Q52: Does Qwen3.5 support CP?
+Yes, it is supported. For details, please refer to [Qwen 3.5 Best Practices](https://swift.readthedocs.io/en/latest/BestPractices/Qwen3_8-Best-Practice.html).
+
+### Q53: Can gkd support different system prompts for teacher and student, like opsd?
+Yes, it can.
+
+### Q54: Can the MoE model be trained using deepspeed zero3?
+Yes, but it will be slow.
+
+### Q55: Does megatron swift support graphics card B300?
+Yes.
+
+### Q56: What if the results of running a MoE model using megatron stf and swift stf are not the same?
+MoE models should be run using Megatron whenever possible, as Megatron + MoE is relatively mature. Transformers only started supporting MoE training in version 5.0 and later, so it may not be stable.
+
+### Q57: Under what circumstances should think mode be enabled during training?
+If your training data involves CoT, it is recommended to enable think mode.
+
+### Q58: Do all data with `<think></think>` need to have the think mode enabled during training?
+This depends on the specific training scenario. If the data doesn't involve a lot of logical reasoning, you can use no-thinking.
+
+### Q59: An error occurred while training qwenvl-2.5.
+```shell
+[rankØ]: Original Traceback (most recent call last):
+[rank0]:
+File "/apdcephfs_qy3/share_300998916/weituchong/miniforge3/envs/qwen/lib/python3.10/site-packages/torch/utils/data/_utils/worker.py", line 349, in _worker_loop
+[rank0] :
+data = fetcher. fetch index)
+type: ignore [possibly-undefined]
+[rank0]:
+File"/apdcephfs_qy3/share_300998916/weituchong/miniforge3/envs/qwen/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py", line 52, in fetch
+[rankø]:
+data = [self-dataset [idx] for idx in possibly_batched_index]
+[rankø]:
+File"/apdcephfs_qy3/share_300998916/weituchong/miniforge3/envs/qwen/Lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py", line 52, in
+[rankø] :
+data = [self dataset [idx] for idx in possibly_batched_index]
+[rank0]:
+File "/apdcephfs_qy3/share_300998916/weituchong/miniforge3/envs/qwen/lib/python3.10/site-packages/swift/llm/dataset/utils-py", line 191, in _getitem
+[rank0]:
+raise ValueError( 'Failed to retrieve the dataset. You can avoid this issue by increasing
+'max_length'
+or "
+[rankø]: ValueError: Failed to retrieve the dataset. You can avoid this issue by increasing 'max_length' or modifying the 'truncation_strategy -
+```
+If there are no other error messages above, then the dataset is too long. Increase the `--max_length`, and as long as it doesn't cause an OOM (Out of Memory) error, there shouldn't be any problem.
+
+### Q60: How to perform dynamic data augmentation on image samples when training a multimodal model, i.e., augment the data once before each batch is input into the model?
+Swift does not currently have out-of-the-box support for dynamic data enhancements; you can extend the source code as needed.
+
+### Q61: How many samples are typically needed for GRPO training?
+A few thousand will be effective, and more will be even more effective.
+
+### Q62: Can Swift be used for pre-training visual models?
+Yes, you can, but you'll need to adjust the learning rate yourself. See the [tutorial document](https://swift.readthedocs.io/en/latest/BestPractices/Rapidly-Training-VL-model.html) for details.
+
+### Q63: Does magetron support using custom functions via `--loss_type my_loss` like in Swift?
+Megatron currently requires modifications to the loss_func in the trainer; simpler custom logic will be supported in the future.
+
+### Q64: Does the Swift framework support Agentic RL training?
+Yes，For details, please refer to [Multiple Rounds of Training](https://swift.readthedocs.io/en/latest/Instruction/GRPO/DeveloperGuide/multi_turn.html).
+
+### Q65: How can I train Qwen3-Omni on ROCm/MI300X using megatron-swift?
+You can refer to this [best practice](https://swift.readthedocs.io/en/latest/BestPractices/AMD-support.html).
+
 ## Inference
 
 Swift supports inference via Python scripts, command line, and UI interfaces. For details, see [Inference and Deployment](https://swift.readthedocs.io/en/latest/Instruction/Inference-and-deployment.html).
@@ -559,3 +624,6 @@ swift eval does not support DDP startup.
 ### Q13: Where can I see what additional fields are included in the query besides the question during Swift evaluation?
 The simplest way is to look at the input field in the output reviews file; it's the Markdown format of the content input to the model. <br>
 If the backend is OpenCompass, these outputs won't be available, and you'll need to use a native backend.
+
+### Q14: When installing evalscope using pip, it keeps getting stuck at "preparing metadata(pyproject.toml)".
+This process involves evaluating dependencies during installation, which may be relatively slow.

--- a/swift/arguments/sft_args.py
+++ b/swift/arguments/sft_args.py
@@ -209,7 +209,7 @@ class SftArguments(SwanlabArguments, TunerArguments, BaseArguments, Seq2SeqTrain
         TunerArguments.__post_init__(self)
         self._check_padding_free()
         if self.vit_gradient_checkpointing is None:
-            self.vit_gradient_checkpointing = not self.freeze_vit
+            self.vit_gradient_checkpointing = self.gradient_checkpointing
         if self.optimizer is None:
             if self.lorap_lr_ratio:
                 self.optimizer = 'lorap'

--- a/swift/template/templates/qwen.py
+++ b/swift/template/templates/qwen.py
@@ -746,7 +746,7 @@ class Qwen3_5EmbTemplate(Qwen3_5Template):
                     if raw_num is not None:
                         num_eos_tokens = int(raw_num)
             except (json.JSONDecodeError, ValueError, TypeError) as e:
-                logger.warning(f"Failed to parse sparse_info.json: {e}")
+                logger.warning(f'Failed to parse sparse_info.json: {e}')
         self.num_eos_tokens = num_eos_tokens
 
         if num_eos_tokens > 0:


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
Issue: A new default value derivation line added in ms-swift 4.4.2 caused the ViT gradient checkpoint to be incorrectly disabled during multimodal model training, resulting in a surge in GPU memory usage from 68 GiB to 98 GiB.

When `freeze_vit=True` (the default value for multimodal computing), it is deduced that `vit_gradient_checkpointing = False`.
The implicit assumption of this derivation is that "ViT is frozen → gradient checkpointing is not needed". However, `freeze_vit=True` only sets the ViT parameter `requires_grad=False`; the forward activations of ViT are still in the computation graph (gradients need to pass through ViT and be propagated back to LLM). After disabling garbage collection (GC), all these activations are retained in GPU memory.

fix:Change `not self.freeze_vit` to `self.gradient_checkpointing` to make ViT GC follow the global GC settings. This is consistent with the existing logic in the upstream `TrainArgumentsMixin` (that code is dead code because it was overridden by `sft_args.py`).