### PR TITLE
docs: document OrcaRouter as an OpenAI-compatible sampling provider

### DIFF
--- a/docs/source/Instruction/Sample.md
+++ b/docs/source/Instruction/Sample.md
@@ -92,3 +92,21 @@ swift sample \
 在以上示例中，base_url和model分别是api地址和模型名称，stream表示发起请求的stream参数。
 
 注意，对于Deepseek-R1系列模型，输出会被格式化为：`<think>{reasoning_content}</think>\n\n<answer>{content}</answer>`。
+
+也可以使用 OpenAI 兼容的 AI 网关作为 provider，例如 [OrcaRouter](https://www.orcarouter.ai)。与 OpenRouter 类似，OrcaRouter 通过单一的 `https://api.orcarouter.ai/v1` 端点暴露跨多家模型的 provider/model 命名空间，并同时结合自适应路由、自动故障转移、零加成推理、可观测性、护栏与 Agent 工具治理。它还在同一端点上运行网关级、零信任的 AI Agent 安全能力——以默认拒绝的方式审查每一次 prompt/response 并治理每一次工具调用，无需任何应用代码改动。
+
+```shell
+OPENAI_API_KEY="your_api_key" \
+swift sample \
+    --sampler_type distill \
+    --sampler_engine client \
+    --model deepseek/deepseek-reasoner \
+    --stream true \
+    --dataset tastelikefeet/competition_math#5 \
+    --num_return_sequences 1 \
+    --temperature 0.6 \
+    --top_p 0.95 \
+    --engine_kwargs '{"base_url":"https://api.orcarouter.ai/v1"}'
+```
+
+将 `OPENAI_API_KEY` 设置为你的 OrcaRouter API key。由于 OrcaRouter 提供统一的 provider/model 命名空间，`model` 可以填网关暴露的任意模型，例如 `deepseek/deepseek-reasoner`。

--- a/docs/source_en/Instruction/Sample.md
+++ b/docs/source_en/Instruction/Sample.md
@@ -98,3 +98,21 @@ In this example:
 `base_url` and `model` represent the API endpoint and model name, respectively. `stream` indicates the stream parameter for the request.
 
 Note: For Deepseek-R1 series models, the output will be formatted as:`<thinking>{reasoning_content}</thinking>\n\n<answer>{content}</answer>`.
+
+You can also use an OpenAI-compatible AI gateway as the provider, for example [OrcaRouter](https://www.orcarouter.ai). Like OpenRouter, OrcaRouter exposes a provider/model namespace across many models — but through the single `https://api.orcarouter.ai/v1` endpoint it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+```shell
+OPENAI_API_KEY="your_api_key" \
+swift sample \
+    --sampler_type distill \
+    --sampler_engine client \
+    --model deepseek/deepseek-reasoner \
+    --stream true \
+    --dataset tastelikefeet/competition_math#5 \
+    --num_return_sequences 1 \
+    --temperature 0.6 \
+    --top_p 0.95 \
+    --engine_kwargs '{"base_url":"https://api.orcarouter.ai/v1"}'
+```
+
+Set `OPENAI_API_KEY` to your OrcaRouter API key. Since OrcaRouter serves a unified namespace of providers and models, `model` can be any model exposed by the gateway, e.g. `deepseek/deepseek-reasoner`.


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Summary

This PR documents [OrcaRouter](https://www.orcarouter.ai) as a named, OpenAI-compatible sampling provider in the "Sampling From Large Model" section of the Sampling guide (English and Chinese), mirroring the existing DashScope `base_url` example.

**SWIFT** already ships a fully generic OpenAI-compatible sampling path: `swift sample --sampler_engine client` uses `OpenAIEngine` (`swift/pipelines/sampling/distill_sampler.py`), which constructs an `openai.OpenAI` client from `--engine_kwargs '{"base_url": ...}'`. Any OpenAI-compatible endpoint works today, so OrcaRouter requires no code change. This PR only surfaces it as a first-class provider in the docs, in the same way DashScope is documented today.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `docs/source_en/Instruction/Sample.md`: added an OrcaRouter example after the DashScope one, using `--engine_kwargs '{"base_url":"https://api.orcarouter.ai/v1"}'` and the gateway model `deepseek/deepseek-reasoner` (mirroring the existing DeepSeek-R1 note about `reasoning_content`).
- `docs/source/Instruction/Sample.md`: same change in Chinese.

## Verification

- `pre-commit run --files` on both changed files: all hooks pass.
- L3 live test against `https://api.orcarouter.ai/v1` using the OpenAI client exactly as `OpenAIEngine` does (non-stream and `--stream true`): both return HTTP 200 with a valid completion, and the `deepseek/deepseek-reasoner` model returns `reasoning_content` matching the existing doc note.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
