### PR TITLE
perf(rlhf): vectorize padding-free sequence reductions

### DIFF
--- a/swift/rlhf_trainers/dpo_trainer.py
+++ b/swift/rlhf_trainers/dpo_trainer.py
@@ -139,22 +139,18 @@ class DPOTrainer(RLHFTrainerMixin, SwiftMixin, DataLoaderMixin, HFDPOTrainer):
         if self.template.padding_free:
             cu_seqlens = self.get_cu_seqlens(text_position_ids, batch.get('logits_to_keep'))
             num_examples = (cu_seqlens.shape[0] - 1) // 2
-            all_logps = per_token_logps.new_zeros((num_examples * 2, ))
-            completion_lengths = (cu_seqlens[1:] - cu_seqlens[:-1])
-            chosen_lengths = completion_lengths[:num_examples]
-            rejected_lengths = completion_lengths[num_examples:]
-            public_lengths = torch.min(chosen_lengths, rejected_lengths)  # l_p in the paper
-
-            for i in range(cu_seqlens.shape[0] - 1):
-                start, end = cu_seqlens[i], cu_seqlens[i + 1]
-                length = end - start
-                public_length = public_lengths[i % num_examples]
-                if self.args.ld_alpha is not None and not is_ref_model and length > public_length:
-                    front_logps = per_token_logps[:, start:start + public_length].sum()
-                    rear_logps = per_token_logps[:, start + public_length:end].sum()
-                    all_logps[i] = front_logps + self.args.ld_alpha * rear_logps
-                else:
-                    all_logps[i] = per_token_logps[:, start:end].sum()
+            completion_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+            if self.args.ld_alpha is not None and not is_ref_model:
+                chosen_lengths = completion_lengths[:num_examples]
+                rejected_lengths = completion_lengths[num_examples:]
+                public_lengths = torch.min(chosen_lengths, rejected_lengths)  # l_p in the paper
+                public_lengths = torch.cat((public_lengths, public_lengths))
+                front_lengths = torch.min(completion_lengths, public_lengths)
+                split_lengths = torch.stack((front_lengths, completion_lengths - front_lengths), dim=-1).flatten()
+                split_logps = self._packed_sequence_sum(per_token_logps.flatten(), split_lengths).view(-1, 2)
+                all_logps = split_logps[:, 0] + self.args.ld_alpha * split_logps[:, 1]
+            else:
+                all_logps = self._packed_sequence_sum(per_token_logps.flatten(), completion_lengths)
             num_tokens = cu_seqlens[num_examples]
             if not is_ref_model:
                 output['nll_loss'] = -origin_per_token_logps[:, :num_tokens][loss_mask[:, :num_tokens]].mean()

--- a/swift/rlhf_trainers/kto_trainer.py
+++ b/swift/rlhf_trainers/kto_trainer.py
@@ -109,12 +109,10 @@ class KTOTrainer(RLHFTrainerMixin, SwiftMixin, HFKTOTrainer):
             logits, labels, label_pad_token_id=self.label_pad_token_id, reduction='sum')
         if self.template.padding_free:
             cu_seqlens = self.get_cu_seqlens(text_position_ids, inputs.get('logits_to_keep'))
-            all_logps = per_token_logps.new_zeros(cu_seqlens.shape[0] - 1)
-            all_logits = per_token_logps.new_zeros(cu_seqlens.shape[0] - 1)
-            for i in range(cu_seqlens.shape[0] - 1):
-                start, end = cu_seqlens[i], cu_seqlens[i + 1]
-                all_logps[i] = per_token_logps[:, start:end].sum()
-                all_logits[i] = sum_logits[:, start:end].sum()
+            completion_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+            packed_values = torch.stack((per_token_logps.flatten(), sum_logits.to(per_token_logps.dtype).flatten()),
+                                        dim=-1)
+            all_logps, all_logits = self._packed_sequence_sum(packed_values, completion_lengths).unbind(dim=-1)
         else:
             all_logps = per_token_logps.sum(-1)
             all_logits = sum_logits.sum(-1)

--- a/swift/rlhf_trainers/rlhf_mixin.py
+++ b/swift/rlhf_trainers/rlhf_mixin.py
@@ -133,6 +133,17 @@ class RLHFTrainerMixin:
         kwargs = {'train_dataset': train_dataset} if 'train_dataset' in parameters else {}
         return get_train_sampler(**kwargs)
 
+    @staticmethod
+    def _packed_sequence_sum(values: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Sum contiguous packed token values without reading sequence lengths on the host."""
+        segment_ids = torch.repeat_interleave(
+            torch.arange(lengths.shape[0], device=lengths.device), lengths, output_size=values.shape[0])
+        # Match torch.sum's effective accumulation precision for low-precision inputs.
+        accumulation_values = values.float() if values.dtype in (torch.float16, torch.bfloat16) else values
+        result = accumulation_values.new_zeros((lengths.shape[0], *values.shape[1:]))
+        result.index_add_(0, segment_ids, accumulation_values)
+        return result.to(values.dtype)
+
     def get_per_token_logps(
         self,
         logits: torch.FloatTensor,

--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -1221,13 +1221,14 @@ class SwiftMixin:
 
     def get_cu_seqlens(self, position_ids, logits_to_keep) -> torch.Tensor:
         cu_seqlens = get_packed_seq_params(position_ids)['cu_seq_lens_q']
-        res_cu_seqlens = cu_seqlens.clone()
         if isinstance(logits_to_keep, torch.Tensor):
-            for i in range(cu_seqlens.shape[0] - 1):
-                start, end = cu_seqlens[i], cu_seqlens[i + 1]
-                res_cu_seqlens[i + 1:] -= (~logits_to_keep[start:end]).sum()
-        elif isinstance(logits_to_keep, int):
-            res_cu_seqlens[1:] -= position_ids.shape[-1] + 1 - logits_to_keep
+            kept_cumsum = logits_to_keep.to(cu_seqlens.dtype).cumsum(dim=0, dtype=cu_seqlens.dtype)
+            kept_cumsum = torch.cat((cu_seqlens.new_zeros(1), kept_cumsum))
+            res_cu_seqlens = kept_cumsum[cu_seqlens.long()]
+        else:
+            res_cu_seqlens = cu_seqlens.clone()
+            if isinstance(logits_to_keep, int):
+                res_cu_seqlens[1:] -= position_ids.shape[-1] + 1 - logits_to_keep
         return res_cu_seqlens
 
     @contextmanager

--- a/tests/test_align/test_rlhf_loss.py
+++ b/tests/test_align/test_rlhf_loss.py
@@ -1,9 +1,16 @@
+import os
 import pytest
 import torch
+import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from swift.rlhf_trainers import rlhf_mixin
+from swift.rlhf_trainers.dpo_trainer import DPOTrainer
+from swift.rlhf_trainers.kto_trainer import KTOTrainer
+from swift.rlhf_trainers.rlhf_mixin import RLHFTrainerMixin
+from swift.trainers.mixin import SwiftMixin
+from swift.utils import get_packed_seq_params
 
 
 @pytest.mark.parametrize('dtype', [torch.float32, torch.bfloat16])
@@ -37,3 +44,300 @@ def test_sequence_parallel_selective_log_softmax(dtype, reduction):
     torch.testing.assert_close(actual_mask, expected_mask)
     actual_logps.sum().backward()
     torch.testing.assert_close(logits.grad, expected_logits.grad)
+
+
+def _test_devices():
+    devices = [torch.device('cpu')]
+    if torch.cuda.is_available():
+        devices.append(torch.device('cuda'))
+    return devices
+
+
+def _reference_compact_cu_seqlens(cu_seqlens, keep_mask):
+    boundaries = cu_seqlens.cpu().tolist()
+    compact_boundaries = [0]
+    kept = 0
+    for start, end in zip(boundaries[:-1], boundaries[1:]):
+        kept += int(keep_mask[start:end].sum().cpu())
+        compact_boundaries.append(kept)
+    return torch.tensor(compact_boundaries, dtype=cu_seqlens.dtype, device=cu_seqlens.device)
+
+
+def _reference_segment_sum(values, lengths):
+    outputs = []
+    offset = 0
+    for length in lengths.cpu().tolist():
+        outputs.append(values[offset:offset + length].sum(dim=0))
+        offset += length
+    return torch.stack(outputs)
+
+
+def _reference_dpo_sum(values, lengths, num_examples, ld_alpha=None, is_ref_model=False):
+    lengths_list = lengths.cpu().tolist()
+    public_lengths = [min(lengths_list[i], lengths_list[i + num_examples]) for i in range(num_examples)]
+    outputs = []
+    offset = 0
+    for i, length in enumerate(lengths_list):
+        public_length = public_lengths[i % num_examples]
+        if ld_alpha is not None and not is_ref_model and length > public_length:
+            front = values[offset:offset + public_length].sum()
+            rear = values[offset + public_length:offset + length].sum()
+            outputs.append(front + ld_alpha * rear)
+        else:
+            outputs.append(values[offset:offset + length].sum())
+        offset += length
+    return torch.stack(outputs)
+
+
+class _ModelStub:
+
+    def __init__(self, logits):
+        self.logits = logits
+
+    def __call__(self, **kwargs):
+        return SimpleNamespace(logits=self.logits)
+
+
+class _LogitsToKeepModel:
+
+    def __init__(self, logits):
+        self.logits = logits
+
+    def __call__(self, logits_to_keep=None, **kwargs):
+        logits = self.logits
+        if isinstance(logits_to_keep, torch.Tensor):
+            logits = logits[:, logits_to_keep]
+        return SimpleNamespace(logits=logits)
+
+
+class _PaddingFreeDPOStub:
+
+    def __init__(self, ld_alpha=0.5):
+        self.args = SimpleNamespace(ld_alpha=ld_alpha, use_logits_to_keep=True)
+        self.template = SimpleNamespace(sequence_parallel_size=1, padding_free=True)
+        self.aux_loss_enabled = False
+        self.is_encoder_decoder = False
+        self.label_pad_token_id = -100
+        self.loss_type = ['sigmoid']
+
+    def get_use_logits_to_keep(self, default_value=True):
+        return True
+
+    prepare_logits_to_keep = SwiftMixin.prepare_logits_to_keep
+    get_cu_seqlens = SwiftMixin.get_cu_seqlens
+    get_per_token_logps = RLHFTrainerMixin.get_per_token_logps
+    _packed_sequence_sum = staticmethod(RLHFTrainerMixin._packed_sequence_sum)
+
+
+class TestPackedRLHFReduction(unittest.TestCase):
+
+    def test_padding_free_dpo_logits_to_keep_ld_integration(self):
+        sequence_lengths = [4, 3, 5, 2]
+        label_mask_values = [False, True, False, True, True, True, False, True, True, True, False, True, True, False]
+
+        for device in _test_devices():
+            with self.subTest(device=device):
+                torch.manual_seed(23)
+                position_ids = torch.cat([torch.arange(length, device=device)
+                                          for length in sequence_lengths]).unsqueeze(0)
+                label_mask = torch.tensor(label_mask_values, dtype=torch.bool, device=device)
+                token_ids = torch.arange(1, 15, device=device, dtype=torch.long) % 6 + 1
+                labels = token_ids.masked_fill(~label_mask, -100).unsqueeze(0)
+                actual_logits = torch.randn(1, labels.shape[1], 7, device=device, requires_grad=True)
+                expected_logits = actual_logits.detach().clone().requires_grad_(True)
+
+                actual_trainer = _PaddingFreeDPOStub()
+                actual_batch = {
+                    'labels': labels.clone(),
+                    'position_ids': position_ids.clone(),
+                    'text_position_ids': position_ids.clone(),
+                }
+                with patch.dict(os.environ, {'SWIFT_SINGLE_DEVICE_MODE': '1'}):
+                    actual_output = DPOTrainer.concatenated_forward(actual_trainer, _LogitsToKeepModel(actual_logits),
+                                                                    actual_batch)
+
+                expected_trainer = _PaddingFreeDPOStub()
+                expected_batch = {
+                    'labels': labels.clone(),
+                    'position_ids': position_ids.clone(),
+                    'text_position_ids': position_ids.clone(),
+                }
+                with patch.dict(os.environ, {'SWIFT_SINGLE_DEVICE_MODE': '1'}):
+                    SwiftMixin.prepare_logits_to_keep(expected_trainer, expected_batch)
+                self.assertTrue(expected_batch['logits_to_keep'].dtype == torch.bool)
+                expected_labels = torch.roll(expected_batch['labels'], shifts=-1, dims=1)
+                selected_logits = expected_logits[:, expected_batch['logits_to_keep']]
+                expected_logps, expected_mean_logits, expected_loss_mask = RLHFTrainerMixin.get_per_token_logps(
+                    expected_trainer, selected_logits, expected_labels)
+                expected_cu_seqlens = SwiftMixin.get_cu_seqlens(expected_trainer, position_ids,
+                                                                expected_batch['logits_to_keep'])
+                expected_lengths = expected_cu_seqlens[1:] - expected_cu_seqlens[:-1]
+                self.assertEqual(expected_lengths.cpu().tolist(), [3, 2, 4, 1])
+                expected_all_logps = _reference_dpo_sum(
+                    expected_logps.flatten(), expected_lengths, num_examples=2, ld_alpha=0.5)
+                num_tokens = int(expected_cu_seqlens[2].item())
+                expected_nll_loss = -expected_logps[:, :num_tokens][expected_loss_mask[:, :num_tokens]].mean()
+                expected_chosen_logits = expected_mean_logits[:, :num_tokens][expected_loss_mask[:, :num_tokens]].mean()
+                expected_rejected_logits = expected_mean_logits[:, num_tokens:][expected_loss_mask[:,
+                                                                                                   num_tokens:]].mean()
+
+                actual_all_logps = torch.cat((actual_output['chosen_logps'], actual_output['rejected_logps']))
+                torch.testing.assert_close(actual_all_logps, expected_all_logps, rtol=1e-5, atol=1e-6)
+                torch.testing.assert_close(actual_output['nll_loss'], expected_nll_loss, rtol=1e-5, atol=1e-6)
+                torch.testing.assert_close(
+                    actual_output['mean_chosen_logits'], expected_chosen_logits, rtol=1e-5, atol=1e-6)
+                torch.testing.assert_close(
+                    actual_output['mean_rejected_logits'], expected_rejected_logits, rtol=1e-5, atol=1e-6)
+
+                actual_objective = actual_all_logps.sum() + actual_output['nll_loss']
+                expected_objective = expected_all_logps.sum() + expected_nll_loss
+                actual_objective.backward()
+                expected_objective.backward()
+                torch.testing.assert_close(actual_logits.grad, expected_logits.grad, rtol=1e-5, atol=1e-6)
+
+    def test_get_cu_seqlens(self):
+        sequence_lengths = [4, 3, 5, 2]
+        keep_masks = [
+            [True] * sum(sequence_lengths),
+            [True, False, True, False, False, False, False, True, True, False, True, False, False, True],
+            [False] * sum(sequence_lengths),
+        ]
+        trainer = object.__new__(SwiftMixin)
+
+        for device in _test_devices():
+            position_ids = torch.cat([torch.arange(length, device=device) for length in sequence_lengths]).unsqueeze(0)
+            original = get_packed_seq_params(position_ids)['cu_seq_lens_q']
+            for keep_values in keep_masks:
+                with self.subTest(device=device, keep_values=keep_values):
+                    keep_mask = torch.tensor(keep_values, dtype=torch.bool, device=device)
+                    expected = _reference_compact_cu_seqlens(original, keep_mask)
+                    actual = trainer.get_cu_seqlens(position_ids, keep_mask)
+                    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+                    self.assertEqual(actual.dtype, original.dtype)
+                    self.assertEqual(actual.device, original.device)
+
+            with self.subTest(device=device, logits_to_keep=None):
+                actual = trainer.get_cu_seqlens(position_ids, None)
+                torch.testing.assert_close(actual, original, rtol=0, atol=0)
+
+            with self.subTest(device=device, logits_to_keep=11):
+                expected = original.clone()
+                expected[1:] -= position_ids.shape[-1] + 1 - 11
+                actual = trainer.get_cu_seqlens(position_ids, 11)
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_packed_sequence_sum_forward_and_backward(self):
+        lengths = [0, 3, 2, 0, 4]
+        total_tokens = sum(lengths)
+
+        for device in _test_devices():
+            dtypes = [torch.float32, torch.bfloat16]
+            if device.type == 'cuda':
+                dtypes.append(torch.float16)
+            for dtype in dtypes:
+                for trailing_shape in [(), (2, )]:
+                    with self.subTest(device=device, dtype=dtype, trailing_shape=trailing_shape):
+                        torch.manual_seed(42)
+                        shape = (total_tokens, *trailing_shape)
+                        actual_values = torch.randn(shape, dtype=dtype, device=device, requires_grad=True)
+                        expected_values = actual_values.detach().clone().requires_grad_(True)
+                        device_lengths = torch.tensor(lengths, dtype=torch.int32, device=device)
+
+                        actual = RLHFTrainerMixin._packed_sequence_sum(actual_values, device_lengths)
+                        expected = _reference_segment_sum(expected_values, device_lengths)
+                        torch.testing.assert_close(actual, expected)
+                        self.assertEqual(actual.dtype, dtype)
+
+                        grad = torch.randn_like(actual)
+                        actual.backward(grad)
+                        expected.backward(grad)
+                        torch.testing.assert_close(actual_values.grad, expected_values.grad, rtol=0, atol=0)
+
+    def test_dpo_packed_aggregation(self):
+        lengths_list = [3, 5, 0, 5, 2, 4]
+        num_examples = len(lengths_list) // 2
+        total_tokens = sum(lengths_list)
+        cases = [(None, False), (0.0, False), (0.3, False), (0.3, True)]
+
+        for device in _test_devices():
+            for dtype in [torch.float32, torch.bfloat16]:
+                lengths = torch.tensor(lengths_list, dtype=torch.int32, device=device)
+                cu_seqlens = torch.cat((lengths.new_zeros(1), lengths.cumsum(0, dtype=lengths.dtype)))
+                for ld_alpha, is_ref_model in cases:
+                    with self.subTest(device=device, dtype=dtype, ld_alpha=ld_alpha, is_ref_model=is_ref_model):
+                        torch.manual_seed(7)
+                        actual_values = torch.randn(1, total_tokens, dtype=dtype, device=device, requires_grad=True)
+                        expected_values = actual_values.detach().clone().requires_grad_(True)
+                        reduced_logits = torch.randn_like(actual_values)
+                        loss_mask = torch.ones_like(actual_values, dtype=torch.bool)
+                        logits = torch.zeros(1, total_tokens, 2, dtype=dtype, device=device)
+
+                        trainer = SimpleNamespace(
+                            get_use_logits_to_keep=lambda _: False,
+                            aux_loss_enabled=False,
+                            is_encoder_decoder=False,
+                            template=SimpleNamespace(sequence_parallel_size=1, padding_free=True),
+                            label_pad_token_id=-100,
+                            loss_type=['sigmoid'],
+                            args=SimpleNamespace(ld_alpha=ld_alpha),
+                            get_cu_seqlens=lambda *_: cu_seqlens,
+                            get_per_token_logps=lambda *_, **__: (actual_values, reduced_logits, loss_mask),
+                            _packed_sequence_sum=RLHFTrainerMixin._packed_sequence_sum,
+                        )
+                        batch = {
+                            'labels': torch.ones(1, total_tokens, dtype=torch.long, device=device),
+                            'position_ids': torch.arange(total_tokens, device=device).unsqueeze(0),
+                        }
+
+                        output = DPOTrainer.concatenated_forward(
+                            trainer, _ModelStub(logits), batch, is_ref_model=is_ref_model)
+                        actual = torch.cat((output['chosen_logps'], output['rejected_logps']))
+                        expected = _reference_dpo_sum(expected_values.flatten(), lengths, num_examples, ld_alpha,
+                                                      is_ref_model)
+                        torch.testing.assert_close(actual, expected)
+
+                        actual.sum().backward()
+                        expected.sum().backward()
+                        torch.testing.assert_close(actual_values.grad, expected_values.grad, rtol=0, atol=0)
+
+    def test_kto_packed_aggregation(self):
+        lengths_list = [0, 4, 2, 5]
+        total_tokens = sum(lengths_list)
+
+        for device in _test_devices():
+            for dtype in [torch.float32, torch.bfloat16]:
+                with self.subTest(device=device, dtype=dtype):
+                    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=device)
+                    cu_seqlens = torch.cat((lengths.new_zeros(1), lengths.cumsum(0, dtype=lengths.dtype)))
+                    torch.manual_seed(11)
+                    actual_logps = torch.randn(1, total_tokens, dtype=dtype, device=device, requires_grad=True)
+                    actual_logits = torch.randn(1, total_tokens, dtype=dtype, device=device, requires_grad=True)
+                    expected_logps = actual_logps.detach().clone().requires_grad_(True)
+                    expected_logits = actual_logits.detach().clone().requires_grad_(True)
+                    loss_mask = torch.ones_like(actual_logps, dtype=torch.bool)
+                    model_logits = torch.zeros(1, total_tokens, 2, dtype=dtype, device=device)
+
+                    trainer = SimpleNamespace(
+                        is_encoder_decoder=False,
+                        template=SimpleNamespace(sequence_parallel_size=1, padding_free=True),
+                        label_pad_token_id=-100,
+                        get_cu_seqlens=lambda *_: cu_seqlens,
+                        get_per_token_logps=lambda *_, **__: (actual_logps, actual_logits, loss_mask),
+                        _packed_sequence_sum=RLHFTrainerMixin._packed_sequence_sum,
+                    )
+                    inputs = {
+                        'text_position_ids': torch.arange(total_tokens, device=device).unsqueeze(0),
+                        'position_ids': torch.arange(total_tokens, device=device).unsqueeze(0),
+                    }
+                    labels = torch.ones(1, total_tokens, dtype=torch.long, device=device)
+
+                    output_logps, output_logits = KTOTrainer.get_batch_logps(trainer, inputs, model_logits, labels)
+                    reference_logps = _reference_segment_sum(expected_logps.flatten(), lengths)
+                    reference_logits = _reference_segment_sum(expected_logits.flatten(), lengths)
+                    torch.testing.assert_close(output_logps, reference_logps)
+                    torch.testing.assert_close(output_logits, reference_logits)
+
+                    (output_logps.sum() + 0.25 * output_logits.sum()).backward()
+                    (reference_logps.sum() + 0.25 * reference_logits.sum()).backward()
+                    torch.testing.assert_close(actual_logps.grad, expected_logps.grad, rtol=0, atol=0)
+                    torch.testing.assert_close(actual_logits.grad, expected_logits.grad, rtol=0, atol=0)


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support
- [x] Performance Optimization

## Summary

The Transformers `padding_free` DPO/KTO paths reduce packed per-token values with a Python loop over CUDA-resident sequence boundaries. Each logical sequence can introduce device-scalar slicing, a small reduction, and synchronization. Tensor-mask boundary compaction also performs sequence-count-dependent work.

This PR replaces those operations with tensorized boundary compaction and packed segment reduction. It does not add a public API, CLI option, dependency, or data migration.

## Implementation

- Replace tensor-mask `get_cu_seqlens` updates with an integer prefix count and boundary gather.
- Add private `RLHFTrainerMixin._packed_sequence_sum` using `repeat_interleave(..., output_size=...)` and `index_add_`.
- Use an FP32 accumulation workspace for FP16/BF16 values, then cast back to the input dtype.
- Apply one packed reduction to ordinary DPO and KTO aggregation.
- Apply one dual-value reduction to LD-DPO front/rear values and KTO log-prob/reduced-logit pairs.
- Keep non-padding-free branches unchanged.

## Validation

### Correctness

Focused tests cover CPU/CUDA boundary compaction, zero-length segments, FP32/BF16/FP16 helper behavior where supported, arbitrary trailing dimensions, forward/backward reference parity, ordinary DPO, LD-DPO, reference-model mode, KTO, and the boolean `logits_to_keep` integration path.

```text
pytest: 9 passed, 42 subtests passed
repository harness: Ran 5 tests, OK
```

Commands:

```bash
python -m pytest -q tests/test_align/test_rlhf_loss.py
python tests/run.py \
  --test_dir tests/test_align \
  --pattern test_rlhf_loss.py \
  --no-diff
```

### Performance: layer 1 — reduction microbenchmark

This isolates the old per-segment loop from the new packed reduction. It is intended to show reduction scaling, not end-to-end training speed.

Environment: H200, fixed 131,072 packed tokens, 25% kept tokens, 5 warmups, 30 timed repetitions.

| dtype | segments | loop | packed reduction | speedup |
|---|---:|---:|---:|---:|
| FP32 | 16 | 2.083 ms | 0.217 ms | 9.6x |
| FP32 | 128 | 16.417 ms | 0.189 ms | 87.0x |
| BF16 | 16 | 2.085 ms | 0.229 ms | 9.1x |
| BF16 | 128 | 16.410 ms | 0.204 ms | 80.4x |

The result demonstrates that the new reduction is largely insensitive to the number of packed segments under this workload. It does not imply the same percentage improvement for a complete training step.

### Performance: layer 2 — end-to-end training

This measures the actual Transformers padding-free DPO/KTO path rather than the helper alone.

Workload: Qwen2-0.5B, BF16 LoRA, H200, batch size 64, `max_length=256`, `padding_free=true`, FlashAttention 2.8.3, 40 steps, steady-state steps 11–40, three baseline/patched runs per task.

| task | baseline | patched | change |
|---|---:|---:|---:|
| DPO steady step time | 0.5643 s/it | 0.5247 s/it | -7.02% |
| KTO steady step time | 0.6666 s/it | 0.6481 s/it | -2.77% |

Peak memory was unchanged for this workload: DPO 5.23 GiB and KTO 6.06 GiB. KTO has higher run-to-run variance, so its number is workload evidence rather than a universal guarantee.

### Supporting evidence — Nsight Systems

A paired 12-step trace supports the mechanism behind the end-to-end result:

- `cudaMemcpyAsync`: 26,814 → 6,834 (-74.5%)
- `cudaStreamSynchronize`: 18,318 → 6,030 (-67.1%)
- `cudaLaunchKernel`: 99,624 → 75,396 (-24.3%)
- CUDA kernel instances: 128,832 → 104,604

The trace includes initialization and child processes. These counts are supporting evidence for reduced scalar aggregation and launch fragmentation, not an isolated kernel benchmark.

### Compatibility smoke

Mistral-7B-Instruct-v0.3 (`MistralForCausalLM`) completed baseline and patched 5-step padding-free DPO/KTO smoke runs without traceback. This validates a second decoder-only architecture; the short, warm-up-inclusive run is not used as a performance claim.

## Scope and limitations

- Primary scope is the existing Transformers padding-free DPO/KTO path. The boundary helper is shared with other Trainer consumers and remains behaviorally equivalent for the tested padding-free SFT sequence-accuracy path.
- CUDA atomic accumulation changes floating-point reduction order; small low-order FP32 differences are expected.
- The new path allocates segment IDs and an FP32 workspace for low-precision inputs; peak memory may be higher for very large packed token counts.
- No local NPU result is claimed. Distributed/sequence-parallel and dependency-matrix validation are left to the corresponding upstream CI jobs.
- Official pre-commit environment initialization timed out in the local network environment; direct `flake8`, `isort`, `yapf`, and `git diff --check` passed.

## Follow-up: test discovery

The default `tests/run.py` path currently does not collect `tests/test_align/test_rlhf_loss.py` because `tests/test_align` is not a unittest package. The default command can therefore report `SUCCESS (Runs=0)` for this file. This pre-existing CI discovery gap is intentionally not changed in this performance PR.

A follow-up CI PR should make the runner load non-package test files reliably, or add a dedicated alignment-test job, without broadening discovery into unrelated model-loading tests.

## Rollback

The change is stateless and does not alter persisted data or checkpoints. Rollback is a source revert; no migration or cache invalidation is required.

