### PR TITLE
fix: preserve incomplete flash checkpoints

### DIFF
--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -699,7 +699,6 @@ class SwiftMixin:
         if not success:
             logger.info(f'Skip saving the checkpoint of step {self.state.global_step} '
                         'because the latest checkpoint is not finished.')
-            shutil.rmtree(output_dir, ignore_errors=True)
 
         if self.args.push_to_hub:
             self._push_from_checkpoint(output_dir)


### PR DESCRIPTION
 ## Problem

  When Flash Checkpoint is enabled, Swift writes checkpoint metadata such as
  `trainer_state.json` before calling DLRover to persist the checkpoint.

  If DLRover returns `success=False`, it may only indicate that asynchronous
  persistence has not completed yet. However, Swift currently removes the entire
  checkpoint directory in this case, deleting `trainer_state.json` and other
  already-written files.

  As a result, checkpoint recovery may fail even though the checkpoint is still
  being persisted asynchronously.

  ## Fix

  Stop recursively deleting the checkpoint directory when DLRover reports that
  the latest checkpoint is not finished.

  The existing `dlrover_latest.txt` mechanism remains responsible for identifying
  the latest complete checkpoint. Incomplete checkpoint directories are preserved
  but are not selected during resume.

  ## Validation

  - `python -m compileall -q swift/trainers/mixin.py`
  - `git diff --check`