### PR TITLE
[bugfix] fix typo and stray characters in base argument docstrings

### DIFF
--- a/swift/arguments/base_args/data_args.py
+++ b/swift/arguments/base_args/data_args.py
@@ -60,7 +60,7 @@ class DataArguments:
             sample and continues. Typically used for debugging. Defaults to False.
         remove_unused_columns (bool): Whether to remove columns not used by the model. If `False`, extra columns are
             passed to the trainer's `compute_loss` function, which is useful for custom loss calculations.
-            Defaults to True. Note: The default is `False` for GPRO.
+            Defaults to True. Note: The default is `False` for GRPO.
         disable_auto_column_mapping (bool): By default, column names in the dataset are automatically mapped.
             This parameter disables that behavior (the `columns` parameter remains effective), defaulting to `False`.
         model_name (Optional[List[str]]): For self-cognition tasks, replaces the `{{NAME}}` placeholder in the

--- a/swift/arguments/base_args/model_args.py
+++ b/swift/arguments/base_args/model_args.py
@@ -118,7 +118,7 @@ class ModelArguments:
                     self.max_memory[k + local_rank] = self.max_memory.pop(k)
 
     def _init_torch_dtype(self) -> None:
-        """"If torch_dtype is None, find a proper dtype by the config.json/GPU"""
+        """If torch_dtype is None, find a proper dtype by the config.json/GPU"""
         from ..sft_args import SftArguments
 
         self.torch_dtype: Optional[torch.dtype] = HfConfigFactory.to_torch_dtype(self.torch_dtype)
@@ -218,7 +218,7 @@ class ModelArguments:
 
     def __post_init__(self):
         if self.model is None:
-            raise ValueError(f'Please set --model <model_id_or_path>`, model: {self.model}')
+            raise ValueError(f'Please set --model <model_id_or_path>, model: {self.model}')
         self._init_new_special_tokens()
         self.model_suffix = get_model_name(self.model)
         self._init_device_map()


### PR DESCRIPTION
### Description

Three small correctness fixes in `swift/arguments/base_args/`:

1. `data_args.py`: `remove_unused_columns` docstring says `GPRO`, should be `GRPO`.
   This is the only occurrence of `GPRO` in the repository.
2. `model_args.py`: `_init_torch_dtype` docstring starts with four quotes (`""""`),
   so the leading `"` becomes part of the docstring body.
   `ast.get_docstring()` returns `'"If torch_dtype is None, ...'` before the fix.
3. `model_args.py`: the "model is None" `ValueError` message contains a stray
   backtick after `<model_id_or_path>`, which is shown to end users.

### Test

Docstring / message text only, no behavior change.

- `python -m py_compile swift/arguments/base_args/{data_args,model_args}.py` passes
- `ast.get_docstring(_init_torch_dtype)` now returns
  `'If torch_dtype is None, find a proper dtype by the config.json/GPU'`
- `grep -rn "GPRO"` returns 0 matches
- `ruff` / `yapf` report no new findings (identical count to the unmodified baseline)

AI assistance was used to locate these issues; I reviewed every changed line.