### PR TITLE
Fix colocated vLLM cleanup ordering on rollout failures

### DIFF
--- a/swift/megatron/trainers/rollout_mixin.py
+++ b/swift/megatron/trainers/rollout_mixin.py
@@ -35,7 +35,7 @@ from swift.rlhf_trainers.utils import (VLLM_LORA_INT_ID, VLLM_LORA_NAME, VLLM_LO
                                        check_vllm_version_ge, expand_vllm_param_name_aliases, finish_vllm_weight_reload,
                                        parse_prompt_logprobs, patch_vllm_load_adapter,
                                        patch_vllm_moe_model_weight_loader, profiling_context, profiling_decorator,
-                                       set_expandable_segments, vllm_supports_lora_load_inplace)
+                                       set_expandable_segments, sleep_vllm_engine, vllm_supports_lora_load_inplace)
 from swift.rlhf_trainers.vllm_client import VLLMInferClient
 from swift.rollout import MultiTurnScheduler, invoke_async_hook, multi_turns, run_multi_turn
 from swift.utils import (JsonlWriter, get_current_device, get_logger, is_last_rank, is_vllm_available, remove_response,
@@ -722,40 +722,41 @@ class MegatronRolloutMixin(BaseRolloutTrainerMixin):
 
         context = self.offload_context if self.enable_offload else nullcontext
         with context():
-            if (self.vllm_mode == 'colocate' and self.engine.inner_model_executor.is_sleeping
-                    and 'tags' in inspect.signature(self.engine.engine.wake_up).parameters):
-                aggressive_empty_cache()
-                set_expandable_segments(False)
-                self.engine.engine.wake_up(tags=['kv_cache'])
+            rollout_failed = False
+            try:
+                if (self.vllm_mode == 'colocate' and self.engine.inner_model_executor.is_sleeping
+                        and 'tags' in inspect.signature(self.engine.engine.wake_up).parameters):
+                    aggressive_empty_cache()
+                    set_expandable_segments(False)
+                    self.engine.engine.wake_up(tags=['kv_cache'])
 
-            multi_turn_scheduler = getattr(self, 'multi_turn_scheduler', None)
-            colocate_multi_turn = (
-                multi_turn_scheduler is not None and not getattr(self, 'enable_server_multi_turn', False))
+                multi_turn_scheduler = getattr(self, 'multi_turn_scheduler', None)
+                colocate_multi_turn = (
+                    multi_turn_scheduler is not None and not getattr(self, 'enable_server_multi_turn', False))
 
-            if colocate_multi_turn:
-                requests = self.samples2requests(samples)
-                invoke_async_hook(multi_turn_scheduler.on_trajectory_start(requests))
-                request_config = self._get_request_config()
-                outputs: List[RolloutOutput] = self._rollout_requests(requests, request_config)
-                outputs = run_multi_turn(
-                    requests=requests,
-                    first_turn_outputs=outputs,
-                    scheduler=multi_turn_scheduler,
-                    rollout_fn=lambda reqs, cfg: self._rollout_requests(reqs, cfg),
-                    request_config=request_config,
-                    max_turns=self.args.max_turns,
-                    gather_fn=lambda x: gather_object(x, group=self._get_rollout_group()),
-                )
-            else:
-                # Single-turn rollout (or server multi-turn handled by the engine).
-                outputs: List[RolloutOutput] = self._rollout(samples)
-
-            # Sleep to release memory
-            if self.vllm_mode == 'colocate' and self.args.sleep_level > 0:
-                self.engine.engine.reset_prefix_cache()
-                self.engine.engine.sleep(level=self.args.sleep_level)
-                aggressive_empty_cache()
-                set_expandable_segments(True)
+                if colocate_multi_turn:
+                    requests = self.samples2requests(samples)
+                    invoke_async_hook(multi_turn_scheduler.on_trajectory_start(requests))
+                    request_config = self._get_request_config()
+                    outputs: List[RolloutOutput] = self._rollout_requests(requests, request_config)
+                    outputs = run_multi_turn(
+                        requests=requests,
+                        first_turn_outputs=outputs,
+                        scheduler=multi_turn_scheduler,
+                        rollout_fn=lambda reqs, cfg: self._rollout_requests(reqs, cfg),
+                        request_config=request_config,
+                        max_turns=self.args.max_turns,
+                        gather_fn=lambda x: gather_object(x, group=self._get_rollout_group()),
+                    )
+                else:
+                    # Single-turn rollout (or server multi-turn handled by the engine).
+                    outputs: List[RolloutOutput] = self._rollout(samples)
+            except BaseException:
+                rollout_failed = True
+                raise
+            finally:
+                if self.vllm_mode == 'colocate' and self.args.sleep_level > 0:
+                    sleep_vllm_engine(self.engine.engine, self.args.sleep_level, suppress_errors=rollout_failed)
 
             samples = self._postprocess_rollout_outputs(samples, outputs)
 

--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -49,7 +49,7 @@ from .utils import (VLLM_LORA_INT_ID, VLLM_LORA_NAME, VLLM_LORA_PATH, FlattenedT
                     get_gather_if_zero3_context, parse_prompt_logprobs, patch_lora_merge, patch_lora_unmerge,
                     patch_vllm_load_adapter, patch_vllm_moe_model_weight_loader, prepare_deepspeed, prepare_fsdp,
                     profiling_context, profiling_decorator, revert_runtime_names_to_checkpoint, set_expandable_segments,
-                    vllm_supports_lora_load_inplace)
+                    sleep_vllm_engine, vllm_supports_lora_load_inplace)
 from .vllm_client import VLLMInferClient
 
 DataType = List[Dict[str, Union[torch.Tensor, Any]]]
@@ -1196,6 +1196,7 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
 
         context = self.offload_context if self.enable_offload else nullcontext
         with context():
+            rollout_failed = False
             try:
                 if (self.vllm_mode == 'colocate' and self.engine.inner_model_executor.is_sleeping
                         and 'tags' in inspect.signature(self.engine.engine.wake_up).parameters):
@@ -1220,16 +1221,14 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
                 else:
                     with self.multi_turn_completion_length_context():
                         outputs = self._infer_single_or_multi_turn(samples, self.request_config)
+            except BaseException:
+                rollout_failed = True
+                raise
             finally:
                 # vLLM must release its memory before offload_context reloads the trainer model.
                 # Keep this cleanup on the exception path as well to avoid masking rollout failures with an OOM.
                 if self.vllm_mode == 'colocate' and args.sleep_level > 0:
-                    try:
-                        self.engine.engine.reset_prefix_cache()
-                    finally:
-                        self.engine.engine.sleep(level=args.sleep_level)
-                        aggressive_empty_cache()
-                        set_expandable_segments(True)
+                    sleep_vllm_engine(self.engine.engine, args.sleep_level, suppress_errors=rollout_failed)
         return outputs
 
     def _preprocess_inputs(self, samples: List[OnPolicySample]) -> List[OnPolicySample]:

--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -1196,36 +1196,40 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
 
         context = self.offload_context if self.enable_offload else nullcontext
         with context():
+            try:
+                if (self.vllm_mode == 'colocate' and self.engine.inner_model_executor.is_sleeping
+                        and 'tags' in inspect.signature(self.engine.engine.wake_up).parameters):
+                    aggressive_empty_cache()
+                    set_expandable_segments(False)
+                    self.engine.engine.wake_up(tags=['kv_cache'])
 
-            if (self.vllm_mode == 'colocate' and self.engine.inner_model_executor.is_sleeping
-                    and 'tags' in inspect.signature(self.engine.engine.wake_up).parameters):
-                aggressive_empty_cache()
-                set_expandable_segments(False)
-                self.engine.engine.wake_up(tags=['kv_cache'])
+                if hasattr(self, 'async_generate') and self.async_generate:
+                    all_inputs = gather_object(samples)
+                    self.async_generate_rollout(all_inputs)
 
-            if hasattr(self, 'async_generate') and self.async_generate:
-                all_inputs = gather_object(samples)
-                self.async_generate_rollout(all_inputs)
+                    data_cache = self._queue.get()
+                    all_outputs = gather_object(data_cache.results)
 
-                data_cache = self._queue.get()
-                all_outputs = gather_object(data_cache.results)
+                    per_device_datasize = len(all_outputs) // self.accelerator.num_processes
+                    process_slice = slice(
+                        self.accelerator.process_index * per_device_datasize,
+                        (self.accelerator.process_index + 1) * per_device_datasize,
+                    )
+                    outputs = all_outputs[process_slice]
 
-                per_device_datasize = len(all_outputs) // self.accelerator.num_processes
-                process_slice = slice(
-                    self.accelerator.process_index * per_device_datasize,
-                    (self.accelerator.process_index + 1) * per_device_datasize,
-                )
-                outputs = all_outputs[process_slice]
-
-            else:
-                with self.multi_turn_completion_length_context():
-                    outputs = self._infer_single_or_multi_turn(samples, self.request_config)
-
-            if self.vllm_mode == 'colocate' and args.sleep_level > 0:
-                self.engine.engine.reset_prefix_cache()
-                self.engine.engine.sleep(level=args.sleep_level)
-                aggressive_empty_cache()
-                set_expandable_segments(True)
+                else:
+                    with self.multi_turn_completion_length_context():
+                        outputs = self._infer_single_or_multi_turn(samples, self.request_config)
+            finally:
+                # vLLM must release its memory before offload_context reloads the trainer model.
+                # Keep this cleanup on the exception path as well to avoid masking rollout failures with an OOM.
+                if self.vllm_mode == 'colocate' and args.sleep_level > 0:
+                    try:
+                        self.engine.engine.reset_prefix_cache()
+                    finally:
+                        self.engine.engine.sleep(level=args.sleep_level)
+                        aggressive_empty_cache()
+                        set_expandable_segments(True)
         return outputs
 
     def _preprocess_inputs(self, samples: List[OnPolicySample]) -> List[OnPolicySample]:

--- a/swift/rlhf_trainers/utils.py
+++ b/swift/rlhf_trainers/utils.py
@@ -1680,9 +1680,9 @@ def sleep_vllm_engine(engine, sleep_level: int, suppress_errors: bool = False) -
         try:
             callback()
         except Exception as error:
-            cleanup_error = cleanup_error or error
-            if suppress_errors:
-                get_logger().warning(f'Failed to {operation} during vLLM cleanup: {error}')
+            if cleanup_error is None:
+                cleanup_error = error
+            get_logger().warning(f'Failed to {operation} during vLLM cleanup: {error}')
     if cleanup_error is not None and not suppress_errors:
         raise cleanup_error
 

--- a/swift/rlhf_trainers/utils.py
+++ b/swift/rlhf_trainers/utils.py
@@ -1667,6 +1667,26 @@ def set_expandable_segments(enable: bool) -> None:
         os.environ['PYTORCH_CUDA_ALLOC_CONF'] = f'expandable_segments:{enable}'
 
 
+def sleep_vllm_engine(engine, sleep_level: int, suppress_errors: bool = False) -> None:
+    """Release colocated vLLM memory while attempting every cleanup operation."""
+    cleanup_error = None
+    operations = [
+        ('reset the prefix cache', engine.reset_prefix_cache),
+        ('put the engine to sleep', lambda: engine.sleep(level=sleep_level)),
+        ('empty the device cache', aggressive_empty_cache),
+        ('restore expandable segments', lambda: set_expandable_segments(True)),
+    ]
+    for operation, callback in operations:
+        try:
+            callback()
+        except Exception as error:
+            cleanup_error = cleanup_error or error
+            if suppress_errors:
+                get_logger().warning(f'Failed to {operation} during vLLM cleanup: {error}')
+    if cleanup_error is not None and not suppress_errors:
+        raise cleanup_error
+
+
 def peft_config_to_dict(peft_config):
     if not isinstance(peft_config, dict):
         peft_config = asdict(peft_config)

--- a/tests/utils/test_rollout_offload_order.py
+++ b/tests/utils/test_rollout_offload_order.py
@@ -1,0 +1,87 @@
+import unittest
+from contextlib import contextmanager, nullcontext
+from types import MethodType, SimpleNamespace
+from unittest.mock import Mock, patch
+
+from swift.rlhf_trainers.args_mixin import RolloutTrainerArgumentsMixin
+from swift.rlhf_trainers.rollout_mixin import RolloutTrainerMixin
+
+
+class TestRolloutOffloadOrder(unittest.TestCase):
+
+    def _make_trainer(self, events, rollout_error=None):
+        trainer = object.__new__(RolloutTrainerMixin)
+        args = object.__new__(RolloutTrainerArgumentsMixin)
+        args.sleep_level = 1
+        trainer.args = args
+        trainer.vllm_mode = 'colocate'
+        trainer.enable_offload = True
+        trainer.async_generate = False
+        trainer.state = SimpleNamespace(global_step=0)
+        trainer._last_loaded_step = 0
+        trainer.request_config = Mock()
+        trainer.engine = SimpleNamespace(
+            inner_model_executor=SimpleNamespace(is_sleeping=False),
+            engine=SimpleNamespace(
+                reset_prefix_cache=lambda: events.append('reset_vllm_cache'),
+                sleep=lambda level: events.append(f'sleep_vllm_{level}'),
+            ),
+        )
+
+        @contextmanager
+        def offload_context(_self):
+            events.append('offload_trainer')
+            try:
+                yield
+            finally:
+                events.append('load_trainer')
+
+        def infer(_self, samples, request_config):
+            events.append('rollout')
+            if rollout_error is not None:
+                raise rollout_error
+            return samples
+
+        trainer.offload_context = MethodType(offload_context, trainer)
+        trainer._infer_single_or_multi_turn = MethodType(infer, trainer)
+        trainer.multi_turn_completion_length_context = lambda: nullcontext()
+        return trainer
+
+    @patch('swift.rlhf_trainers.rollout_mixin.set_expandable_segments')
+    @patch('swift.rlhf_trainers.rollout_mixin.aggressive_empty_cache')
+    def test_vllm_sleeps_before_trainer_reload(self, _, __):
+        events = []
+        trainer = self._make_trainer(events)
+
+        result = trainer._fast_infer(['sample'])
+
+        self.assertEqual(result, ['sample'])
+        self.assertEqual(events, [
+            'offload_trainer',
+            'rollout',
+            'reset_vllm_cache',
+            'sleep_vllm_1',
+            'load_trainer',
+        ])
+
+    @patch('swift.rlhf_trainers.rollout_mixin.set_expandable_segments')
+    @patch('swift.rlhf_trainers.rollout_mixin.aggressive_empty_cache')
+    def test_vllm_sleeps_before_trainer_reload_when_rollout_fails(self, _, __):
+        events = []
+        rollout_error = RuntimeError('rollout failed')
+        trainer = self._make_trainer(events, rollout_error)
+
+        with self.assertRaisesRegex(RuntimeError, 'rollout failed'):
+            trainer._fast_infer(['sample'])
+
+        self.assertEqual(events, [
+            'offload_trainer',
+            'rollout',
+            'reset_vllm_cache',
+            'sleep_vllm_1',
+            'load_trainer',
+        ])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/utils/test_rollout_offload_order.py
+++ b/tests/utils/test_rollout_offload_order.py
@@ -9,7 +9,7 @@ from swift.rlhf_trainers.rollout_mixin import RolloutTrainerMixin
 
 class TestRolloutOffloadOrder(unittest.TestCase):
 
-    def _make_trainer(self, events, rollout_error=None):
+    def _make_trainer(self, events, rollout_error=None, reset_error=None):
         trainer = object.__new__(RolloutTrainerMixin)
         args = object.__new__(RolloutTrainerArgumentsMixin)
         args.sleep_level = 1
@@ -20,10 +20,16 @@ class TestRolloutOffloadOrder(unittest.TestCase):
         trainer.state = SimpleNamespace(global_step=0)
         trainer._last_loaded_step = 0
         trainer.request_config = Mock()
+
+        def reset_prefix_cache():
+            events.append('reset_vllm_cache')
+            if reset_error is not None:
+                raise reset_error
+
         trainer.engine = SimpleNamespace(
             inner_model_executor=SimpleNamespace(is_sleeping=False),
             engine=SimpleNamespace(
-                reset_prefix_cache=lambda: events.append('reset_vllm_cache'),
+                reset_prefix_cache=reset_prefix_cache,
                 sleep=lambda level: events.append(f'sleep_vllm_{level}'),
             ),
         )
@@ -47,8 +53,8 @@ class TestRolloutOffloadOrder(unittest.TestCase):
         trainer.multi_turn_completion_length_context = lambda: nullcontext()
         return trainer
 
-    @patch('swift.rlhf_trainers.rollout_mixin.set_expandable_segments')
-    @patch('swift.rlhf_trainers.rollout_mixin.aggressive_empty_cache')
+    @patch('swift.rlhf_trainers.utils.set_expandable_segments')
+    @patch('swift.rlhf_trainers.utils.aggressive_empty_cache')
     def test_vllm_sleeps_before_trainer_reload(self, _, __):
         events = []
         trainer = self._make_trainer(events)
@@ -64,12 +70,31 @@ class TestRolloutOffloadOrder(unittest.TestCase):
             'load_trainer',
         ])
 
-    @patch('swift.rlhf_trainers.rollout_mixin.set_expandable_segments')
-    @patch('swift.rlhf_trainers.rollout_mixin.aggressive_empty_cache')
+    @patch('swift.rlhf_trainers.utils.set_expandable_segments')
+    @patch('swift.rlhf_trainers.utils.aggressive_empty_cache')
     def test_vllm_sleeps_before_trainer_reload_when_rollout_fails(self, _, __):
         events = []
         rollout_error = RuntimeError('rollout failed')
         trainer = self._make_trainer(events, rollout_error)
+
+        with self.assertRaisesRegex(RuntimeError, 'rollout failed'):
+            trainer._fast_infer(['sample'])
+
+        self.assertEqual(events, [
+            'offload_trainer',
+            'rollout',
+            'reset_vllm_cache',
+            'sleep_vllm_1',
+            'load_trainer',
+        ])
+
+    @patch('swift.rlhf_trainers.utils.set_expandable_segments')
+    @patch('swift.rlhf_trainers.utils.aggressive_empty_cache')
+    def test_cleanup_error_does_not_mask_rollout_error(self, _, __):
+        events = []
+        rollout_error = RuntimeError('rollout failed')
+        reset_error = RuntimeError('cache reset failed')
+        trainer = self._make_trainer(events, rollout_error, reset_error)
 
         with self.assertRaisesRegex(RuntimeError, 'rollout failed'):
             trainer._fast_infer(['sample'])


### PR DESCRIPTION
## Summary

Fix the GPU memory transition order between colocated vLLM and the trainer when rollout generation fails.

Previously, vLLM was put to sleep only after rollout generation completed successfully. If synchronous, asynchronous, or multi-turn rollout raised an exception, the sleep call was skipped. Exiting `offload_context` would then reload the trainer model onto the GPU while vLLM was still occupying GPU memory, potentially causing an OOM and masking the original rollout error.

This change applies the fix to both the Transformers and Megatron rollout paths.

## Changes

- Run colocated vLLM cleanup in a `finally` block before `offload_context` reloads the trainer.
- Apply the same lifecycle ordering to the Megatron rollout path.
- Attempt every cleanup operation even if an earlier operation fails.
- Preserve the original rollout exception when cleanup also fails.
- Log every cleanup failure, including failures after the first one.
- Continue raising the first cleanup error when rollout itself succeeded.
- Add regression tests for successful rollouts, failed rollouts, and cleanup failures.

## Tests

`python -m pytest tests/utils/test_rollout_offload_order.py -v` passed all 3 tests.
