### PR TITLE
fix bug: serialize Qwen tool argument JSON literals

### DIFF
--- a/swift/agent_template/qwen3_coder.py
+++ b/swift/agent_template/qwen3_coder.py
@@ -141,8 +141,8 @@ class Qwen3CoderAgentTemplate(HermesAgentTemplate):
                 for args_name, args_value in tool_call['arguments'].items():
                     result_parts.append(f'<parameter={args_name}>\n')
                     # Handle different types of parameter values
-                    if isinstance(args_value, (dict, list)):
-                        # For dictionaries or lists, use json formatting
+                    if isinstance(args_value, (dict, list, bool)) or args_value is None:
+                        # JSON containers and literals must preserve JSON spelling.
                         args_value = json.dumps(args_value, ensure_ascii=False)
                     else:
                         # For other types, convert to strings


### PR DESCRIPTION
Qwen's native chat template serializes non-string tool arguments as JSON. However, the Swift formatter only applied JSON serialization to dictionaries and lists, causing booleans and null values to use Python literals.

For example:

```
{"enabled": true, "optional": null}
```

Previously rendered as:

```
<parameter=enabled>
True
</parameter>
<parameter=optional>
None
</parameter>
```

This PR renders them using the expected JSON literals:

```
<parameter=enabled>
true
</parameter>
<parameter=optional>
null
</parameter>
```

The change only extends the existing JSON serialization path to bool and None. Other argument types retain their previous behavior.