### PR TITLE
Cache downloaded files atomically

### DIFF
--- a/swift/utils/hub_utils.py
+++ b/swift/utils/hub_utils.py
@@ -3,6 +3,7 @@ import hashlib
 import importlib.util
 import os
 import requests
+import tempfile
 from modelscope.hub.api import HubApi, ModelScopeConfig
 from modelscope.hub.utils.utils import get_cache_dir
 from pathlib import Path
@@ -245,12 +246,19 @@ def download_file(url: str) -> str:
     file_path = os.path.join(cache_dir, file_name)
     if os.path.exists(file_path):
         return file_path
-    with requests.get(url, stream=True) as resp:
-        resp.raise_for_status()
-        total_size = int(resp.headers.get('content-length', 0))
-        with open(file_path, 'wb') as f, tqdm(
-                total=total_size, unit='B', unit_scale=True, unit_divisor=1024, desc=file_name) as pbar:
-            for chunk in resp.iter_content(chunk_size=8192):
-                f.write(chunk)
-                pbar.update(len(chunk))
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=cache_dir, prefix=f'.{file_name}.', suffix='.tmp', delete=False) as f:
+            temp_path = f.name
+            with requests.get(url, stream=True) as resp:
+                resp.raise_for_status()
+                total_size = int(resp.headers.get('content-length', 0))
+                with tqdm(total=total_size, unit='B', unit_scale=True, unit_divisor=1024, desc=file_name) as pbar:
+                    for chunk in resp.iter_content(chunk_size=8192):
+                        f.write(chunk)
+                        pbar.update(len(chunk))
+        os.replace(temp_path, file_path)
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.remove(temp_path)
     return file_path

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -56,6 +56,20 @@ class TestHubUtils(unittest.TestCase):
 
     @patch('swift.utils.hub_utils.requests.get')
     @patch('swift.utils.hub_utils.get_cache_dir')
+    def test_download_file_removes_partial_cache_on_failure(self, mock_cache_dir, mock_get):
+        mock_cache_dir.return_value = self.tmp_dir
+        response = self._mock_response([b'partial'])
+        response.iter_content.side_effect = OSError('connection reset')
+        mock_get.return_value = response
+
+        with self.assertRaisesRegex(OSError, 'connection reset'):
+            download_file('https://example.com/model.bin')
+
+        cache_dir = os.path.join(self.tmp_dir, 'files')
+        self.assertEqual(os.listdir(cache_dir), [])
+
+    @patch('swift.utils.hub_utils.requests.get')
+    @patch('swift.utils.hub_utils.get_cache_dir')
     def test_download_file_uses_a_distinct_cache_path_for_each_url(self, mock_cache_dir, mock_get):
         mock_cache_dir.return_value = self.tmp_dir
         mock_get.side_effect = [self._mock_response([b'first']), self._mock_response([b'second'])]


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

`download_file()` now streams into a temporary file in the cache directory and atomically replaces the final cache path only after the response finishes. Failed downloads remove their temporary file, so a later call cannot mistake truncated bytes for a valid cached artifact.

A focused regression test simulates a connection reset and verifies that the cache directory remains empty.

## Experiment results

- RED on current `main`: an interrupted stream left a final cache file containing `b"half"`
- GREEN after the fix: the same interrupted stream leaves no cache entries
- `pre-commit run --files swift/utils/hub_utils.py tests/utils/test_hub_utils.py`
- `python3 -m py_compile swift/utils/hub_utils.py tests/utils/test_hub_utils.py`
- `git diff --check`