### PR TITLE
Make `lora_alpha` a float

### DIFF
--- a/swift/arguments/tuner_args.py
+++ b/swift/arguments/tuner_args.py
@@ -52,7 +52,7 @@ class TunerArguments:
         modules_to_save (List[str]): List of modules to save. Default is an empty list.
 
         lora_rank (int): Rank for LoRA. Default is 8.
-        lora_alpha (int): Alpha value for LoRA. Default is 32.
+        lora_alpha (float): Alpha value for LoRA. Default is 32.0.
         lora_dropout (float): Dropout rate for LoRA. Default is 0.05.
         lora_bias (Literal['none', 'all']): The possible values are 'none' and 'all'. If set to 'all', all biases
             will be trainable. Default is 'none'.
@@ -131,7 +131,7 @@ class TunerArguments:
 
     # lora
     lora_rank: int = 8
-    lora_alpha: int = 32
+    lora_alpha: float = 32.0
     lora_dropout: float = 0.05
     lora_bias: Literal['none', 'all'] = 'none'
     lora_dtype: Literal['float16', 'bfloat16', 'float32', None] = None

--- a/swift/megatron/arguments/megatron_args.py
+++ b/swift/megatron/arguments/megatron_args.py
@@ -463,7 +463,7 @@ class MegatronTunerMixin:
 
     # lora
     lora_rank: int = 8
-    lora_alpha: int = 32
+    lora_alpha: float = 32.0
     lora_dropout: float = 0.05
     lora_bias: Literal['none', 'all'] = 'none'
     lora_dtype: Literal['float16', 'bfloat16', 'float32', None] = None

--- a/swift/tuners/lora_layers.py
+++ b/swift/tuners/lora_layers.py
@@ -517,7 +517,7 @@ class LoRALayer(ActivationMixin):
         adapter_name: str,
         module_key: str,
         r: int,
-        lora_alpha: int,
+        lora_alpha: float,
         lora_dropout: float,
         merge_weights: bool,
     ):
@@ -544,7 +544,7 @@ class MergedLinear(nn.Linear, LoRALayer):
                  module_key: str,
                  base_layer: nn.Linear,
                  r: int = 0,
-                 lora_alpha: int = 1,
+                 lora_alpha: float = 1.0,
                  lora_dropout: float = 0.,
                  enable_lora: List[bool] = [False],
                  fan_in_fan_out: bool = False,

--- a/tests/megatron/test_opsd.py
+++ b/tests/megatron/test_opsd.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
             vllm_max_model_len=10240,
             tuner_type='lora',
             lora_rank=64,
-            lora_alpha=128,
+            lora_alpha=128.0,
             sleep_level=1,
             lmbda=1.0,
             beta=0.5,

--- a/tests/train/test_opsd.py
+++ b/tests/train/test_opsd.py
@@ -13,7 +13,7 @@ def train():
             teacher_model='Qwen/Qwen3.5-4B',
             tuner_type='lora',
             lora_rank=64,
-            lora_alpha=128,
+            lora_alpha=128.0,
             target_modules=['all-linear'],
             use_vllm=True,
             vllm_mode='colocate',


### PR DESCRIPTION
**NOTE**: This is something I've been using locally, that I think makes sense for swift and that works for me; but I also think you might reasonably want to see if PEFT upstream chimes in in the issue I link below.

---

# PR type
- [ ] Bug Fix
- [X] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

There's nothing fundamentally integer or continuous about `lora_alpha`. While artificially restricting to integers may not have a huge impact in typical (human) usage, needlessly discretized parameters can be tricky for hyperparameter search using cleverer-than-grid-search methods (e.g. optuna, Ax).

Now, the `peft` dependency admittedly does have type hints expecting `int`. It seems to deal with floats fine. `peft` upstream documents in their CONTRIBUTING.md a dislike for typing-only fixes. I have nevertheless raised this point, offering to create a PR that changes the types, here: https://github.com/huggingface/peft/issues/3615