### PR TITLE
fix(utils): scope download cache by URL

### DIFF
--- a/swift/utils/hub_utils.py
+++ b/swift/utils/hub_utils.py
@@ -1,4 +1,5 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
+import hashlib
 import importlib.util
 import os
 import requests
@@ -237,6 +238,8 @@ def patch_kernels() -> bool:
 def download_file(url: str) -> str:
     url = url.rstrip('/')
     file_name = url.rsplit('/', 1)[-1]
+    file_stem, file_suffix = os.path.splitext(file_name)
+    file_name = f'{file_stem}-{hashlib.sha256(url.encode("utf-8")).hexdigest()}{file_suffix}'
     cache_dir = os.path.join(get_cache_dir(), 'files')
     os.makedirs(cache_dir, exist_ok=True)
     file_path = os.path.join(cache_dir, file_name)

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -54,6 +54,24 @@ class TestHubUtils(unittest.TestCase):
             self.assertEqual(f.read(), b''.join(chunks))
         response.__exit__.assert_called_once()
 
+    @patch('swift.utils.hub_utils.requests.get')
+    @patch('swift.utils.hub_utils.get_cache_dir')
+    def test_download_file_uses_a_distinct_cache_path_for_each_url(self, mock_cache_dir, mock_get):
+        mock_cache_dir.return_value = self.tmp_dir
+        mock_get.side_effect = [self._mock_response([b'first']), self._mock_response([b'second'])]
+
+        first_path = download_file('https://first.example.com/releases/artifact.bin')
+        second_path = download_file('https://second.example.com/releases/artifact.bin')
+        cached_first_path = download_file('https://first.example.com/releases/artifact.bin')
+
+        self.assertNotEqual(first_path, second_path)
+        self.assertEqual(cached_first_path, first_path)
+        with open(first_path, 'rb') as f:
+            self.assertEqual(f.read(), b'first')
+        with open(second_path, 'rb') as f:
+            self.assertEqual(f.read(), b'second')
+        self.assertEqual(mock_get.call_count, 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Other

# PR information

`download_file` used only the URL basename for its cache key. As a result, different resources such as `https://first.example.com/releases/artifact.bin` and `https://second.example.com/releases/artifact.bin` could return the first cached file.

This change includes a hash of the full URL in the cache filename while preserving the original extension. It adds a regression test that verifies distinct same-named URLs cache separately and a repeated request for the same URL remains cached.

## Experiment results

- Reproduced the collision against the current implementation with two different same-named URLs, then verified the fixed production function returns separate paths and bytes while reusing the same URL's cache entry.
- `pre-commit run --files swift/utils/hub_utils.py tests/utils/test_hub_utils.py`
- `python -m py_compile swift/utils/hub_utils.py tests/utils/test_hub_utils.py`
- `git diff --check`
