### PR TITLE
fix(template): handle MiniCPM-o 4.5 video inputs for vLLM deployment

### DIFF
--- a/swift/template/templates/minicpm.py
+++ b/swift/template/templates/minicpm.py
@@ -15,7 +15,7 @@ from ..constant import LLMTemplateType, MLLMTemplateType
 from ..register import TemplateMeta, register_template
 from ..template_inputs import StdTemplateInputs
 from ..utils import Context, Prompt, findall
-from ..vision_utils import load_audio, load_video_minicpmv_mplug_owl3
+from ..vision_utils import load_audio, load_video_minicpmv_mplug_owl3, local_video_path
 from .llama import Llama3TemplateMeta
 from .qwen import Qwen2_5TemplateMeta, Qwen3MixedTemplateMeta, QwenTemplateMeta
 from .utils import ChatmlTemplateMeta
@@ -321,6 +321,11 @@ class MiniCPMO4_5Template(MiniCPMV4_5Template):
     SAMPLING_RATE = 16000
     MAX_AUDIO_DURATION = 30  # seconds
 
+    def _get_audio_context(self) -> List[Context]:
+        if self.mode == 'vllm':
+            return ['(<audio>./</audio>)']
+        return ['<|audio_start|><|audio_end|>']
+
     def init_env_args(self):
         super().init_env_args()
         self.use_audio_in_video = get_env_args('use_audio_in_video', bool, False)
@@ -333,23 +338,38 @@ class MiniCPMO4_5Template(MiniCPMV4_5Template):
             # Load audio from file path to numpy array at 16kHz
             if isinstance(inputs.audios[index], str):
                 inputs.audios[index] = load_audio(inputs.audios[index], sampling_rate=self.SAMPLING_RATE)
-            return ['<|audio_start|><|audio_end|>']
+            return self._get_audio_context()
         elif media_type == 'video':
             from minicpmo.utils import get_video_frame_audio_segments
-            video = inputs.videos[inputs.video_idx]
-            video_segments, audio_segments, _ = get_video_frame_audio_segments(
-                video, use_audio=self.use_audio_in_video, stack_frames=1)
+            video_idx = inputs.video_idx
+            video = inputs.videos[video_idx]
+            with local_video_path(video) as video_path:
+                video_segments, audio_segments, _ = get_video_frame_audio_segments(
+                    video_path, use_audio=self.use_audio_in_video, stack_frames=1)
+            # The video has already been converted into image/audio segments. In
+            # vLLM/lmdeploy mode, keeping the original value would pass the raw
+            # path or Data URI to the backend as an additional video input.
+            # Compensate for the increment performed by Template._pre_tokenize
+            # so multiple video placeholders continue to consume index 0.
+            if self.mode in {'vllm', 'lmdeploy'}:
+                inputs.videos.pop(video_idx)
+                inputs.video_idx -= 1
             # Insert frames into images list at current position
             images = inputs.images
             inputs.images = images[:inputs.image_idx] + video_segments + images[inputs.image_idx:]
-            # Build context list
-            image_context = [[-100]]
+            # Build context list. vLLM decodes prompt_token_ids while applying
+            # multimodal prompt updates, so a training-only -100 sentinel in
+            # input_ids causes tokenizer.decode() to raise OverflowError.
+            # Reuse the parent mode-aware image placeholder. It emits valid
+            # placeholder text for vLLM and -100 for the transformers path,
+            # where _encode() expands the sentinel before inference.
+            image_context = super().replace_tag('image', inputs.image_idx, inputs)
             context_list = []
             if self.use_audio_in_video and audio_segments:
                 # Insert audio segments into audios list at current position
                 audios = inputs.audios
                 inputs.audios = audios[:inputs.audio_idx] + audio_segments + audios[inputs.audio_idx:]
-                audio_context = ['<|audio_start|><|audio_end|>']
+                audio_context = self._get_audio_context()
                 # Interleave: one image placeholder + one audio placeholder per second
                 for i in range(len(video_segments)):
                     context_list += image_context

--- a/swift/template/vision_utils.py
+++ b/swift/template/vision_utils.py
@@ -6,10 +6,11 @@ import os
 import re
 import requests
 import torch
+from contextlib import contextmanager
 from io import BytesIO
 from PIL import Image
 from requests.adapters import HTTPAdapter
-from typing import Any, Callable, List, TypeVar, Union
+from typing import Any, Callable, Iterator, List, TypeVar, Union
 from urllib3.util.retry import Retry
 
 from swift.utils import get_env_args
@@ -411,14 +412,47 @@ def load_audio(
 
 
 def _resolve_video_local_path(path: Union[str, bytes]) -> tuple:
-    """Return (local_path, is_temp_file). HTTP URLs and raw bytes are written to a temp file."""
-    if isinstance(path, bytes) or (isinstance(path, str) and path.startswith('http')):
+    """Return a local path, materializing URLs, Data URIs, base64 strings, and bytes when needed."""
+    if not isinstance(path, (str, bytes)):
+        return path, False
+    if isinstance(path, str):
+        path = path.strip()
+        is_remote = path.startswith('http')
+        checked_path = None if is_remote else _check_path(path)
+    else:
+        is_remote = False
+        checked_path = None
+    if isinstance(path, bytes) or is_remote or checked_path is None:
         import tempfile
-        with tempfile.NamedTemporaryFile(suffix='.mp4', delete=False) as f:
-            f.write(load_file(path).read())
-            return f.name, True
-    checked = _check_path(path) if isinstance(path, str) else None
-    return checked or path, False
+        video_bytes = load_file(path).read()
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix='.mp4', delete=False) as f:
+                temp_path = f.name
+                f.write(video_bytes)
+            return temp_path, True
+        except Exception:
+            if temp_path is not None:
+                try:
+                    os.remove(temp_path)
+                except OSError:
+                    pass
+            raise
+    return checked_path, False
+
+
+@contextmanager
+def local_video_path(path: Union[str, bytes]) -> Iterator[str]:
+    """Materialize a video input as a local path and remove any temporary file afterwards."""
+    local_path, is_temp = _resolve_video_local_path(path)
+    try:
+        yield local_path
+    finally:
+        if is_temp:
+            try:
+                os.remove(local_path)
+            except OSError:
+                pass
 
 
 def _video_to_ndarrays_local(local_path: str, num_frames: int = -1) -> np.ndarray:
@@ -474,15 +508,8 @@ def _video_get_metadata_local(local_path: str, num_frames: int = -1) -> dict:
 
 def load_vllm_video(path: Union[str, bytes], num_frames: int = -1) -> tuple:
     """Decode video frames + metadata for vLLM rollout; one download, temp file cleaned up."""
-    local_path, is_temp = _resolve_video_local_path(path)
-    try:
+    with local_video_path(path) as local_path:
         return _video_to_ndarrays_local(local_path, num_frames), _video_get_metadata_local(local_path, num_frames)
-    finally:
-        if is_temp:
-            try:
-                os.remove(local_path)
-            except OSError:
-                pass
 
 
 def load_video_valley(video: Union[str, bytes]):

--- a/tests/general/test_minicpmo_template.py
+++ b/tests/general/test_minicpmo_template.py
@@ -1,0 +1,159 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import base64
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+from swift.template.template_inputs import StdTemplateInputs
+from swift.template.templates.minicpm import MiniCPMO4_5Template
+from swift.template.vision_utils import local_video_path
+
+
+class TestMiniCPMO45Template(unittest.TestCase):
+
+    @staticmethod
+    def _make_template(mode):
+        template = object.__new__(MiniCPMO4_5Template)
+        template.use_audio_in_video = True
+        template.max_num_frames = 64
+        template.mode = mode
+        return template
+
+    @staticmethod
+    def _patch_minicpmo(get_video_frame_audio_segments):
+        minicpmo = types.ModuleType('minicpmo')
+        minicpmo_utils = types.ModuleType('minicpmo.utils')
+        minicpmo_utils.get_video_frame_audio_segments = get_video_frame_audio_segments
+        minicpmo.utils = minicpmo_utils
+        return mock.patch.dict(sys.modules, {'minicpmo': minicpmo, 'minicpmo.utils': minicpmo_utils})
+
+    @staticmethod
+    def _make_data_uri(video_bytes=b'video-container-with-audio'):
+        return f'data:video/mp4;base64,{base64.b64encode(video_bytes).decode()}'
+
+    def test_vllm_data_uri_video_uses_temporary_file(self):
+        video_bytes = b'video-container-with-audio'
+        video = self._make_data_uri(video_bytes)
+        captured = {}
+
+        def get_video_frame_audio_segments(video_path, *, use_audio, stack_frames):
+            captured['video_path'] = video_path
+            self.assertTrue(os.path.isfile(video_path))
+            with open(video_path, 'rb') as f:
+                self.assertEqual(f.read(), video_bytes)
+            self.assertTrue(use_audio)
+            self.assertEqual(stack_frames, 1)
+            return ['frame'], ['audio'], None
+
+        template = self._make_template('vllm')
+        inputs = StdTemplateInputs(messages=[], videos=[video])
+        with self._patch_minicpmo(get_video_frame_audio_segments):
+            context = template.replace_tag('video', 0, inputs)
+
+        self.assertFalse(os.path.exists(captured['video_path']))
+        self.assertEqual(inputs.videos, [])
+        self.assertEqual(inputs.video_idx, -1)
+        self.assertEqual(inputs.images, ['frame'])
+        self.assertEqual(inputs.audios, ['audio'])
+        self.assertEqual(context, ['(<image>./</image>)\n', '(<audio>./</audio>)'])
+        self.assertTrue(all(not isinstance(part, list) or all(token_id >= 0 for token_id in part) for part in context))
+
+    def test_vllm_multiple_videos_are_not_skipped(self):
+        video = self._make_data_uri()
+
+        def get_video_frame_audio_segments(video_path, **kwargs):
+            return ['frame'], ['audio'], None
+
+        template = self._make_template('vllm')
+        inputs = StdTemplateInputs(messages=[], videos=[video, video])
+        with self._patch_minicpmo(get_video_frame_audio_segments):
+            # Match Template._pre_tokenize's post-callback index increment.
+            for _ in range(2):
+                template.replace_tag('video', inputs.video_idx, inputs)
+                inputs.video_idx += 1
+
+        self.assertEqual(inputs.videos, [])
+        self.assertEqual(inputs.video_idx, 0)
+        self.assertEqual(inputs.images, ['frame', 'frame'])
+        self.assertEqual(inputs.audios, ['audio', 'audio'])
+
+    def test_transformers_preserves_source_video(self):
+        video = self._make_data_uri()
+
+        def get_video_frame_audio_segments(video_path, **kwargs):
+            return ['frame'], ['audio'], None
+
+        template = self._make_template('transformers')
+        inputs = StdTemplateInputs(messages=[], videos=[video])
+        with self._patch_minicpmo(get_video_frame_audio_segments):
+            context = template.replace_tag('video', 0, inputs)
+
+        self.assertEqual(inputs.videos, [video])
+        self.assertEqual(inputs.video_idx, 0)
+        self.assertEqual(context, [[-100], '<|audio_start|><|audio_end|>'])
+
+    def test_lmdeploy_consumes_source_video(self):
+        video = self._make_data_uri()
+
+        def get_video_frame_audio_segments(video_path, **kwargs):
+            return ['frame'], ['audio'], None
+
+        template = self._make_template('lmdeploy')
+        inputs = StdTemplateInputs(messages=[], videos=[video])
+        with self._patch_minicpmo(get_video_frame_audio_segments):
+            context = template.replace_tag('video', 0, inputs)
+
+        self.assertEqual(inputs.videos, [])
+        self.assertEqual(inputs.video_idx, -1)
+        self.assertEqual(inputs.images, ['frame'])
+        self.assertEqual(inputs.audios, ['audio'])
+        self.assertEqual(context, [[-100], '<|audio_start|><|audio_end|>'])
+
+    def test_audio_placeholder_matches_backend(self):
+        inputs = StdTemplateInputs(messages=[], audios=[object()])
+        expected_contexts = {
+            'vllm': ['(<audio>./</audio>)'],
+            'lmdeploy': ['<|audio_start|><|audio_end|>'],
+            'transformers': ['<|audio_start|><|audio_end|>'],
+        }
+
+        for mode, expected_context in expected_contexts.items():
+            with self.subTest(mode=mode):
+                template = self._make_template(mode)
+                self.assertEqual(template.replace_tag('audio', 0, inputs), expected_context)
+
+    def test_data_uri_video_cleans_up_temporary_file_on_error(self):
+        video = self._make_data_uri(b'invalid-video')
+        captured = {}
+
+        def get_video_frame_audio_segments(video_path, **kwargs):
+            captured['video_path'] = video_path
+            self.assertTrue(os.path.isfile(video_path))
+            raise RuntimeError('decode failed')
+
+        template = self._make_template('vllm')
+        inputs = StdTemplateInputs(messages=[], videos=[video])
+        with self._patch_minicpmo(get_video_frame_audio_segments):
+            with self.assertRaisesRegex(RuntimeError, 'decode failed'):
+                template.replace_tag('video', 0, inputs)
+
+        self.assertFalse(os.path.exists(captured['video_path']))
+        self.assertEqual(inputs.videos, [video])
+
+    def test_local_video_path_preserves_local_file(self):
+        with tempfile.NamedTemporaryFile(suffix='.mp4', delete=False) as f:
+            f.write(b'local-video')
+            source_path = f.name
+        try:
+            with local_video_path(source_path) as resolved_path:
+                self.assertEqual(resolved_path, os.path.abspath(source_path))
+            self.assertTrue(os.path.exists(source_path))
+        finally:
+            os.remove(source_path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Summary

This PR fixes MiniCPM-o 4.5 video-with-audio inference when using a
Data URI with the vLLM backend.

It addresses four related problems:

1. Video Data URIs were passed directly to `minicpmo-utils`, which
   expects a local file path.
2. The original video was forwarded to the deployment backend after it
   had already been converted into image and audio segments.
3. A training-only `-100` image sentinel could reach vLLM prompt
   decoding.
4. The generated audio placeholder did not match the format expected
   by vLLM.

## Root cause

When `USE_AUDIO_IN_VIDEO=true`, `MiniCPMO4_5Template.replace_tag()`
passes the video input to `get_video_frame_audio_segments()`.

For a request containing:

```text
data:video/mp4;base64,...
```

the raw Data URI was treated as a file path. After audio/video
segmentation, the original video also remained in `inputs.videos`,
causing it to be sent to vLLM a second time.

The generated prompt could additionally contain:

```text
-100
```

which is an internal training sentinel rather than a valid token ID.
vLLM attempts to decode the prompt token IDs and therefore fails on the
negative value.

For audio inputs, ms-swift generated:

```text
<|audio_start|><|audio_end|>
```

while vLLM expects the input-side placeholder:

```text
(<audio>./</audio>)
```

This prevented vLLM from applying its multimodal prompt replacement.

## Changes

### Video input localization

A video-localization context manager was added to
`swift/template/vision_utils.py`.

It:

- reuses `load_file()` to handle Data URIs, raw Base64 strings, URLs
  and bytes;
- writes non-local inputs to a unique temporary `.mp4` file;
- removes the temporary file after successful processing;
- also removes the temporary file when video decoding raises an
  exception;
- leaves existing local video files unchanged.

### Avoid duplicate video inputs

After MiniCPM-o converts a video into image and audio segments:

- vLLM and LMDeploy modes remove the already-consumed original video;
- `video_idx` is adjusted so that requests containing multiple videos
  do not skip later video placeholders;
- Transformers mode retains the original video because the existing
  encoding path uses it to distinguish video frames from standalone
  images.

As a result, vLLM receives:

```python
multi_modal_data = {
    'image': video_frames,
    'audio': audio_segments,
}
```

without also receiving the original video Data URI.

### Backend-compatible placeholders

The MiniCPM-o template now uses mode-aware placeholders.

For vLLM:

```text
Image: (<image>./</image>)
Audio: (<audio>./</audio>)
```

For Transformers and LMDeploy, the existing model-side audio marker is
preserved:

```text
<|audio_start|><|audio_end|>
```

This prevents the training-only `-100` image sentinel from reaching
vLLM prompt decoding and allows vLLM to expand audio placeholders
correctly.

### Regression tests

A dedicated unittest module was added:

```text
tests/general/test_minicpmo_template.py
```

It covers:

- Data URI materialization into a temporary local video file;
- temporary-file cleanup after successful decoding;
- temporary-file cleanup after a decoding exception;
- preservation of existing local video files;
- vLLM image and audio placeholders;
- multiple-video index handling;
- removal of consumed videos in vLLM;
- removal of consumed videos in LMDeploy;
- preservation of source videos in Transformers mode;
- backend-specific direct-audio placeholders.

## Reproduction

### Environment

- Python: 3.11
- Model: `OpenBMB/MiniCPM-o-4_5`
- Template: `minicpmo4_5`
- Backend: vLLM
- vLLM: 0.26.0
- `USE_AUDIO_IN_VIDEO=true`
- Input: OpenAI-compatible `video_url` containing a video Data URI

Start the server:

```bash
USE_AUDIO_IN_VIDEO=true swift deploy \
  --model OpenBMB/MiniCPM-o-4_5 \
  --model_type minicpmo \
  --template minicpmo4_5 \
  --infer_backend vllm \
  --served_model_name minicpm-o-4.5 \
  --vllm_limit_mm_per_prompt \
  '{"image":8,"video":1,"audio":8}' \
  --port 8000
```

Generate a small synthetic video containing an audio track:

```bash
ffmpeg -y \
  -f lavfi -i color=c=blue:s=320x240:r=1 \
  -f lavfi -i sine=frequency=1000:sample_rate=16000 \
  -t 2 \
  -c:v libx264 \
  -pix_fmt yuv420p \
  -c:a aac \
  -shortest \
  /tmp/minicpmo-av.mp4
```

Send the video as a Data URI:

```bash
VIDEO_FILE=/tmp/minicpmo-av.mp4
API_BASE=http://127.0.0.1:8000

{
  printf '%s' \
    '{"model":"minicpm-o-4.5","messages":[{"role":"user","content":[{"type":"video_url","video_url":{"url":"data:video/mp4;base64,'
  base64 < "${VIDEO_FILE}" | tr -d '\r\n'
  printf '%s' \
    '"}},{"type":"text","text":"Describe the video and audio."}]}],"temperature":0,"max_tokens":256}'
} | curl -sS --fail-with-body \
  --max-time 600 \
  "${API_BASE}/v1/chat/completions" \
  -H 'Content-Type: application/json' \
  --data-binary @-
```

## Behavior before this change

Depending on which preprocessing stage was reached, the request failed
with one of the following symptoms:

```text
The video Data URI is treated as a local file path.

AssertionError: ... got: 'd'

OverflowError: out of range integral type conversion attempted

AssertionError: Failed to apply prompt replacement for
mm_items['audio'][0]
```

## Behavior after this change

The same Data URI request completes successfully:

- the video is decoded through a temporary local file;
- image and audio segments are passed to vLLM;
- the original video is not forwarded again;
- no negative token ID reaches vLLM prompt decoding;
- audio prompt replacement completes successfully;
- the API returns an HTTP 200 response with a non-empty assistant
  result.

# Experiment results

## Lint

```text
pre-commit run --all-files

flake8........................................................Passed
isort.........................................................Passed
yapf..........................................................Passed
trim trailing whitespace......................................Passed
check yaml.....................................................Passed
fix end of files...............................................Passed
fix requirements.txt...........................................Passed
fix double quoted strings......................................Passed
check for merge conflicts......................................Passed
mixed line ending..............................................Passed
```

## Unit tests

Command:

```bash
python -m unittest discover \
  -s tests/general \
  -p 'test_minicpmo_template.py' \
  -v
```

Result:

```text
Ran 7 tests in 0.005s

OK
```

The tests passed for vLLM, LMDeploy and Transformers behavior.