### PR TITLE
Fix exact token consistency in agentic multi-step rollouts

### DIFF
--- a/examples/train/grpo/plugin/plugin.py
+++ b/examples/train/grpo/plugin/plugin.py
@@ -1190,8 +1190,7 @@ class ToolCallScheduler(MultiTurnScheduler):
     def step(self, infer_request: 'RolloutInferRequest', response_choice: 'ChatCompletionResponseChoice',
              current_turn: int) -> Dict:
         completion = response_choice.message.content
-        token_ids = response_choice.token_ids
-        loss_mask = [1] * len(token_ids)
+        token_ids, loss_mask, rollout_logprobs = self.prepare_response_continuation(response_choice)
         tool_calls = self._extract_tool_calls(completion)
         # assert len(tool_calls) == 1, 'this scheduler is designed for one tool call per turn'
         tool_results = self._execute_tools(tool_calls)
@@ -1207,6 +1206,7 @@ class ToolCallScheduler(MultiTurnScheduler):
             'infer_request': infer_request,
             'response_token_ids': token_ids,
             'response_loss_mask': loss_mask,
+            'rollout_logprobs': rollout_logprobs,
             'rollout_infos': {
                 'tool_results': tool_results[0],
                 'num_turns': current_turn,

--- a/swift/ray/megatron/gkd_trainer.py
+++ b/swift/ray/megatron/gkd_trainer.py
@@ -73,8 +73,9 @@ class GKDTrainer(BaseRayTrainer):
             if scheduler_cfg not in multi_turns:
                 raise ValueError(f'Unknown multi_turn_scheduler: {scheduler_cfg!r}; '
                                  f'available: {list(multi_turns)}')
-            scheduler_kwargs = {'max_turns': self._max_turns}
-            tokenizer = getattr(getattr(self, 'template', None), 'tokenizer', None)
+            template = getattr(self, 'template', None)
+            scheduler_kwargs = {'max_turns': self._max_turns, 'template': template}
+            tokenizer = getattr(template, 'tokenizer', None)
             if tokenizer is not None:
                 scheduler_kwargs['tokenizer'] = tokenizer
             gym_env = getattr(args, 'gym_env', None)

--- a/swift/ray/megatron/grpo_trainer.py
+++ b/swift/ray/megatron/grpo_trainer.py
@@ -105,7 +105,11 @@ class GRPOTrainer(BaseRayTrainer):
             if scheduler_cfg not in multi_turns:
                 raise ValueError(f'Unknown multi_turn_scheduler: {scheduler_cfg!r}; '
                                  f'available: {list(multi_turns)}')
-            scheduler_kwargs = {'max_turns': self._max_turns}
+            scheduler_kwargs = {
+                'max_turns': self._max_turns,
+                'tokenizer': self.template.tokenizer,
+                'template': self.template,
+            }
             gym_env = getattr(args, 'gym_env', None)
             if gym_env is not None:
                 scheduler_kwargs['gym_env'] = gym_env

--- a/swift/rlhf_trainers/grpo_trainer.py
+++ b/swift/rlhf_trainers/grpo_trainer.py
@@ -2050,7 +2050,7 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
             template = self.template
             current_length = model_inputs['input_ids'].shape[1]
             with self._template_context(template):
-                encoded_data = [template.encode(data.to_template_dict()) for data in chunk_origin_data]
+                encoded_data = [encode_sample(data, template) for data in chunk_origin_data]
                 for ed in encoded_data:
                     ed.pop('_extra_kwargs', None)
                 chunk_model_inputs.update(

--- a/swift/rollout/agent_loop.py
+++ b/swift/rollout/agent_loop.py
@@ -120,14 +120,12 @@ def _run_multi_turn_impl(
             response = output.response
             response_choice = response.choices[0]
             completion = response_choice.message.content
-            is_continuations[index] = False
-            if messages[-1]['role'] == 'assistant':
-                messages[-1]['content'] += completion
-                is_continuations[index] = True
-            else:
-                messages.append({'role': 'assistant', 'content': completion})
+            is_continuations[index] = scheduler.append_assistant_completion(requests[index], completion)
 
         current_requests = [requests[index] for index in index_to_infer]
+        assistant_snapshots = [
+            scheduler.snapshot_and_materialize_assistant_messages(req) for req in current_requests
+        ]
 
         async def _gather_turn_ends():
             return list(await asyncio.gather(*[
@@ -135,15 +133,20 @@ def _run_multi_turn_impl(
                 for req, output in zip(current_requests, outputs)
             ]))
 
-        turn_results = loop.run_until_complete(_gather_turn_ends())
-        for tr, index in zip(turn_results, index_to_infer):
-            if tr.get('rollout_infos'):
-                rollout_infos[index].update(tr['rollout_infos'])
+        try:
+            turn_results = loop.run_until_complete(_gather_turn_ends())
+            for tr, index in zip(turn_results, index_to_infer):
+                if tr.get('rollout_infos'):
+                    rollout_infos[index].update(tr['rollout_infos'])
 
-        should_stops = [
-            tr.get('done', scheduler.check_finished(req, output.response.choices[0], current_turn))
-            for tr, req, output in zip(turn_results, current_requests, outputs)
-        ]
+            should_stops = [
+                tr.get('done', scheduler.check_finished(req, output.response.choices[0], current_turn))
+                for tr, req, output in zip(turn_results, current_requests, outputs)
+            ]
+            turn_result_by_index = dict(zip(index_to_infer, turn_results))
+        finally:
+            for snapshots in assistant_snapshots:
+                scheduler.restore_assistant_message_snapshots(snapshots)
 
         next_turn_index_to_infer: List[int] = []
         for stop, index, output in zip(should_stops, index_to_infer, outputs):
@@ -153,24 +156,31 @@ def _run_multi_turn_impl(
                 is_continuation = is_continuations[index]
                 response_choice = output.response.choices[0]
                 current_logprobs = extract_logprobs_from_choice(response_choice)
-                final_token_ids = response_choice.token_ids
+                step_result = turn_result_by_index[index]
+                if 'rollout_logprobs' in step_result:
+                    current_logprobs = step_result['rollout_logprobs'] or []
+                final_token_ids, final_mask = scheduler.get_response_token_data(
+                    requests[index],
+                    response_choice,
+                    is_continuation=is_continuation,
+                    response_token_ids=step_result.get('response_token_ids'),
+                    response_loss_mask=step_result.get('response_loss_mask'))
 
                 if is_continuation and response_token_ids[index]:
                     response_token_ids[index][-1].extend(final_token_ids)
-                    if response_loss_mask[index]:
-                        response_loss_mask[index][-1].extend([1] * len(final_token_ids))
+                    response_loss_mask[index][-1].extend(final_mask)
                     if rollout_logprobs[index] and current_logprobs:
                         rollout_logprobs[index][-1].extend(current_logprobs)
                 elif not response_token_ids[index]:
                     if final_token_ids:
                         response_token_ids[index] = [list(final_token_ids)]
-                        response_loss_mask[index] = [[1] * len(final_token_ids)]
+                        response_loss_mask[index] = [list(final_mask)]
                     if current_logprobs:
                         rollout_logprobs[index] = [current_logprobs]
                 else:
                     if final_token_ids:
                         response_token_ids[index].append(list(final_token_ids))
-                        response_loss_mask[index].append([1] * len(final_token_ids))
+                        response_loss_mask[index].append(list(final_mask))
                     if current_logprobs:
                         rollout_logprobs[index].append(current_logprobs)
 
@@ -206,23 +216,24 @@ def _run_multi_turn_impl(
                 continue
 
             is_continuation = is_continuations[index]
+            turn_ids, turn_mask = scheduler.get_response_token_data(
+                requests[index], output.response.choices[0], is_continuation=is_continuation)
             step_result = scheduler.step(requests[index], output.response.choices[0], current_turn)
             current_request: RolloutInferRequest = step_result['infer_request']
-            return_token_id = False
-            if 'response_token_ids' in step_result:
+            if step_result.get('response_token_ids') is not None or step_result.get('response_loss_mask') is not None:
+                turn_ids, turn_mask = scheduler.get_response_token_data(
+                    requests[index],
+                    output.response.choices[0],
+                    is_continuation=is_continuation,
+                    response_token_ids=step_result.get('response_token_ids'),
+                    response_loss_mask=step_result.get('response_loss_mask'))
+            if turn_ids:
                 if is_continuation and response_token_ids[index]:
-                    response_token_ids[index][-1].extend(step_result['response_token_ids'])
+                    response_token_ids[index][-1].extend(turn_ids)
+                    response_loss_mask[index][-1].extend(turn_mask)
                 else:
-                    response_token_ids[index].append(step_result['response_token_ids'])
-                return_token_id = True
-            if 'response_loss_mask' in step_result:
-                assert return_token_id, 'You must return response_token_ids with response_loss_mask return'
-                assert len(step_result['response_loss_mask']) == len(step_result['response_token_ids']), \
-                    'response_loss_mask must have the same length as response_token_ids'
-                if is_continuation and response_loss_mask[index]:
-                    response_loss_mask[index][-1].extend(step_result['response_loss_mask'])
-                else:
-                    response_loss_mask[index].append(step_result['response_loss_mask'])
+                    response_token_ids[index].append(turn_ids)
+                    response_loss_mask[index].append(turn_mask)
 
             if 'rollout_infos' in step_result:
                 # Always overwrite the rollout info for this step.
@@ -240,6 +251,8 @@ def _run_multi_turn_impl(
                 else:
                     rollout_logprobs[index].append(current_logprobs)
 
+            if response_token_ids[index]:
+                scheduler.set_assistant_message_token_ids(current_request, response_token_ids[index][-1])
             requests[index] = current_request
             next_turn_index_to_infer.append(index)
 

--- a/swift/rollout/multi_turn.py
+++ b/swift/rollout/multi_turn.py
@@ -26,9 +26,113 @@ class RolloutScheduler(ABC):
                  *args,
                  **kwargs):
         self.infer_engine = infer_engine
-        # Tokenizer can be passed explicitly (e.g., in colocate mode where infer_engine may be None)
+        # Tokenizer/template can be passed explicitly when colocate mode has no infer_engine.
         self._tokenizer = kwargs.get('tokenizer', None)
+        self._template = kwargs.get('template', None)
         self.max_turns = max_turns
+
+    def get_response_token_data(self, infer_request: 'RolloutInferRequest',
+                                response_choice: 'ChatCompletionResponseChoice',
+                                is_continuation: bool = False,
+                                response_token_ids: Optional[List[int]] = None,
+                                response_loss_mask: Optional[List[int]] = None) -> tuple[List[int], List[int]]:
+        """Return exact IDs and the loss mask for one generated assistant segment.
+
+        The engine reports sampled IDs only. The deterministic response prefix is
+        part of the prompt, but must be represented in the training completion as
+        masked IDs. Scheduler overrides are normalized by the same contract.
+        """
+        ids = list(response_choice.token_ids or []) if response_token_ids is None else list(response_token_ids)
+        mask = None if response_loss_mask is None else list(response_loss_mask)
+        if mask is not None:
+            assert len(mask) == len(ids), 'response_loss_mask must have the same length as response_token_ids'
+            assert all(value in (0, 1) for value in mask), 'response_loss_mask values must be 0 or 1'
+        if mask is None:
+            mask = [1] * len(ids)
+
+        prefix_ids: List[int] = []
+        template = self._template or getattr(self.infer_engine, 'template', None)
+        tokenizer = self.tokenizer
+        if not is_continuation and template is not None and tokenizer is not None:
+            from swift.template import StdTemplateInputs
+            template_inputs = StdTemplateInputs(
+                messages=[], chat_template_kwargs=dict(infer_request.chat_template_kwargs or {}))
+            response_prefix = template._get_response_prefix(template_inputs)
+            if response_prefix:
+                prefix_ids = list(tokenizer.encode(response_prefix, add_special_tokens=False))
+
+        prefix_is_explicit = (
+            prefix_ids and response_loss_mask is not None and ids[:len(prefix_ids)] == prefix_ids
+            and mask[:len(prefix_ids)] == [0] * len(prefix_ids))
+        if prefix_ids and not prefix_is_explicit:
+            ids = prefix_ids + ids
+            mask = [0] * len(prefix_ids) + mask
+        return ids, mask
+
+    def prepare_response_continuation(
+            self, response_choice: 'ChatCompletionResponseChoice') -> tuple[List[int], List[int], List[float]]:
+        """Normalize sampled output before appending deterministic content."""
+        token_ids = list(response_choice.token_ids or [])
+        if response_choice.logprobs is None:
+            rollout_logprobs = []
+        elif 'content' in response_choice.logprobs:
+            rollout_logprobs = [item['logprob'] for item in response_choice.logprobs['content']]
+        else:
+            rollout_logprobs = []
+        if rollout_logprobs and len(rollout_logprobs) != len(token_ids):
+            raise ValueError(
+                f'rollout_logprobs length ({len(rollout_logprobs)}) must match sampled token_ids '
+                f'length ({len(token_ids)})')
+        return token_ids, [1] * len(token_ids), rollout_logprobs
+
+    def set_assistant_message_token_ids(self, infer_request: 'RolloutInferRequest', token_ids: List[int]) -> None:
+        """Freeze the latest assistant message as exact IDs for the next inference turn."""
+        for message in reversed(infer_request.messages):
+            if message.get('role') == 'assistant':
+                message['content'] = list(token_ids)
+                return
+
+    def snapshot_and_materialize_assistant_messages(self,
+                                                    infer_request: 'RolloutInferRequest') -> List[tuple[dict, Any]]:
+        """Temporarily decode ID-backed assistant history for text-oriented scheduler hooks."""
+        tokenizer = self.tokenizer
+        snapshots = []
+        for message in infer_request.messages:
+            if message.get('role') != 'assistant':
+                continue
+            original_content = message.get('content')
+            token_ids = original_content.get('token_ids') if isinstance(original_content, dict) else original_content
+            if not isinstance(token_ids, list) or (token_ids and not isinstance(token_ids[0], int)):
+                continue
+            if tokenizer is None:
+                raise RuntimeError('A tokenizer is required to materialize an ID-backed assistant response')
+            snapshots.append((message, deepcopy(original_content)))
+            message['content'] = tokenizer.decode(token_ids, skip_special_tokens=False)
+        return snapshots
+
+    @staticmethod
+    def restore_assistant_message_snapshots(snapshots: List[tuple[dict, Any]]) -> None:
+        """Restore exact assistant contents after text-oriented scheduler hooks."""
+        for message, content in snapshots:
+            message['content'] = content
+
+    def append_assistant_completion(self, infer_request: 'RolloutInferRequest', completion: str) -> bool:
+        """Append generated text, decoding an ID-backed message only for a continuation."""
+        messages = infer_request.messages
+        if messages[-1]['role'] != 'assistant':
+            messages.append({'role': 'assistant', 'content': completion})
+            return False
+
+        content = messages[-1].get('content')
+        token_ids = content.get('token_ids') if isinstance(content, dict) else content
+        if isinstance(token_ids, list) and (not token_ids or isinstance(token_ids[0], int)):
+            tokenizer = self.tokenizer
+            if tokenizer is None:
+                raise RuntimeError('A tokenizer is required to continue an ID-backed assistant response')
+            content = tokenizer.decode(token_ids, skip_special_tokens=False)
+            messages[-1]['content'] = content
+        messages[-1]['content'] += completion
+        return True
 
     # ------------------------------------------------------------------
     # Universal hooks — called by BOTH ``run()`` (server mode) and
@@ -287,20 +391,19 @@ class MultiTurnScheduler(RolloutScheduler, ABC):
 
             # Update conversation history
             completion = response_choice.message.content
-            is_continuation = False
-            if messages[-1]['role'] == 'assistant':
-                messages[-1]['content'] += completion
-                is_continuation = True
-            else:
-                messages.append({'role': 'assistant', 'content': completion})
+            is_continuation = self.append_assistant_completion(current_request, completion)
 
             # Check stopping conditions
-            turn_result = await self.on_turn_end(current_request, response_choice, current_turn)
-            if turn_result.get('rollout_infos'):
-                rollout_infos.update(turn_result['rollout_infos'])
-            should_stop = self.check_finished(current_request, response_choice, current_turn)
-            if 'done' in turn_result:
-                should_stop = turn_result['done']
+            assistant_snapshots = self.snapshot_and_materialize_assistant_messages(current_request)
+            try:
+                turn_result = await self.on_turn_end(current_request, response_choice, current_turn)
+                if turn_result.get('rollout_infos'):
+                    rollout_infos.update(turn_result['rollout_infos'])
+                should_stop = self.check_finished(current_request, response_choice, current_turn)
+                if 'done' in turn_result:
+                    should_stop = turn_result['done']
+            finally:
+                self.restore_assistant_message_snapshots(assistant_snapshots)
 
             # double-check if user forget to judge the max_turns
             if self.max_turns:
@@ -309,22 +412,23 @@ class MultiTurnScheduler(RolloutScheduler, ABC):
             if should_stop:
                 # Collect final turn's data
                 current_logprobs = self._extract_logprobs_from_choice(response_choice)
-                final_token_ids = response_choice.token_ids
+                final_token_ids, final_loss_mask = self.get_response_token_data(
+                    current_request, response_choice, is_continuation=is_continuation)
 
                 if is_continuation and total_response_ids:
                     # For continuation, extend the last turn's data
                     total_response_ids[-1].extend(final_token_ids)
                     if total_response_loss_mask:
-                        total_response_loss_mask[-1].extend([1] * len(final_token_ids))
+                        total_response_loss_mask[-1].extend(final_loss_mask)
                     if total_rollout_logprobs and current_logprobs:
                         total_rollout_logprobs[-1].extend(current_logprobs)
-                elif not total_response_ids:
-                    # First turn stopped immediately - need to initialize with final response data
+                else:
+                    # Start a new assistant turn, including the first-turn-immediate-stop case.
                     if final_token_ids:
-                        total_response_ids = [list(final_token_ids)]
-                        total_response_loss_mask = [[1] * len(final_token_ids)]
+                        total_response_ids.append(list(final_token_ids))
+                        total_response_loss_mask.append(final_loss_mask)
                     if current_logprobs:
-                        total_rollout_logprobs = [current_logprobs]
+                        total_rollout_logprobs.append(current_logprobs)
 
                 # Validate rollout_logprobs completeness: if logprobs are incomplete (missing for some turns),
                 # clear them to disable rollout importance sampling correction (which requires complete logprobs)
@@ -359,7 +463,11 @@ class MultiTurnScheduler(RolloutScheduler, ABC):
                 )
 
             # Prepare next turn
+            response_ids, response_mask = self.get_response_token_data(
+                current_request, response_choice, is_continuation=is_continuation)
             ret = self.step(current_request, response_choice, current_turn)
+            ret.setdefault('response_token_ids', response_ids)
+            ret.setdefault('response_loss_mask', response_mask)
             current_request: 'RolloutInferRequest' = ret['infer_request']
 
             # Track response tokens and masks
@@ -396,6 +504,9 @@ class MultiTurnScheduler(RolloutScheduler, ABC):
                     total_rollout_logprobs[-1].extend(current_logprobs)
                 else:
                     total_rollout_logprobs.append(current_logprobs)
+
+            if total_response_ids:
+                self.set_assistant_message_token_ids(current_request, total_response_ids[-1])
 
             current_turn += 1
 

--- a/swift/template/base.py
+++ b/swift/template/base.py
@@ -964,6 +964,37 @@ class Template(ProcessorMixin):
     def _tokenize(self, context, **kwargs):
         return self.tokenizer(context, return_attention_mask=False, add_special_tokens=False, **kwargs)['input_ids']
 
+    @staticmethod
+    def _get_token_backed_response_ids(response: Context) -> Optional[List[int]]:
+        if isinstance(response, dict):
+            token_ids = response.get('token_ids', response.get('input_ids'))
+        elif isinstance(response, list) and (not response or isinstance(response[0], int)):
+            token_ids = response
+        else:
+            return None
+        if not isinstance(token_ids, list) or any(not isinstance(token_id, int) for token_id in token_ids):
+            return None
+        return list(token_ids)
+
+    def _remove_response_separator_overlap(self, response: Context,
+                                           extra_context_list: Optional[List[Context]]) -> List[Context]:
+        """Keep sampled terminal tokens while removing their overlap from a template separator."""
+        response_ids = self._get_token_backed_response_ids(response)
+        if not response_ids or not extra_context_list:
+            return extra_context_list or []
+        if any(not isinstance(context, str) for context in extra_context_list):
+            return extra_context_list
+
+        separator_ids = []
+        for context in extra_context_list:
+            separator_ids.extend(self._tokenize(context))
+        max_overlap = min(len(response_ids), len(separator_ids))
+        for overlap in range(max_overlap, 0, -1):
+            if response_ids[-overlap:] == separator_ids[:overlap]:
+                remaining_ids = separator_ids[overlap:]
+                return [remaining_ids] if remaining_ids else []
+        return extra_context_list
+
     def replace_tag(self, media_type: Literal['image', 'video', 'audio'], index: int,
                     inputs: StdTemplateInputs) -> List[Context]:
         """Override this function to do your own replace operation.
@@ -1432,6 +1463,7 @@ class Template(ProcessorMixin):
                 response=response,
                 system=system,
                 round0=i)
+            extra_context_list = self._remove_response_separator_overlap(response, extra_context_list)
             res_context_list += extra_context_list
             res_context_types += [extra_context_type] * len(extra_context_list)
         if template_meta.auto_add_bos and sep_token:

--- a/tests/rollout/test_exact_token_io.py
+++ b/tests/rollout/test_exact_token_io.py
@@ -1,0 +1,379 @@
+from copy import deepcopy
+
+import pytest
+
+from swift.infer_engine.protocol import (ChatCompletionResponse, ChatCompletionResponseChoice, ChatMessage, RequestConfig,
+                                         RolloutInferRequest, RolloutOutput, UsageInfo)
+from swift.rollout.agent_loop import run_multi_turn
+from swift.rollout.multi_turn import MultiTurnScheduler
+
+
+class PrefixTokenizer:
+    """Encode the deterministic response prefix used by scheduler tests."""
+
+    def encode(self, text, add_special_tokens=False):
+        """Map the configured prefix to stable token IDs."""
+        return {
+            '<prefix>': [9, 8],
+            '<next-prefix>': [7],
+        }[text]
+
+    def decode(self, token_ids, skip_special_tokens=False):
+        """Expose exact historical IDs as text to scheduler hooks."""
+        return f'decoded:{",".join(map(str, token_ids))}'
+
+
+class ToolResultTokenizer(PrefixTokenizer):
+    """Encode the deterministic tool observation for agentic scheduler tests."""
+
+    def encode(self, text, add_special_tokens=False):
+        """Keep the tool observation separate from model sampled tokens."""
+        if text == 'Result: 3':
+            return [21, 22]
+        return super().encode(text, add_special_tokens=add_special_tokens)
+
+
+class PrefixTemplate:
+    """Resolve response prefix from per-request template arguments."""
+
+    def _get_response_prefix(self, inputs):
+        """Return the request-specific response prefix."""
+        return inputs.chat_template_kwargs.get('response_prefix', '')
+
+
+class Scheduler(MultiTurnScheduler):
+    """Provide the abstract scheduler step for token normalization tests."""
+
+    def step(self, infer_request, response_choice, current_turn):
+        """Return an unchanged request; these tests exercise token normalization only."""
+        return {'infer_request': infer_request}
+
+
+def make_choice(token_ids):
+    """Build an inference response choice containing exact sampled IDs."""
+    return ChatCompletionResponseChoice(
+        0, ChatMessage('assistant', 'sampled text'), 'stop', token_ids=token_ids)
+
+
+def make_request():
+    """Build a request with an explicit deterministic assistant prefix."""
+    return RolloutInferRequest(
+        messages=[{'role': 'user', 'content': 'question'}],
+        chat_template_kwargs={'response_prefix': '<prefix>'})
+
+
+class NonBijectiveTokenizer:
+    """Model a tokenizer whose decode/encode round trip loses token identity."""
+
+    def encode(self, text, add_special_tokens=False):
+        """Return the canonical encoding for text shared by multiple tokenizations."""
+        assert text == 'same text'
+        return [13]
+
+    def decode(self, token_ids, skip_special_tokens=False):
+        """Map distinct tokenizations to the same visible text."""
+        assert token_ids in ([11, 12], [13])
+        return 'same text'
+
+
+def test_text_round_trip_cannot_preserve_sampled_token_ids():
+    """Show why decoded assistant text cannot be the training token source."""
+    tokenizer = NonBijectiveTokenizer()
+    sampled_ids = [11, 12]
+
+    decoded_text = tokenizer.decode(sampled_ids, skip_special_tokens=False)
+    reconstructed_ids = tokenizer.encode(decoded_text, add_special_tokens=False)
+
+    assert decoded_text == tokenizer.decode(reconstructed_ids, skip_special_tokens=False)
+    assert reconstructed_ids != sampled_ids
+
+
+def test_exact_response_token_contract():
+    """Define alignment among deterministic, sampled, mask, and logprob data."""
+    deterministic_prefix_ids = [9, 8]
+    sampled_ids = [11, 12]
+    sampled_logprobs = [-0.2, -0.4]
+
+    response_token_ids = deterministic_prefix_ids + sampled_ids
+    response_loss_mask = [0] * len(deterministic_prefix_ids) + [1] * len(sampled_ids)
+
+    assert len(response_token_ids) == len(response_loss_mask)
+    assert sum(response_loss_mask) == len(sampled_ids)
+    assert len(sampled_logprobs) == sum(response_loss_mask)
+    assert response_token_ids[-len(sampled_ids):] == sampled_ids
+
+
+def test_scheduler_adds_masked_prefix_to_sampled_ids():
+    """Normalize engine sampled IDs into the full assistant token sequence."""
+    scheduler = Scheduler(tokenizer=PrefixTokenizer(), template=PrefixTemplate())
+
+    ids, mask = scheduler.get_response_token_data(make_request(), make_choice([11, 12]))
+
+    assert ids == [9, 8, 11, 12]
+    assert mask == [0, 0, 1, 1]
+
+
+def test_sampled_prefix_values_are_not_mistaken_for_deterministic_prefix():
+    """Preserve sampled actions even when their values equal the template prefix."""
+    scheduler = Scheduler(tokenizer=PrefixTokenizer(), template=PrefixTemplate())
+
+    ids, mask = scheduler.get_response_token_data(make_request(), make_choice([9, 8, 11]))
+
+    assert ids == [9, 8, 9, 8, 11]
+    assert mask == [0, 0, 1, 1, 1]
+
+
+def test_explicit_masked_prefix_is_not_duplicated():
+    """Accept a caller-provided prefix only when its zero mask proves its role."""
+    scheduler = Scheduler(tokenizer=PrefixTokenizer(), template=PrefixTemplate())
+
+    ids, mask = scheduler.get_response_token_data(
+        make_request(),
+        make_choice([11]),
+        response_token_ids=[9, 8, 7],
+        response_loss_mask=[0, 0, 0])
+
+    assert ids == [9, 8, 7]
+    assert mask == [0, 0, 0]
+
+
+def test_continuation_does_not_repeat_response_prefix():
+    """Treat continuation IDs as part of the current assistant message."""
+    scheduler = Scheduler(tokenizer=PrefixTokenizer(), template=PrefixTemplate())
+
+    ids, mask = scheduler.get_response_token_data(
+        make_request(), make_choice([12]), is_continuation=True)
+
+    assert ids == [12]
+    assert mask == [1]
+
+
+@pytest.mark.parametrize('loss_mask', ([1], [2, 1]))
+def test_invalid_response_loss_mask_is_rejected(loss_mask):
+    """Reject masks with a wrong length or values outside the binary contract."""
+    scheduler = Scheduler(tokenizer=PrefixTokenizer(), template=PrefixTemplate())
+
+    with pytest.raises(AssertionError):
+        scheduler.get_response_token_data(
+            make_request(),
+            make_choice([11, 12]),
+            response_token_ids=[11, 12],
+            response_loss_mask=loss_mask)
+
+
+def make_output(token_ids, text, logprobs, finish_reason=None):
+    """Build one fake engine output for the real multi-turn driver."""
+    choice = ChatCompletionResponseChoice(
+        0,
+        ChatMessage('assistant', text),
+        finish_reason,
+        logprobs={'content': [{'logprob': value} for value in logprobs]},
+        token_ids=token_ids)
+    response = ChatCompletionResponse(
+        'fake-model', [choice], UsageInfo(0, len(token_ids), len(token_ids)))
+    return RolloutOutput(response=response)
+
+
+class TwoTurnScheduler(Scheduler):
+    """Stop after the second response while adding a user observation."""
+
+    async def on_turn_end(self, infer_request, response_choice, current_turn):
+        """Expose the first response to the next turn as an observation."""
+        return {'done': current_turn >= 2}
+
+    def step(self, infer_request, response_choice, current_turn):
+        """Append an observation before the next model inference."""
+        infer_request.messages.append({'role': 'user', 'content': 'observation'})
+        return {'infer_request': infer_request}
+
+
+class MutatingPrefixScheduler(TwoTurnScheduler):
+    """Change the next turn's prefix in place while completing the current turn."""
+
+    def step(self, infer_request, response_choice, current_turn):
+        infer_request.chat_template_kwargs['response_prefix'] = '<next-prefix>'
+        return super().step(infer_request, response_choice, current_turn)
+
+
+class TokenHistoryBoundaryScheduler(TwoTurnScheduler):
+    """Record the text-oriented scheduler view at each turn boundary."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize scheduler hook snapshots."""
+        super().__init__(*args, **kwargs)
+        self.hook_messages = []
+
+    async def on_turn_end(self, infer_request, response_choice, current_turn):
+        """Capture scheduler-visible messages before deciding whether to stop."""
+        self.hook_messages.append(deepcopy(infer_request.messages))
+        return await super().on_turn_end(infer_request, response_choice, current_turn)
+
+
+def test_colocate_driver_accumulates_exact_ids_masks_and_logprobs():
+    """Run the real colocate driver with fake engine outputs across two turns."""
+    request = make_request()
+    first_output = make_output([11, 12], 'first', [-0.2, -0.4], finish_reason=None)
+    second_output = make_output([13], 'second', [-0.7], finish_reason='stop')
+    outputs_by_turn = iter([[second_output]])
+
+    def rollout_fn(requests, request_config):
+        """Return the next fake engine output and support distributed empty batches."""
+        if not requests:
+            return []
+        assert requests[0].messages[-1] == {'role': 'user', 'content': 'observation'}
+        return next(outputs_by_turn)
+
+    result = run_multi_turn(
+        [request],
+        [first_output],
+        TwoTurnScheduler(tokenizer=PrefixTokenizer(), template=PrefixTemplate()),
+        rollout_fn,
+        RequestConfig(n=1),
+        max_turns=2)
+
+    assert result[0].response_token_ids == [[9, 8, 11, 12], [9, 8, 13]]
+    assert result[0].response_loss_mask == [[0, 0, 1, 1], [0, 0, 1]]
+    assert result[0].rollout_logprobs == [[-0.2, -0.4], [-0.7]]
+
+
+def test_colocate_completed_turn_uses_prefix_before_scheduler_mutation():
+    """Keep each completed turn bound to the prefix active during its inference."""
+    request = make_request()
+    first_output = make_output([11, 12], 'first', [-0.2, -0.4], finish_reason=None)
+    second_output = make_output([13], 'second', [-0.7], finish_reason='stop')
+
+    def rollout_fn(requests, request_config):
+        if not requests:
+            return []
+        return [second_output]
+
+    result = run_multi_turn(
+        [request],
+        [first_output],
+        MutatingPrefixScheduler(tokenizer=PrefixTokenizer(), template=PrefixTemplate()),
+        rollout_fn,
+        RequestConfig(n=1),
+        max_turns=2)
+
+    assert result[0].response_token_ids == [[9, 8, 11, 12], [7, 13]]
+    assert result[0].response_loss_mask == [[0, 0, 1, 1], [0, 1]]
+
+
+def test_colocate_driver_preserves_token_history_across_scheduler_boundary():
+    """Keep exact IDs for inference while presenting decoded text to scheduler hooks."""
+    request = make_request()
+    scheduler = TokenHistoryBoundaryScheduler(tokenizer=PrefixTokenizer(), template=PrefixTemplate())
+    first_output = make_output([11, 12], 'first action', [-0.2, -0.4], finish_reason=None)
+    second_output = make_output([13], 'second action', [-0.7], finish_reason='stop')
+    inference_messages = []
+
+    def rollout_fn(requests, request_config):
+        """Capture the exact next-turn inference history."""
+        if not requests:
+            return []
+        inference_messages.append(deepcopy(requests[0].messages))
+        return [second_output]
+
+    result = run_multi_turn(
+        [request],
+        [first_output],
+        scheduler,
+        rollout_fn,
+        RequestConfig(n=1),
+        max_turns=2)
+
+    assert scheduler.hook_messages[0][-1] == {'role': 'assistant', 'content': 'first action'}
+    assert inference_messages[0][1] == {'role': 'assistant', 'content': [9, 8, 11, 12]}
+    assert scheduler.hook_messages[1][1] == {
+        'role': 'assistant',
+        'content': 'decoded:9,8,11,12',
+    }
+    assert scheduler.hook_messages[1][-1] == {'role': 'assistant', 'content': 'second action'}
+    assert result[0].response_token_ids == [[9, 8, 11, 12], [9, 8, 13]]
+    assert result[0].response_loss_mask == [[0, 0, 1, 1], [0, 0, 1]]
+
+
+class ContinuationScheduler(TwoTurnScheduler):
+    """Continue generating the same assistant message on the second turn."""
+
+    def step(self, infer_request, response_choice, current_turn):
+        """Keep the assistant message last so the next response is a continuation."""
+        return {'infer_request': infer_request}
+
+
+class ToolCallScheduler(Scheduler):
+    """Model the exact-token contract of an agentic tool-call scheduler."""
+
+    def check_finished(self, infer_request, response_choice, current_turn):
+        """Continue after a tool call and finish on the next model response."""
+        return current_turn >= 2
+
+    def step(self, infer_request, response_choice, current_turn):
+        """Append a masked tool observation after sampled model tokens."""
+        infer_request.messages[-1]['content'] += 'Result: 3'
+        token_ids = list(response_choice.token_ids)
+        tool_result_ids = self.tokenizer.encode('Result: 3', add_special_tokens=False)
+        return {
+            'infer_request': infer_request,
+            'response_token_ids': token_ids + tool_result_ids,
+            'response_loss_mask': [1] * len(token_ids) + [0] * len(tool_result_ids),
+        }
+
+
+def test_tool_call_scheduler_preserves_sampled_tokens_and_masks_tool_result():
+    """Keep tool observations out of the loss while preserving exact history."""
+    request = make_request()
+    first_output = make_output(
+        [11, 12], 'Action: calculator\nAction Input: 1 + 2\n', [-0.2, -0.4], finish_reason=None)
+    second_output = make_output([31, 32], 'The answer is 3', [-0.7, -0.8], finish_reason='stop')
+    inference_messages = []
+
+    def rollout_fn(requests, request_config):
+        """Capture the token-backed assistant history before the final turn."""
+        if not requests:
+            return []
+        inference_messages.append(deepcopy(requests[0].messages))
+        return [second_output]
+
+    result = run_multi_turn(
+        [request],
+        [first_output],
+        ToolCallScheduler(tokenizer=ToolResultTokenizer(), template=PrefixTemplate()),
+        rollout_fn,
+        RequestConfig(n=1),
+        max_turns=2)
+
+    assert inference_messages[0][1] == {
+        'role': 'assistant',
+        'content': [9, 8, 11, 12, 21, 22],
+    }
+    assert result[0].response_token_ids == [[9, 8, 11, 12, 21, 22, 31, 32]]
+    assert result[0].response_loss_mask == [[0, 0, 1, 1, 0, 0, 1, 1]]
+    assert result[0].rollout_logprobs == [[-0.2, -0.4, -0.7, -0.8]]
+
+
+def test_colocate_driver_merges_continuation_without_repeating_prefix():
+    """Merge exact continuation data into the current assistant token turn."""
+    request = make_request()
+    first_output = make_output([11], 'first', [-0.2], finish_reason=None)
+    second_output = make_output([12], ' continued', [-0.4], finish_reason='stop')
+    outputs_by_turn = iter([[second_output]])
+
+    def rollout_fn(requests, request_config):
+        """Return the continuation output and support distributed empty batches."""
+        if not requests:
+            return []
+        assert requests[0].messages[-1] == {'role': 'assistant', 'content': [9, 8, 11]}
+        return next(outputs_by_turn)
+
+    result = run_multi_turn(
+        [request],
+        [first_output],
+        ContinuationScheduler(tokenizer=PrefixTokenizer(), template=PrefixTemplate()),
+        rollout_fn,
+        RequestConfig(n=1),
+        max_turns=2)
+
+    assert result[0].response_token_ids == [[9, 8, 11, 12]]
+    assert result[0].response_loss_mask == [[0, 0, 1, 1]]
+    assert result[0].rollout_logprobs == [[-0.2, -0.4]]

--- a/tests/rollout/test_server_exact_token_io.py
+++ b/tests/rollout/test_server_exact_token_io.py
@@ -1,0 +1,232 @@
+import asyncio
+import sys
+from contextlib import nullcontext
+from copy import deepcopy
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from swift.infer_engine.protocol import (
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatMessage,
+    RequestConfig,
+    RolloutInferRequest,
+    UsageInfo,
+)
+from swift.rl_core.data import GRPOBatch, GRPOSample
+from swift.rlhf_trainers.grpo_trainer import GRPOTrainer
+from swift.rollout.multi_turn import MultiTurnScheduler, RolloutScheduler
+from swift.template import Template as SwiftTemplate
+
+
+class PrefixTokenizer:
+
+    def encode(self, text, add_special_tokens=False):
+        assert text == '<prefix>'
+        return [9, 8]
+
+    def decode(self, token_ids, skip_special_tokens=False):
+        return f'decoded:{",".join(map(str, token_ids))}'
+
+
+class SeparatorTokenizer:
+    mapping = {
+        '<end>\n': [9, 10],
+        '<pair>\n': [7, 8, 10],
+    }
+
+    def __call__(self, text, **kwargs):
+        return {'input_ids': self.mapping[text]}
+
+
+class PrefixTemplate:
+
+    def _get_response_prefix(self, inputs):
+        return inputs.chat_template_kwargs.get('response_prefix', '')
+
+
+class ExactTokenTemplate:
+    padding_free = False
+    enable_thinking = None
+
+    def encode(self, data, **kwargs):
+        content = data['messages'][-1]['content']
+        if isinstance(content, dict):
+            response_ids = content['token_ids']
+            response_mask = content['loss_scale']
+        else:
+            response_ids = [13]
+            response_mask = [1]
+        return {
+            'input_ids': [100, *response_ids],
+            'labels': [-100, *[token_id if mask else -100
+                               for token_id, mask in zip(response_ids, response_mask)]],
+        }
+
+    def data_collator(self, encoded_data, padding_to=None):
+        self.encoded_data = encoded_data
+        return {
+            key: torch.tensor([item[key] for item in encoded_data])
+            for key in ('input_ids', 'labels')
+        }
+
+
+class AsyncTwoTurnEngine:
+
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.inference_messages = []
+
+    async def infer_async(self, infer_request, request_config, **kwargs):
+        self.inference_messages.append(deepcopy(infer_request.messages))
+        return next(self.responses)
+
+
+class ServerBoundaryScheduler(MultiTurnScheduler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.hook_messages = []
+
+    async def on_turn_end(self, infer_request, response_choice, current_turn):
+        self.hook_messages.append(deepcopy(infer_request.messages))
+        return {}
+
+    def check_finished(self, infer_request, response_choice, current_turn):
+        return current_turn >= 2
+
+    def step(self, infer_request, response_choice, current_turn):
+        infer_request.messages.append({'role': 'user', 'content': 'observation'})
+        return {'infer_request': infer_request}
+
+
+def make_response(token_ids, text, logprobs, finish_reason=None):
+    choice = ChatCompletionResponseChoice(
+        0,
+        ChatMessage('assistant', text),
+        finish_reason,
+        logprobs={'content': [{'logprob': value} for value in logprobs]},
+        token_ids=token_ids)
+    return ChatCompletionResponse('fake-model', [choice], UsageInfo(0, len(token_ids), len(token_ids)))
+
+
+def test_server_scheduler_preserves_exact_token_history():
+    request = RolloutInferRequest(
+        messages=[{'role': 'user', 'content': 'question'}],
+        chat_template_kwargs={'response_prefix': '<prefix>'})
+    engine = AsyncTwoTurnEngine([
+        make_response([11, 12], 'first action', [-0.2, -0.4]),
+        make_response([13], 'second action', [-0.7], finish_reason='stop'),
+    ])
+    scheduler = ServerBoundaryScheduler(
+        infer_engine=engine, tokenizer=PrefixTokenizer(), template=PrefixTemplate())
+
+    result = asyncio.run(scheduler.run(request, RequestConfig(n=1)))
+
+    assert scheduler.hook_messages[0][-1] == {'role': 'assistant', 'content': 'first action'}
+    assert engine.inference_messages[1][1] == {'role': 'assistant', 'content': [9, 8, 11, 12]}
+    assert scheduler.hook_messages[1][1] == {
+        'role': 'assistant',
+        'content': 'decoded:9,8,11,12',
+    }
+    assert scheduler.hook_messages[1][-1] == {'role': 'assistant', 'content': 'second action'}
+    assert result.response_token_ids == [[9, 8, 11, 12], [9, 8, 13]]
+    assert result.response_loss_mask == [[0, 0, 1, 1], [0, 0, 1]]
+    assert result.rollout_logprobs == [[-0.2, -0.4], [-0.7]]
+
+
+def test_multimodal_chunk_rebuild_preserves_exact_response_tokens():
+    sample = GRPOSample(
+        messages=[
+            {'role': 'user', 'content': 'question'},
+            {'role': 'assistant', 'content': 'decoded response'},
+        ],
+        images=[object()],
+        response_token_ids=[[9, 8, 11, 12]],
+        response_loss_mask=[[0, 0, 1, 1]])
+    batch = GRPOBatch(
+        completion_mask=torch.ones((1, 5)),
+        truncated_mask=torch.zeros(1),
+        seq_lengths=torch.tensor([5]))
+    template = ExactTokenTemplate()
+    trainer = SimpleNamespace(
+        is_multimodal=True,
+        template=template,
+        accelerator=SimpleNamespace(device=torch.device('cpu')),
+        _template_context=lambda template: nullcontext())
+
+    model_inputs, _ = GRPOTrainer.get_chunked_inputs(
+        trainer, {'input_ids': torch.zeros((1, 5), dtype=torch.long)}, batch, 0, 1, origin_data=[sample])
+
+    assert model_inputs['input_ids'][0].tolist() == [100, 9, 8, 11, 12]
+    assert template.encoded_data[0]['labels'] == [-100, -100, -100, 11, 12]
+
+
+def test_token_backed_response_deduplicates_template_separator_overlap():
+    template = object.__new__(SwiftTemplate)
+    template.processor = SeparatorTokenizer()
+
+    assert template._remove_response_separator_overlap(
+        {'token_ids': [1, 9], 'loss_scale': [1, 1]}, ['<end>\n']) == [[10]]
+    assert template._remove_response_separator_overlap(
+        {'token_ids': [1, 7, 8], 'loss_scale': [1, 1, 1]}, ['<pair>\n']) == [[10]]
+    assert template._remove_response_separator_overlap([1, 9, 10], ['<end>\n']) == []
+    no_overlap = ['<end>\n']
+    assert template._remove_response_separator_overlap({'token_ids': [1, 2]}, no_overlap) is no_overlap
+    assert template._remove_response_separator_overlap('text response', no_overlap) is no_overlap
+
+
+class RayDriverProbeScheduler(RolloutScheduler):
+    pass
+
+
+@pytest.mark.parametrize('trainer_name', ['GRPOTrainer', 'GKDTrainer'])
+def test_ray_driver_scheduler_preserves_deterministic_response_prefix(monkeypatch, trainer_name):
+    try:
+        import ray  # noqa: F401
+    except ModuleNotFoundError:
+        ray_module = ModuleType('ray')
+        ray_module.__path__ = []
+        runtime_env_module = ModuleType('ray.runtime_env')
+        runtime_env_module.RuntimeEnv = type('RuntimeEnv', (), {})
+        util_module = ModuleType('ray.util')
+        util_module.__path__ = []
+        scheduling_module = ModuleType('ray.util.scheduling_strategies')
+        scheduling_module.PlacementGroupSchedulingStrategy = type('PlacementGroupSchedulingStrategy', (), {})
+        ray_module.util = util_module
+        monkeypatch.setitem(sys.modules, 'ray', ray_module)
+        monkeypatch.setitem(sys.modules, 'ray.runtime_env', runtime_env_module)
+        monkeypatch.setitem(sys.modules, 'ray.util', util_module)
+        monkeypatch.setitem(sys.modules, 'ray.util.scheduling_strategies', scheduling_module)
+
+    import swift.ray.megatron.gkd_trainer as gkd_module
+    import swift.ray.megatron.grpo_trainer as grpo_module
+
+    scheduler_name = 'ray_driver_exact_token_probe'
+    monkeypatch.setitem(grpo_module.multi_turns, scheduler_name, RayDriverProbeScheduler)
+    monkeypatch.setitem(gkd_module.multi_turns, scheduler_name, RayDriverProbeScheduler)
+
+    trainer_module = grpo_module if trainer_name == 'GRPOTrainer' else gkd_module
+    trainer_cls = getattr(trainer_module, trainer_name)
+    tokenizer = PrefixTokenizer()
+    template = PrefixTemplate()
+    template.tokenizer = tokenizer
+
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.args = SimpleNamespace(multi_turn_scheduler=scheduler_name, max_turns=2, gym_env=None)
+    trainer.template = template
+    trainer._prepare_multi_turn()
+    scheduler = trainer._multi_turn_scheduler
+
+    assert scheduler.infer_engine is None
+    assert scheduler.tokenizer is tokenizer
+    assert scheduler._template is template
+
+    request = SimpleNamespace(chat_template_kwargs={'response_prefix': '<prefix>'}, messages=[])
+    response_choice = SimpleNamespace(token_ids=[11, 12])
+    token_ids, loss_mask = scheduler.get_response_token_data(request, response_choice)
+
+    assert token_ids == [9, 8, 11, 12]
+    assert loss_mask == [0, 0, 1, 1]


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Problem

Agentic multi-step rollouts can decode sampled assistant token IDs into text and later re-encode that text when constructing subsequent inference history or training inputs. Tokenization is not generally bijective, so this round trip can change the token sequence. The resulting rollout may train on tokens different from those sampled during inference, especially across scheduler mutations, tool observations, deterministic response prefixes, and multimodal chunk rebuilds.

## Fix

- Keep engine-sampled token IDs as the source of truth across colocate and server multi-turn rollouts.
- Represent deterministic response prefixes and scheduler-added content with aligned loss masks.
- Preserve token-backed assistant history across scheduler hooks and agentic continuations.
- Reuse exact response tokens when rebuilding multimodal training chunks.
- Forward the template and tokenizer through Ray Megatron GRPO/GKD scheduler setup.
- Avoid duplicating template separators already present in token-backed responses.
- Add regression coverage for non-bijective tokenization, prefixes, continuations, tool calls, server/colocate paths, multimodal chunks, and Ray schedulers.

## Experiment results

- Python 3.12 static compilation passes for all changed source and test files.
- The patch includes focused regression tests under tests/rollout/test_exact_token_io.py and tests/rollout/test_server_exact_token_io.py.
- Full pytest execution was not available in the local preparation environment because it did not contain a compatible torch/transformers ms-swift test stack. The PR is opened as a draft pending CI or a compatible test environment.