### PR TITLE
fix: honor sampled fps in Qwen-Omni video_second_per_grid

### DIFF
--- a/swift/template/templates/qwen.py
+++ b/swift/template/templates/qwen.py
@@ -899,7 +899,13 @@ class Qwen2_5OmniTemplate(Qwen2_5VLTemplate):
             if isinstance(video, list):  # image list
                 from qwen_omni_utils import vision_process
                 video_inputs['sample_fps'] = vision_process.FPS
-            _video = fetch_video(video_inputs, **kwargs)
+            _video, sample_fps = fetch_video(video_inputs, return_video_sample_fps=True, **kwargs)
+            # Record the fps actually used when sampling frames (mirrors the VL v2_5 path). Without
+            # it the HF processor falls back to fps=1.0, so `video_second_per_grid` (temporal spacing
+            # driving TMRoPE + the audio/video token interleaving under `use_audio_in_video`) ignores
+            # the real fps. Needed in every mode: the transformers/train path recomputes it from this
+            # value in `_encode`, and vllm re-runs the HF processor on the forwarded mm_processor_kwargs.
+            inputs.mm_processor_kwargs.setdefault('fps', []).append(sample_fps)
             if isinstance(_video, torch.Tensor):
                 _video = _video.to(torch.uint8)
             inputs.videos[index] = _video
@@ -997,6 +1003,15 @@ class Qwen2_5OmniTemplate(Qwen2_5VLTemplate):
         media_inputs.pop('input_ids')
         media_inputs.pop('attention_mask')
         media_inputs = to_float_dtype(media_inputs, self.model_info.torch_dtype)
+        # The processor receives pre-sampled frames (no fps) and computes `video_second_per_grid`
+        # from the default fps=1.0. Override it with the fps actually used during sampling so the
+        # temporal position ids / audio-video token interleaving honor the user-configured fps.
+        fps = inputs.mm_processor_kwargs.get('fps')
+        if inputs.videos and fps and 'video_second_per_grid' in media_inputs:
+            video_processor = getattr(processor, 'video_processor', None) or processor.image_processor
+            media_inputs['video_second_per_grid'] = [
+                video_processor.temporal_patch_size / tmp for tmp in fps
+            ]
         input_ids = encoded['input_ids']
         labels = encoded['labels']
         loss_scale = encoded.get('loss_scale', None)


### PR DESCRIPTION
Qwen2.5/3-Omni pre-sample video frames in `replace_tag` and pass the processor decoded frames without an `fps`, so `Qwen*OmniProcessor` falls back to its default `fps=1.0` and computes `video_second_per_grid = temporal_patch_size / 1.0`. For e.g. fps=10 this is 10x too large (2.0 instead of 0.2), which skews TMRoPE's temporal axis and, under `use_audio_in_video`, front-loads all audio tokens onto the first few frames instead of interleaving them evenly.

The VL (v2_5) path already forwards the real sampled fps; the Omni path was missing it. Capture it via `return_video_sample_fps=True`, record it in `mm_processor_kwargs['fps']` (vLLM path) and recompute `video_second_per_grid` from it in `_encode` (transformers/train path). Affects both omni_v2_5 and omni_v3.

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix incorrect `video_second_per_grid` for Qwen-Omni (Qwen2.5-Omni / Qwen3-Omni) video & `use_audio_in_video` inputs.

## Problem

The Omni templates pre-sample video frames in `replace_tag` and pass the decoded frames to the processor **without `fps`**. `Qwen*OmniProcessor` then falls back to its default `fps=1.0` and computes `video_second_per_grid = temporal_patch_size / 1.0`. For a video sampled at e.g. fps=10 the correct value is `2/10 = 0.2`, but the model receives `2.0` (10x too large).

This skews TMRoPE's temporal axis, and under `use_audio_in_video` it front-loads all audio tokens onto the first few video frames instead of interleaving them evenly across the clip.

## Root cause
The VL path (`Qwen2VLTemplate`, version `v2_5`) already forwards the real sampled fps (`return_video_sample_fps=True` → `mm_processor_kwargs['fps']` → `second_per_grid_ts`). The Omni path was missing this step, so the fps set by the user (env `fps` / `chat_template_kwargs`) affects frame sampling but never reaches `video_second_per_grid`.

## Fix
In `Qwen2_5OmniTemplate` (covers both `omni_v2_5` and `omni_v3`):
- capture the real sampled fps with `return_video_sample_fps=True`;
- record it in `mm_processor_kwargs['fps']` so the vLLM path re-runs its HF processor with the correct fps;
- recompute `video_second_per_grid = temporal_patch_size / fps` in `_encode` for the transformers/train path (mirrors the v2_5 path).
