### PR TITLE
fix: materialize state_dict for SentenceTransformer full-parameter save

### DIFF
--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -385,6 +385,13 @@ class SwiftMixin:
                 else:
                     self.model.save_pretrained(output_dir, safe_serialization=safe_serialization, **save_kwargs)
             else:
+                # `Trainer.save_model` calls `self._save(output_dir)` without a state_dict
+                # on the plain/DDP path (transformers only passes one for FSDP/DeepSpeed).
+                # The None fill-in above is skipped for SentenceTransformer models (they are
+                # in `supported_names`), so materialize it here before the ST save branch
+                # consumes it via `state_dict.items()`.
+                if state_dict is None:
+                    state_dict = self.model.state_dict()
 
                 @contextmanager
                 def save_context():


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Trainer.save_model calls _save(output_dir) without a state_dict on the plain/DDP path (transformers only passes an explicit state_dict for the FSDP/DeepSpeed branches). In _save_model, the `if state_dict is None` fill-in is gated behind the `not isinstance(..., supported_classes) and class_name not in supported_names` check, and 'SentenceTransformer' is in supported_names, so it is skipped for ST models. The ST save branch then does state_dict.items() on None and raises:

    AttributeError: 'NoneType' object has no attribute 'items'

This makes full-parameter finetuning of any SentenceTransformer-loaded model (e.g. gte-Qwen2, embeddinggemma) uncheckpointable on single-GPU / DDP. Fix by materializing state_dict from the model inside the ST branch, mirroring the existing None fill-in above. LoRA is unaffected (adapter save path); FSDP/DeepSpeed already pass a state_dict.
