### PR TITLE
fix(train): fail fast on incompatible DLRover flash checkpoint APIs

### DIFF
--- a/swift/pipelines/train/sft.py
+++ b/swift/pipelines/train/sft.py
@@ -38,7 +38,7 @@ class SwiftSft(SwiftPipeline, TunerMixin):
                 from dlrover.trainer.torch.flash_checkpoint.hf_trainer import HfFlashCheckpointer
             except ImportError:
                 raise ValueError('Please install DLRover to use Flash Checkpoint: `pip install dlrover[k8s,torch]`.')
-            from swift.trainers.mixin import _validate_dlrover_flash_checkpoint_api
+            from swift.trainers.utils import _validate_dlrover_flash_checkpoint_api
             _validate_dlrover_flash_checkpoint_api(HfFlashCheckpointer, CheckpointEngine)
 
     def _prepare_generation_config(self):

--- a/swift/pipelines/train/sft.py
+++ b/swift/pipelines/train/sft.py
@@ -26,17 +26,20 @@ class SwiftSft(SwiftPipeline, TunerMixin):
     def __init__(self, args: Optional[Union[List[str], SftArguments]] = None) -> None:
         super().__init__(args)
         self.train_msg = {}
+        self._prepare_flash_ckpt()
         self._prepare_model_tokenizer()
         self._prepare_template()
-        self._prepare_flash_ckpt()
 
     @RayHelper.function(group='default')
     def _prepare_flash_ckpt(self):
         if self.args.use_flash_ckpt:
             try:
-                import dlrover.trainer.torch.flash_checkpoint.hf_trainer
+                from dlrover.trainer.torch.flash_checkpoint.engine import CheckpointEngine
+                from dlrover.trainer.torch.flash_checkpoint.hf_trainer import HfFlashCheckpointer
             except ImportError:
-                raise ValueError('Please install dlrover to use flash ckpt `pip install dlrover[k8s,torch]')
+                raise ValueError('Please install DLRover to use Flash Checkpoint: `pip install dlrover[k8s,torch]`.')
+            from swift.trainers.mixin import _validate_dlrover_flash_checkpoint_api
+            _validate_dlrover_flash_checkpoint_api(HfFlashCheckpointer, CheckpointEngine)
 
     def _prepare_generation_config(self):
         args = self.args

--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -64,24 +64,6 @@ logger = get_logger()
 transformers_5 = version.parse(transformers.__version__) >= version.parse('5.0.0')
 
 
-def _validate_dlrover_flash_checkpoint_api(checkpointer_cls, checkpoint_engine_cls):
-    required_parameters = [
-        (checkpointer_cls.save_checkpoint_to_storage, 'blocking'),
-        (checkpoint_engine_cls.wait_latest_checkpoint, 'max_steps'),
-    ]
-    missing_parameters = []
-    for method, parameter_name in required_parameters:
-        parameters = inspect.signature(method).parameters
-        accepts_kwargs = any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
-        if parameter_name not in parameters and not accepts_kwargs:
-            missing_parameters.append(parameter_name)
-    if missing_parameters:
-        missing = ', '.join(missing_parameters)
-        raise ValueError('The installed DLRover Flash Checkpoint API is incompatible with ms-swift. '
-                         f'Missing method parameters: {missing}. Install the latest DLRover source with '
-                         '`pip install git+https://github.com/intelligent-machine-learning/dlrover.git`.')
-
-
 class SwiftMixin:
     FLASH_CKPT_WAIT_TIMEOUT = 1800
 

--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -64,6 +64,24 @@ logger = get_logger()
 transformers_5 = version.parse(transformers.__version__) >= version.parse('5.0.0')
 
 
+def _validate_dlrover_flash_checkpoint_api(checkpointer_cls, checkpoint_engine_cls):
+    required_parameters = [
+        (checkpointer_cls.save_checkpoint_to_storage, 'blocking'),
+        (checkpoint_engine_cls.wait_latest_checkpoint, 'max_steps'),
+    ]
+    missing_parameters = []
+    for method, parameter_name in required_parameters:
+        parameters = inspect.signature(method).parameters
+        accepts_kwargs = any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
+        if parameter_name not in parameters and not accepts_kwargs:
+            missing_parameters.append(parameter_name)
+    if missing_parameters:
+        missing = ', '.join(missing_parameters)
+        raise ValueError('The installed DLRover Flash Checkpoint API is incompatible with ms-swift. '
+                         f'Missing method parameters: {missing}. Install the latest DLRover source with '
+                         '`pip install git+https://github.com/intelligent-machine-learning/dlrover.git`.')
+
+
 class SwiftMixin:
     FLASH_CKPT_WAIT_TIMEOUT = 1800
 

--- a/swift/trainers/utils.py
+++ b/swift/trainers/utils.py
@@ -25,6 +25,24 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 
+def _validate_dlrover_flash_checkpoint_api(checkpointer_cls, checkpoint_engine_cls):
+    required_parameters = [
+        (checkpointer_cls.save_checkpoint_to_storage, 'blocking'),
+        (checkpoint_engine_cls.wait_latest_checkpoint, 'max_steps'),
+    ]
+    missing_parameters = []
+    for method, parameter_name in required_parameters:
+        parameters = inspect.signature(method).parameters
+        accepts_kwargs = any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
+        if parameter_name not in parameters and not accepts_kwargs:
+            missing_parameters.append(parameter_name)
+    if missing_parameters:
+        missing = ', '.join(missing_parameters)
+        raise ValueError('The installed DLRover Flash Checkpoint API is incompatible with ms-swift. '
+                         f'Missing method parameters: {missing}. Install the latest DLRover source with '
+                         '`pip install git+https://github.com/intelligent-machine-learning/dlrover.git`.')
+
+
 def _get_deepspeed_elastic_world_size():
     if dist.is_available() and dist.is_initialized():
         return dist.get_world_size()

--- a/tests/utils/test_flash_checkpoint_compat.py
+++ b/tests/utils/test_flash_checkpoint_compat.py
@@ -1,7 +1,7 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import unittest
 
-from swift.trainers.mixin import _validate_dlrover_flash_checkpoint_api
+from swift.trainers.utils import _validate_dlrover_flash_checkpoint_api
 
 
 class DLRover061Engine:

--- a/tests/utils/test_flash_checkpoint_compat.py
+++ b/tests/utils/test_flash_checkpoint_compat.py
@@ -1,0 +1,44 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import unittest
+
+from swift.trainers.mixin import _validate_dlrover_flash_checkpoint_api
+
+
+class DLRover061Engine:
+
+    def wait_latest_checkpoint(self, timeout=None):
+        pass
+
+
+class DLRoverMasterEngine:
+
+    def wait_latest_checkpoint(self, timeout=None, max_steps=None):
+        pass
+
+
+class DLRover061Checkpointer:
+
+    def save_checkpoint_to_storage(self, step):
+        pass
+
+
+class DLRoverMasterCheckpointer:
+
+    def save_checkpoint_to_storage(self, step, blocking=False):
+        pass
+
+
+class TestFlashCheckpointCompatibility(unittest.TestCase):
+
+    def test_dlrover_061_is_rejected_before_training(self):
+        with self.assertRaisesRegex(ValueError, 'blocking.*max_steps') as error:
+            _validate_dlrover_flash_checkpoint_api(DLRover061Checkpointer, DLRover061Engine)
+        install_command = 'pip install git+https://github.com/intelligent-machine-learning/dlrover.git'
+        self.assertIn(install_command, str(error.exception))
+
+    def test_new_dlrover_api_is_accepted(self):
+        _validate_dlrover_flash_checkpoint_api(DLRoverMasterCheckpointer, DLRoverMasterEngine)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate the DLRover Flash Checkpoint API before loading the model
- fail fast with an actionable source-install command when `blocking` or `max_steps` is unavailable
- add regression tests for the released DLRover 0.6.1 API and the current source API

## Motivation

The latest published DLRover release, 0.6.1, does not accept the `blocking` and `max_steps` arguments used by ms-swift. The incompatibility is currently discovered only while saving a checkpoint or shutting down training.

Silently dropping these arguments would be unsafe because `blocking=True` prevents the final checkpoint from being skipped while a previous asynchronous save holds the shared-memory lock. This change keeps the current checkpoint semantics and reports the incompatible dependency before model loading.

## Validation

- focused unit tests: 2 passed
- project test runner: 2/2 passed
- all relevant pre-commit hooks passed
- `git diff --check` passed

Related to #9912.
