### PR TITLE
Fix external plugin module name collisions

### DIFF
--- a/swift/utils/utils.py
+++ b/swift/utils/utils.py
@@ -3,7 +3,8 @@ import asyncio
 import datetime as dt
 import fnmatch
 import glob
-import importlib
+import hashlib
+import importlib.util
 import json
 import json_repair
 import numpy as np
@@ -403,10 +404,23 @@ def patch_getattr(obj_cls, item_name: str):
 
 def import_external_file(file_path: str):
     file_path = os.path.abspath(os.path.expanduser(file_path))
-    py_dir, py_file = os.path.split(file_path)
+    py_dir = os.path.dirname(file_path)
     assert os.path.isdir(py_dir), f'py_dir: {py_dir}'
     sys.path.insert(0, py_dir)
-    return importlib.import_module(py_file.split('.', 1)[0])
+    module_name = f'_swift_external_{hashlib.sha256(file_path.encode()).hexdigest()}'
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f'Cannot import external file: {file_path}')
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
 
 
 def json_parse_to_dict(value: Union[str, Dict, None], strict: bool = True) -> Union[str, Dict]:

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -1,9 +1,10 @@
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 
-from swift.utils import copy_files_by_pattern
+from swift.utils import copy_files_by_pattern, import_external_file
 
 
 class TestFileUtils(unittest.TestCase):
@@ -26,6 +27,27 @@ class TestFileUtils(unittest.TestCase):
             os.path.join(self.tmp_dir, 'source'), os.path.join(self.tmp_dir, 'target'), ['*.txt', 'subfolder/*.txt'])
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'target', '1.txt')))
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'target', 'subfolder', '2.txt')))
+
+    def test_import_external_files_with_same_name(self):
+        plugin_dirs = [os.path.join(self.tmp_dir, name) for name in ('first', 'second')]
+        plugin_paths = []
+        for plugin_dir, value in zip(plugin_dirs, ('first', 'second')):
+            os.makedirs(plugin_dir)
+            plugin_path = os.path.join(plugin_dir, 'plugin.py')
+            with open(plugin_path, 'w') as f:
+                f.write(f'VALUE = {value!r}\n')
+            plugin_paths.append(plugin_path)
+
+        modules = []
+        try:
+            modules = [import_external_file(plugin_path) for plugin_path in plugin_paths]
+            self.assertEqual([module.VALUE for module in modules], ['first', 'second'])
+        finally:
+            for module in modules:
+                sys.modules.pop(module.__name__, None)
+            for plugin_dir in plugin_dirs:
+                while plugin_dir in sys.path:
+                    sys.path.remove(plugin_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

External plugins are currently imported by their filename stem. When two configured plugins have the same filename in different directories, Python reuses the first entry from `sys.modules`, so the second plugin is never executed.

Load external plugins under a stable module key derived from their absolute path. This keeps same-path imports cached while isolating same-name files from different directories, and removes a partially initialized module if execution fails.

The regression test creates two `plugin.py` files in separate directories and verifies that both modules execute with their own values.

## Experiment results

- `python -m unittest tests.utils.test_file_utils.TestFileUtils.test_import_external_files_with_same_name` (passed)
- `python -m unittest tests.utils.test_file_utils` (2 tests passed)
- `pre-commit run --files swift/utils/utils.py tests/utils/test_file_utils.py` (passed)
- `git diff --check` (passed)
