### PR TITLE
fix：(megatron 0.16.1) support PackedSeqParams without total_tokens

### DIFF
--- a/swift/megatron/utils/utils.py
+++ b/swift/megatron/utils/utils.py
@@ -248,8 +248,9 @@ def get_packed_seq_params(args, position_ids: torch.Tensor) -> PackedSeqParams:
         max_seqlen_q=max_seqlen_q,
         max_seqlen_kv=max_seqlen_kv,
         qkv_format='thd',
-        total_tokens=position_ids.numel(),
     )
+    if hasattr(packed, 'total_tokens'):
+        packed.total_tokens = position_ids.numel()
     if hasattr(packed, 'cp_partition_mode'):
         packed.cp_partition_mode = args.cp_partition_mode
 


### PR DESCRIPTION
Make PackedSeqParams construction compatible with Megatron-Core versions that do not expose the total_tokens field by assigning it only when supported. On Ascend A3 with Megatron-Core 0.16.1, the original constructor reproduced the unexpected-keyword error, while the patched packing path succeeded with cu_seqlens=[0, 3, 5] and max_seqlen=3; both example scripts remain unchanged and pass shell syntax validation.
