### PR TITLE
docs(deploy): fix broken link to examples/infer

### DIFF
--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -1,4 +1,4 @@
-Please refer to the examples in [examples/infer](../../infer/) and change `swift infer` to `swift deploy` to start the service. (You need to additionally remove `--val_dataset`)
+Please refer to the examples in [examples/infer](../infer/) and change `swift infer` to `swift deploy` to start the service. (You need to additionally remove `--val_dataset`)
 
 e.g.
 ```shell


### PR DESCRIPTION
### Motivation
In examples/deploy/README.md, the relative link to examples/infer is ../../infer/, which resolves to a non-existent infer/ directory at the repository root. The correct target is ../infer/ (i.e. examples/infer/).

### Modification
- Fix the relative link from ../../infer/ to ../infer/ in examples/deploy/README.md.

### Verification
- Confirmed examples/infer/ exists in the repository.
- The link now resolves to the correct directory.