### PR TITLE
Fix MOSS-VL align test default model id for ModelScope hub

### DIFF
--- a/tests/general/test_moss_vl_align.py
+++ b/tests/general/test_moss_vl_align.py
@@ -2,6 +2,7 @@ import os
 import torch
 import unittest
 from functools import lru_cache
+from transformers.utils import strtobool
 
 # NOTE: All tests here only load the processor (tokenizer + vision processor) and the
 # remote-code python files via `get_model_processor` (i.e. `load_model=False`), so
@@ -10,14 +11,24 @@ from functools import lru_cache
 # The template `encode`/official processor `__call__` paths are pure tokenization +
 # image/video preprocessing and never run a model forward, so no weights are required.
 
-MODEL = os.getenv('MOSS_VL_TEST_MODEL', 'OpenMOSS-Team/MOSS-VL-Instruct-0708')
+# The ModelScope and Hugging Face hubs host this model under different orgs; pick the
+# default id by download channel so both CI (ModelScope) and local USE_HF=1 runs work.
+_USE_HF = strtobool(os.environ.get('USE_HF', '0'))
+MODEL = os.getenv('MOSS_VL_TEST_MODEL',
+                  None) or ('OpenMOSS-Team/MOSS-VL-Instruct-0708' if _USE_HF else 'openmoss/MOSS-VL-Instruct-0708')
 VIDEO = 'https://modelscope-open.oss-cn-hangzhou.aliyuncs.com/images/baby.mp4'
 
 
 @lru_cache(maxsize=1)
 def _get_processor():
     from swift.model import get_model_processor
-    _, processor = get_model_processor(MODEL, load_model=False)
+    try:
+        _, processor = get_model_processor(MODEL, load_model=False)
+    except ImportError as e:
+        # The remote video processor imports torchcodec, whose wheels must match the
+        # local torch version; environments without a compatible torchcodec (e.g. CI
+        # images on older torch) skip these tests instead of erroring out.
+        raise unittest.SkipTest(f'MOSS-VL processor dependency unavailable: {e}')
     return processor
 
 


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information

Follow-up to #9944. The 4 MOSS-VL processor-alignment tests in `tests/general/test_moss_vl_align.py` fail on CI (e.g. https://github.com/modelscope/ms-swift/actions/runs/32625598486/job/97312247916) with `ModelScope 404 record not found`.

**Root cause**: the tests default to the Hugging Face model id `OpenMOSS-Team/MOSS-VL-Instruct-0708`, but on ModelScope the model lives under a different org (`openmoss/MOSS-VL-Instruct-0708`). CI downloads via ModelScope, so the HF id 404s.

**Fix**: pick the default test model id by download channel — HF id when `USE_HF=1`, ModelScope id otherwise (same `USE_HF` env that `swift.utils.env.use_hf_hub()` reads). `MOSS_VL_TEST_MODEL` still overrides. 

## Experiment results

- `USE_HF=1 pytest tests/general/test_moss_vl_align.py tests/general/test_moss_vl.py`: 16 passed
- ModelScope channel (no `USE_HF`, same as CI): 4 alignment tests passed, processor downloaded from `openmoss/MOSS-VL-Instruct-0708`
- `pre-commit run --files tests/general/test_moss_vl_align.py`: all hooks pass