### PR TITLE
feat(fsdp2): load model on meta device for non-rank0 ranks (0 CPU RAM per worker)

### DIFF
--- a/swift/model/register.py
+++ b/swift/model/register.py
@@ -651,9 +651,8 @@ def get_model_processor(
         **kwargs)
     if load_model and _fsdp2_use_meta_loading() and int(os.environ.get('RANK', '0')) != 0:
         from accelerate import init_empty_weights
-        logger.info(
-            'FSDP2 non-rank0: loading the model on the meta device (0 CPU RAM), '
-            'weights will be synced from rank0 by accelerate during prepare.')
+        logger.info('FSDP2 non-rank0: loading the model on the meta device (0 CPU RAM), '
+                    'weights will be synced from rank0 by accelerate during prepare.')
         # Mask ACCELERATE_USE_FSDP during loading: transformers' FSDP non-rank0 branch
         # (modeling_utils._move_missing_keys) would otherwise materialize meta params
         # as CPU zeros (full model in host RAM per rank). device_map was already

--- a/swift/model/register.py
+++ b/swift/model/register.py
@@ -28,6 +28,22 @@ logger = get_logger()
 transformers_5 = version.parse(transformers.__version__) >= version.parse('5.0.0.dev')
 
 
+def _fsdp2_use_meta_loading() -> bool:
+    """Whether non-rank0 ranks should load the model on the meta device under FSDP2 (0 CPU RAM).
+
+    The weights are later synced from rank0 by accelerate's ``cpu_ram_efficient_loading``
+    path during ``prepare``. Can be disabled with env ``SWIFT_FSDP2_META_LOADING=0``.
+    """
+    if os.environ.get('SWIFT_FSDP2_META_LOADING', '1') == '0':
+        return False
+    if os.environ.get('FSDP_VERSION') != '2':  # set by SftArguments._init_fsdp
+        return False
+    try:
+        return int(os.environ.get('WORLD_SIZE', '1')) > 1
+    except ValueError:
+        return False
+
+
 def register_model(model_meta: ModelMeta, *, exist_ok: bool = False) -> None:
     """
     model_type: The unique ID for the model type. Models with the same model_type share
@@ -633,6 +649,22 @@ def get_model_processor(
         new_special_tokens=new_special_tokens,
         model_kwargs=model_kwargs,
         **kwargs)
+    if load_model and _fsdp2_use_meta_loading() and int(os.environ.get('RANK', '0')) != 0:
+        from accelerate import init_empty_weights
+        logger.info(
+            'FSDP2 non-rank0: loading the model on the meta device (0 CPU RAM), '
+            'weights will be synced from rank0 by accelerate during prepare.')
+        # Mask ACCELERATE_USE_FSDP during loading: transformers' FSDP non-rank0 branch
+        # (modeling_utils._move_missing_keys) would otherwise materialize meta params
+        # as CPU zeros (full model in host RAM per rank). device_map was already
+        # resolved earlier in this function, so masking here is safe.
+        use_fsdp = os.environ.pop('ACCELERATE_USE_FSDP', None)
+        try:
+            with init_empty_weights():
+                return loader.load()
+        finally:
+            if use_fsdp is not None:
+                os.environ['ACCELERATE_USE_FSDP'] = use_fsdp
     return loader.load()
 
 


### PR DESCRIPTION
## Problem

With `--fsdp fsdp2`, transformers 5.x has no rank0-only *zero-memory* loading path. In `from_pretrained`, the FSDP non-rank0 branch (`transformers/modeling_utils.py`, `_move_missing_keys`) materializes every parameter with `torch.zeros_like(param, device="cpu")` — i.e. **each rank allocates the full model in CPU RAM** (a 35B bf16 model ≈ 67G per rank, ~136G peak including prepare-time copies). On hosts that budget CPU RAM per device (e.g. 125G per accelerator), `N x 136G` inevitably OOM-kills workers during loading/prepare, regardless of world size.

Measured on 16x Ascend 910B (2T host RAM, Qwen3.5-35B-A3B): 16 workers x ~136G anon RSS ≈ 2.2T → kernel global OOM kill during prepare (dmesg evidence captured).

## Solution

Only rank 0 needs real weights; accelerate's `cpu_ram_efficient_loading` path (`accelerate/utils/fsdp_utils.py`: *"If `cpu_ram_efficient_loading` is enabled, only rank 0 loads the weights"*) already distributes rank-0 weights to all ranks during `prepare`. This PR makes non-rank0 ranks load on the **meta device** and keeps the model there until accelerate takes over:

- module-level helper `_fsdp2_use_meta_loading()` — enabled when FSDP2 + world_size>1, disable via `SWIFT_FSDP2_META_LOADING=0`
- in `get_model_processor()`: non-rank0 loads under `init_empty_weights()`, with `ACCELERATE_USE_FSDP` **temporarily masked** during the loading window

Two details that matter:

1. **Masking `ACCELERATE_USE_FSDP` inside the loading window is essential**: transformers' non-rank0 branch would otherwise turn meta params back into CPU zeros (full model in host RAM per rank), silently defeating the optimization. `device_map` is resolved earlier in the same function, so masking at this point is safe.
2. **Do NOT add a custom weight-sync hook after `prepare`**: we prototyped a per-parameter `broadcast(p.to_local(), src=0)` hook on `Trainer._prepare_for_training` and it deadlocks HCCL collective ordering (`HcclAllGather` dispatch timeout), because accelerate's own sync already runs inside `prepare`. The official path handles everything — this PR deliberately contains no sync code.

## Verification (16x Ascend 910B 64G, ms-swift 4.4.2, Qwen3.5-35B-A3B LoRA)

| Metric | Before (full load per rank) | After (meta loading) |
|---|---|---|
| Host CPU RAM peak (loading+prepare) | ~2.2T for 16 ranks → kernel OOM kill | **187G total, independent of world size** |
| Per-worker host RAM (non-rank0) | ~136G | **~0 (meta device)** |
| NPU HBM per card | 28.3G @ 8 cards | **19.5G (DPO) / 20.9G (KTO) @ 16 cards** |
| Correctness (DPO) | loss start 0.6914 (=ln2); logps/chosen -128.8 | **loss start 0.6914; logps/chosen -129.0** (matches full-load baseline) |

DPO and KTO smoke tests both pass end-to-end at full 16-card world size.

Requires #9980 (`ACCELERATE_USE_FSDP` fix) as prerequisite — without it, `device_map='npu:{rank}'` forces full per-device NPU loading before this code path is even reached.
