### PR TITLE
fix(metrics): count empty NLG predictions in score averages

### DIFF
--- a/swift/metrics/nlg.py
+++ b/swift/metrics/nlg.py
@@ -18,7 +18,11 @@ def compute_rouge_bleu(preds: List[str], labels: List[str]):
     for pred, label in zip(preds, labels):
         hypothesis = [w.strip(' ') for w in jieba.cut(pred) if w.strip(' ')]
         reference = [w.strip(' ') for w in jieba.cut(label) if w.strip(' ')]
-        if not hypothesis or not reference:
+        if not reference:
+            continue
+        if not hypothesis:
+            for metric in score_dict.values():
+                metric.update(0.)
             continue
         rouge = Rouge()
         scores = rouge.get_scores(' '.join(hypothesis), ' '.join(reference))[0]

--- a/tests/utils/test_nlg_metrics.py
+++ b/tests/utils/test_nlg_metrics.py
@@ -1,0 +1,35 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from swift.metrics.nlg import compute_rouge_bleu
+
+
+# Keep aggregation tests independent from the optional jieba dependency.
+@patch.dict('sys.modules', {'jieba': SimpleNamespace(cut=str.split)})
+class TestNlgMetrics(unittest.TestCase):
+
+    def test_exact_match_scores_full_points(self):
+        scores = compute_rouge_bleu(['the cat is here'], ['the cat is here'])
+
+        self.assertEqual(scores, {
+            'rouge-1': 100.0,
+            'rouge-2': 100.0,
+            'rouge-l': 100.0,
+            'bleu-4': 100.0,
+        })
+
+    def test_empty_prediction_counts_towards_mean(self):
+        exact_match = 'the cat is here'
+        scores = compute_rouge_bleu([exact_match, ''], [exact_match, 'a different reference'])
+
+        self.assertEqual(scores, {
+            'rouge-1': 50.0,
+            'rouge-2': 50.0,
+            'rouge-l': 50.0,
+            'bleu-4': 50.0,
+        })
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

`compute_rouge_bleu` currently skips a sample whenever either its prediction or reference is empty. When the reference is non-empty but the model prediction is empty, this removes the failed generation from the metric denominator and inflates the aggregate ROUGE and BLEU scores.

This PR:

- Records zero for all NLG metrics when the prediction is empty and the reference is non-empty.
- Preserves the existing behavior of skipping samples with empty references.
- Adds regression coverage for both exact matches and mixed exact/empty prediction batches.
- Keeps the aggregation tests independent from the optional `jieba` dependency.

## Experiment results

For a two-sample batch containing one exact match and one empty prediction:

- Before: ROUGE-1/2/L and BLEU-4 were all `100.0`.
- After: all four metrics are `50.0`.
- A standalone exact match remains `100.0`.

Validation:

- `python -m pytest -q tests/utils/test_nlg_metrics.py` — 2 passed
- `pre-commit run --files swift/metrics/nlg.py tests/utils/test_nlg_metrics.py` — all hooks passed
- Repository test runner — SUCCESS
