### PR TITLE
fix(dataset): honor explicit hub prefixes

### DIFF
--- a/swift/dataset/loader.py
+++ b/swift/dataset/loader.py
@@ -325,7 +325,7 @@ def load_dataset(
         use_hf_default = True if use_hf_hub() else False
     for dataset in datasets:
         dataset_syntax = DatasetSyntax.parse(dataset)
-        use_hf = dataset_syntax.use_hf or use_hf_default
+        use_hf = dataset_syntax.use_hf if dataset_syntax.use_hf is not None else use_hf_default
         # compat dataset_name
         if dataset_syntax.dataset in DATASET_MAPPING:
             dataset_meta = DATASET_MAPPING[dataset_syntax.dataset]

--- a/tests/general/test_dataset_source.py
+++ b/tests/general/test_dataset_source.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import patch
+
+from datasets import Dataset as HfDataset
+
+from swift.dataset import DatasetMeta, DatasetSyntax, load_dataset
+from swift.dataset.loader import DatasetLoader
+
+
+class TestDatasetSourceSelection(unittest.TestCase):
+
+    def test_dataset_syntax_parses_explicit_hub_prefixes(self):
+        self.assertIs(DatasetSyntax.parse('hf::example-org/dataset').use_hf, True)
+        self.assertIs(DatasetSyntax.parse('ms::example-org/dataset').use_hf, False)
+
+    def test_explicit_ms_source_overrides_global_hf_default(self):
+        observed = []
+
+        def fake_load_repo_dataset(self, dataset_id, subset, *, use_hf=None, revision=None):
+            observed.append((dataset_id, use_hf))
+            return HfDataset.from_dict({
+                'messages': [[{
+                    'role': 'user',
+                    'content': 'hello',
+                }, {
+                    'role': 'assistant',
+                    'content': 'world',
+                }]]
+            })
+
+        with patch.object(DatasetSyntax, 'get_dataset_meta', return_value=DatasetMeta()), \
+                patch.object(DatasetLoader, '_load_repo_dataset', new=fake_load_repo_dataset):
+            train_dataset, val_dataset = load_dataset('ms::example-org/private-dataset', use_hf=True)
+
+        self.assertEqual(observed, [('example-org/private-dataset', False)])
+        self.assertEqual(len(train_dataset), 1)
+        self.assertIsNone(val_dataset)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/general/test_dataset_source.py
+++ b/tests/general/test_dataset_source.py
@@ -1,7 +1,6 @@
 import unittest
-from unittest.mock import patch
-
 from datasets import Dataset as HfDataset
+from unittest.mock import patch
 
 from swift.dataset import DatasetMeta, DatasetSyntax, load_dataset
 from swift.dataset.loader import DatasetLoader
@@ -18,15 +17,14 @@ class TestDatasetSourceSelection(unittest.TestCase):
 
         def fake_load_repo_dataset(self, dataset_id, subset, *, use_hf=None, revision=None):
             observed.append((dataset_id, use_hf))
-            return HfDataset.from_dict({
-                'messages': [[{
+            return HfDataset.from_dict(
+                {'messages': [[{
                     'role': 'user',
                     'content': 'hello',
                 }, {
                     'role': 'assistant',
                     'content': 'world',
-                }]]
-            })
+                }]]})
 
         with patch.object(DatasetSyntax, 'get_dataset_meta', return_value=DatasetMeta()), \
                 patch.object(DatasetLoader, '_load_repo_dataset', new=fake_load_repo_dataset):


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Problem

When a caller explicitly selects ModelScope with `ms::dataset-id`, `load_dataset(..., use_hf=True)` still routes the dataset through Hugging Face.

## Root cause

`DatasetSyntax.parse()` represents the explicit ModelScope selection as `False`, but the loader used `dataset_syntax.use_hf or use_hf_default`. Python therefore treated that explicit `False` value as absent and substituted the global default.

## Changes

- Preserve an explicit hub prefix whenever it is present, and use the global default only when no prefix was supplied.
- Add a local regression test that exercises `load_dataset()` with the remote fetch mocked and verifies both prefix parsing and the ModelScope route.

## Experiment results

Baseline RED: the regression test observed `True` for `ms::example-org/private-dataset` when `use_hf=True`; it expected `False`.

GREEN:

- `python -m unittest discover -s tests/general -p 'test_dataset_source.py' -v` — 2 passed
- `python -m py_compile swift/dataset/loader.py tests/general/test_dataset_source.py`
- `pre-commit run --all-files`

## AI assistance

AI assistance was used for investigation and drafting. The production change and the tests above were executed against the current repository checkout.
