### PR TITLE
[examples] fix do_eval() call arity in the rft baseline-eval block

### DIFF
--- a/examples/train/rft/rft.py
+++ b/examples/train/rft/rft.py
@@ -198,7 +198,7 @@ def main():
 
     if False:
         # eval the original model
-        do_eval(first_model, None)
+        do_eval(first_model, model_type, None)
 
     model = first_model
     for i in range(5):


### PR DESCRIPTION
## Problem

`examples/train/rft/rft.py` defines

```python
def do_eval(model, model_type: str, iter):     # :146
```

and the RFT loop calls it correctly at `:215`:

```python
acc = do_eval(ckpt, model_type, i)
```

But the baseline-evaluation block at the top of `main()` passes only two arguments:

```python
if False:
    # eval the original model
    do_eval(first_model, None)                 # :201  -> TypeError
```

```
TypeError: do_eval() missing 1 required positional argument: 'iter'
```

The block is guarded by `if False:` and is clearly meant to be flipped on by the user
("eval the original model", in the same spirit as the other opt-in comments in this file:
`# add custom data filter here...`, `# if want to train the original model everytime...`).
Anyone who flips it gets a `TypeError` instead of a baseline number.

## What the intended call was

`do_eval` has a branch that exists solely for this call site:

```python
if iter is None:
    iter = 'origin'
```

`:215` always passes an `int`, so `iter is None` is unreachable today — it is there to name the
baseline run's log file `logs/eval_iter_origin.log`. That is, `None` was meant to be the third
argument (`iter`), and `model_type` was dropped. As written, `None` binds to `model_type`
instead, which would also have rendered `--model_type None` into the `swift eval` command line.

## Fix

```diff
-        do_eval(first_model, None)
+        do_eval(first_model, model_type, None)
```

One line. `model_type` is already in scope two lines above (`model_type = 'qwen2_5_math'`).

## Verification

No GPU here, so I replayed the call sites against the real signature via
`inspect.Signature.bind`, with `:215` as the control group:

```
signature: (model, model_type, iter)
  line 201, as written: TypeError: missing a required argument: 'iter'
  line 201, patched   : binds OK -> {'model': 'Qwen/Qwen2.5-Math-7B-Instruct', 'model_type': 'qwen2_5_math', 'iter': None}
  line 215 (control)  : binds OK -> {'model': 'ckpt', 'model_type': 'qwen2_5_math', 'iter': 0}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
