### PR TITLE
[NPU] Adapt vLLM-Ascend 0.23 runtime

### DIFF
--- a/docs/source/BestPractices/NPU-support.md
+++ b/docs/source/BestPractices/NPU-support.md
@@ -46,7 +46,7 @@
 | torch_npu | >= 2.7.1.post4  |
 
 基础环境准备请参照 [Ascend PyTorch 安装文档](https://gitcode.com/Ascend/pytorch)。本文示例实验环境为 8 * 昇腾910B3 64G。
-注：vllm ascend系列官方推荐版本配套已更新至 CANN9.0.0 torch 2.9.0 torch_npu 2.9.0 vllm-ascend 0.18.0(A3) 0.19.1(A5)，详情请参阅 [vLLM Ascend 安装文档](https://docs.vllm.ai/projects/ascend/en/v0.18.0/installation.html)。
+vLLM-Ascend 需要与 CANN、torch 和 torch_npu 按整套兼容矩阵安装，详情请参阅 [vLLM-Ascend 0.23.0 安装文档](https://docs.vllm.ai/projects/ascend/en/v0.23.0/installation.html)。
 
 | 一级特性 | 特性                | 进展     |
 | -------- | ------------------- | -------- |
@@ -195,7 +195,7 @@ docker run -it \
 ### 本地环境安装
 ```shell
 # 创建新的 conda 虚拟环境（可选）
-conda create -n swift-npu python=3.11 -y
+conda create -n swift-npu python=3.12 -y
 conda activate swift-npu
 
 # 注意进行后续操作前要先 source 激活 CANN 环境
@@ -210,8 +210,10 @@ git clone https://github.com/modelscope/ms-swift.git
 cd ms-swift
 pip install -e .
 
-# 安装 torch_npu
-pip install torch_npu==2.9.0 decorator
+# 安装匹配的 PyTorch/TorchNPU 运行时
+pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0
+pip install torch_npu==2.10.0.post4 decorator \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 # 如果你想要使用 deepspeed（控制显存占用，训练速度会有一定下降）
 pip install deepspeed
 
@@ -219,8 +221,10 @@ pip install deepspeed
 pip install evalscope[opencompass]
 
 # 如果需要使用 vllm-ascend 进行推理，请安装以下包（更多版本请参考 [vLLM-Ascend 官网](https://docs.vllm.ai/projects/ascend/en/latest/installation.html)）
-pip install vllm==0.18.0
-pip install vllm-ascend==0.18.0
+pip install vllm==0.23.0
+pip install vllm-ascend==0.23.0 \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 ```
 
 ### NPU 可用性检查
@@ -701,9 +705,11 @@ ASCEND_RT_VISIBLE_DEVICES=0 swift deploy --model xxx/checkpoint-xxx-merged --max
 ### 使用vLLM-ascend进行部署
 使用pypi进行安装：
 ```shell
-# 请以 vLLM-Ascend 官方兼容矩阵为准；以下为本文验证版本。
-pip install vllm==0.14.0
-pip install vllm-ascend==0.14.0rc1
+# 请以 vLLM-Ascend 官方兼容矩阵为准；以下为本文推荐版本。
+pip install vllm==0.23.0
+pip install vllm-ascend==0.23.0 \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 ```
 原始模型：
 ```shell

--- a/docs/source_en/BestPractices/NPU-support.md
+++ b/docs/source_en/BestPractices/NPU-support.md
@@ -44,7 +44,8 @@ Recommended base environment versions:
 | CANN      | >= 8.5.1        |
 | torch     | >= 2.7.1        |
 | torch_npu | >= 2.7.1.post4  |
-Note: The officially recommended version compatibility matrix for the vLLM Ascend series has been updated to CANN 9.0.0, torch 2.9.0, torch_npu 2.9.0, vllm-ascend 0.18.0 for A3, and vllm-ascend 0.19.1 for A5. For details, see the [vLLM Ascend installation guide](https://docs.vllm.ai/projects/ascend/en/v0.18.0/installation.html).
+
+Install vLLM-Ascend together with CANN, torch, and torch_npu as one compatibility set. For details, see the [vLLM-Ascend 0.23.0 installation guide](https://docs.vllm.ai/projects/ascend/en/v0.23.0/installation.html).
 
 For base environment setup, see the [Ascend PyTorch installation guide](https://gitcode.com/Ascend/pytorch). The examples in this document were verified on 8 * Ascend 910B3 64G.
 
@@ -197,7 +198,7 @@ After entering the container, run `source /usr/local/Ascend/ascend-toolkit/set_e
 
 ```shell
 # Create a new conda virtual environment (optional)
-conda create -n swift-npu python=3.11 -y
+conda create -n swift-npu python=3.12 -y
 conda activate swift-npu
 
 # Source the CANN environment before the following steps
@@ -212,8 +213,10 @@ git clone https://github.com/modelscope/ms-swift.git
 cd ms-swift
 pip install -e .
 
-# Install torch_npu
-pip install torch_npu==2.9.0 decorator
+# Install the matching PyTorch/TorchNPU runtime
+pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0
+pip install torch_npu==2.10.0.post4 decorator \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 # If you want to use deepspeed (to reduce memory usage, with some speed overhead)
 pip install deepspeed
 
@@ -221,8 +224,10 @@ pip install deepspeed
 pip install evalscope[opencompass]
 
 # If you need vllm-ascend for inference, install the following packages (for more versions, see the [vLLM-Ascend official website](https://docs.vllm.ai/projects/ascend/en/latest/installation.html))
-pip install vllm==0.18.0
-pip install vllm-ascend==0.18.0
+pip install vllm==0.23.0
+pip install vllm-ascend==0.23.0 \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 ```
 
 ### NPU Availability Check
@@ -700,9 +705,11 @@ ASCEND_RT_VISIBLE_DEVICES=0 swift deploy --model xxx/checkpoint-xxx-merged --max
 Install from PyPI:
 
 ```shell
-# Refer to the official vLLM-Ascend compatibility matrix; the following versions are verified in this document.
-pip install vllm==0.14.0
-pip install vllm-ascend==0.14.0rc1
+# Refer to the official vLLM-Ascend compatibility matrix; the following versions are recommended here.
+pip install vllm==0.23.0
+pip install vllm-ascend==0.23.0 \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 ```
 
 Original model:

--- a/swift/model/npu_patch/env.py
+++ b/swift/model/npu_patch/env.py
@@ -18,8 +18,7 @@ def _bootstrap_vllm_ascend_custom_opp_env() -> None:
     if spec is None or spec.origin is None:
         return
 
-    vendor_path = os.path.join(
-        os.path.dirname(spec.origin), '_cann_ops_custom', 'vendors', 'custom_transformer')
+    vendor_path = os.path.join(os.path.dirname(spec.origin), '_cann_ops_custom', 'vendors', 'custom_transformer')
     if not os.path.isdir(vendor_path):
         return
 

--- a/swift/model/npu_patch/env.py
+++ b/swift/model/npu_patch/env.py
@@ -1,6 +1,7 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 from __future__ import annotations
 
+import importlib.util
 import os
 
 from swift.utils.logger import get_logger
@@ -11,10 +12,28 @@ _DEFAULT_NPU_HCCL_CONNECT_TIMEOUT = '600'
 _TORCH_NPU_GETENV_MODULE = 'torch_npu.utils.patch_getenv'
 
 
+def _bootstrap_vllm_ascend_custom_opp_env() -> None:
+    """Expose wheel-bundled custom OPPs before torch-npu initializes CANN."""
+    spec = importlib.util.find_spec('vllm_ascend')
+    if spec is None or spec.origin is None:
+        return
+
+    vendor_path = os.path.join(
+        os.path.dirname(spec.origin), '_cann_ops_custom', 'vendors', 'custom_transformer')
+    if not os.path.isdir(vendor_path):
+        return
+
+    current_paths = [path for path in os.environ.get('ASCEND_CUSTOM_OPP_PATH', '').split(':') if path]
+    if vendor_path in current_paths:
+        return
+    os.environ['ASCEND_CUSTOM_OPP_PATH'] = ':'.join([vendor_path, *current_paths])
+    logger.info('Registered the vLLM-Ascend wheel custom OPP path before torch-npu initialization.')
+
+
 def _patch_torch_npu_getenv() -> None:
     try:
         from torch_npu.utils import patch_getenv
-    except Exception:
+    except Exception:  # noqa: BLE001
         return
 
     orig_environ_get = getattr(patch_getenv, '_orig_environ_get', None)
@@ -42,6 +61,7 @@ def _patch_torch_npu_getenv() -> None:
 
 
 def apply_patch() -> None:
+    _bootstrap_vllm_ascend_custom_opp_env()
     _patch_torch_npu_getenv()
 
     if 'HCCL_CONNECT_TIMEOUT' in os.environ:

--- a/swift/model/npu_patch/vllm_ascend_lora.py
+++ b/swift/model/npu_patch/vllm_ascend_lora.py
@@ -2,6 +2,8 @@
 """vLLM-Ascend LoRA compatibility patches."""
 from __future__ import annotations
 
+import inspect
+
 import torch
 
 from swift.utils.logger import get_logger
@@ -10,9 +12,34 @@ _QWEN3_5_QKVZ_SUFFIX = '.linear_attn.in_proj_qkvz'
 logger = get_logger()
 
 
+def _supports_vllm_ascend_fused_moe_lora() -> bool:
+    """Return whether the installed plugin provides an Ascend MoE LoRA wrapper."""
+    try:
+        from vllm_ascend.lora.fused_moe import AscendFusedMoEWithLoRA
+    except (ImportError, AttributeError):
+        return False
+    return AscendFusedMoEWithLoRA is not None
+
+
+def _supports_native_packed_lora_expansion(wrapper_cls) -> bool:
+    """Detect vLLM's generic packed-LoRA expansion by implementation capability."""
+    set_lora = getattr(wrapper_cls, 'set_lora', None)
+    if not callable(set_lora) or not callable(getattr(wrapper_cls, 'expand_packed_lora', None)):
+        return False
+    code = getattr(set_lora, '__code__', None)
+    if code is not None and 'expand_packed_lora' in code.co_names:
+        return True
+    try:
+        return 'expand_packed_lora' in inspect.getsource(set_lora)
+    except (OSError, TypeError):
+        return False
+
+
 def validate_vllm_ascend_lora_training(model, args) -> None:
     """Reject training configurations whose expert LoRA cannot run in vLLM-Ascend."""
     if args.tuner_type != 'lora' or not args.vllm_enable_lora or not model.model_info.is_moe_model:
+        return
+    if _supports_vllm_ascend_fused_moe_lora():
         return
 
     tuner = getattr(model, 'base_model', None)
@@ -31,6 +58,8 @@ def validate_vllm_ascend_lora_training(model, args) -> None:
 def validate_vllm_ascend_megatron_lora_training(models, args) -> None:
     """Reject Megatron expert LoRA that vLLM-Ascend cannot apply during rollout."""
     if args.tuner_type != 'lora' or not args.vllm_enable_lora or not args.model_info.is_moe_model:
+        return
+    if _supports_vllm_ascend_fused_moe_lora():
         return
 
     routed_expert_modules = sorted({
@@ -78,9 +107,11 @@ def _exclude_unsupported_fused_moe_lora_modules(
 
 def _patch_vllm_ascend_fused_moe_lora_modules() -> None:
     """Keep vLLM's CUDA-only FusedMoE LoRA wrapper out of the NPU path."""
+    if _supports_vllm_ascend_fused_moe_lora():
+        return
     try:
-        import vllm.lora.model_manager as model_manager
         import vllm.lora.utils as lora_utils
+        from vllm.lora import model_manager
     except ImportError:
         return
 
@@ -171,6 +202,8 @@ def patch_vllm_ascend_lora_runtime() -> None:
         return
 
     wrapper_cls = AscendMergedColumnParallelLinearWithLoRA
+    if _supports_native_packed_lora_expansion(wrapper_cls):
+        return
     if getattr(wrapper_cls, '_swift_qwen3_5_qkvz_lora_patched', False):
         return
     origin_set_lora = wrapper_cls.set_lora

--- a/swift/model/npu_patch/vllm_ascend_lora.py
+++ b/swift/model/npu_patch/vllm_ascend_lora.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import inspect
-
 import torch
 
 from swift.utils.logger import get_logger


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information

Adapt the NPU runtime integration to vLLM-Ascend 0.23.0.

## Changes

- Register the custom OPP path bundled with the `vllm-ascend` wheel before `torch_npu` initializes CANN.
- Detect and use the native vLLM-Ascend fused-MoE LoRA implementation when available.
- Skip legacy packed-LoRA expansion patches when the installed vLLM version already supports them natively.
- Update Chinese and English NPU documentation with the vLLM-Ascend 0.23.0 installation instructions:
  - Python 3.12
  - PyTorch 2.10.0 / TorchNPU 2.10.0.post4
  - vLLM 0.23.0 / vLLM-Ascend 0.23.0
  - Required Ascend PyPI mirror indexes

## Compatibility

Please install CANN, PyTorch, TorchNPU, and vLLM-Ascend according to the official compatibility matrix.

## Experiment results

- [ ] NPU environment initialization
- [ ] vLLM-Ascend inference
- [ ] MoE LoRA rollout/training