### PR TITLE
Fix NaN for full-parameter SFT with DeepSpeed ZeRO-1/2 on torch<2.9 (AdamW int32 flat-partition overflow)

### DIFF
--- a/swift/trainers/mixin.py
+++ b/swift/trainers/mixin.py
@@ -1108,10 +1108,38 @@ class SwiftMixin:
     def create_optimizer_and_scheduler(self, num_training_steps: int):
         self.optimizer_callback.create_optimizer_and_scheduler(num_training_steps)
 
+    def _disable_foreach_for_deepspeed(self):
+        """Disable foreach for AdamW on torch<2.9 with DeepSpeed ZeRO-1/2 (no-op otherwise).
+
+        torch<2.9 `torch._foreach_*` kernels use a signed int32 element index and write out
+        of bounds when a flat tensor has numel > INT32_MAX.  DeepSpeed ZeRO-1/2 flattens each
+        param group into one FP32 flat partition per DP rank; for full-parameter SFT of large
+        models that partition can exceed the boundary and corrupt memory (loss NaN).  Falling
+        back to the single-tensor path (foreach=False) avoids the bug without changing the
+        optimizer's group layout or checkpoint format, and costs about the same as foreach
+        because ZeRO feeds the base optimizer a few large flat tensors rather than many
+        small ones (measured ~2% on the 2 GiB flat).
+        """
+        if version.parse(torch.__version__) >= version.parse('2.9.0'):
+            return
+        ds_config = getattr(self.args, 'deepspeed', None) or {}
+        # ZeRO-3 partitions parameters individually (no oversized flat tensor); only
+        # stage 1/2 flatten a whole group into one FP32 partition per rank.
+        if not isinstance(ds_config, dict) or ds_config.get('zero_optimization', {}).get('stage') not in (1, 2):
+            return
+        optimizer = self.optimizer
+        if optimizer is None or not isinstance(optimizer, torch.optim.AdamW):
+            return
+        optimizer.defaults['foreach'] = False
+        for group in optimizer.param_groups:
+            group['foreach'] = False
+        logger.info('[adamw-foreach] disabled foreach for DeepSpeed ZeRO on torch<2.9.')
+
     def create_optimizer(self, model=None):
         self._optimizer_ori = self.optimizer = self.optimizer_callback.create_optimizer(model=model)
         if self.optimizer is not None:
             self.optimizer.param_groups = [pg for pg in self.optimizer.param_groups if len(pg['params']) > 0]
+            self._disable_foreach_for_deepspeed()
         return self.optimizer
 
     def create_scheduler(self, num_training_steps: int, optimizer=None):


### PR DESCRIPTION
### Problem

On torch<2.9, `torch._foreach_*` kernels index tensors with signed int32 elements and write out of bounds when a flat tensor exceeds `INT32_MAX` (2,147,483,647) elements. DeepSpeed ZeRO-1/2 flattens each optimizer param group into one FP32 flat partition per DP rank, so full-parameter training of large models crosses this boundary and the AdamW step corrupts memory — loss turns NaN right after the first optimizer step.

Reproduced with Qwen3.5-9B full SFT (`--optim adamw_torch --deepspeed zero1`, bf16, 4×A100):

- an independent `torch._foreach_add_` probe on a 2,238,382,272-element tensor writes 65,344 elements past the end (guard corrupted, 3/3 repeats); `AdamW(foreach=False)` and a chunked reference are clean;
- training loss is 0.24 at step 1 and NaN from step 2; the same command on 8 GPUs (partition below the boundary) stays finite.

### Fix

In `SwiftMixin.create_optimizer`, after the HF Trainer creates the optimizer and before DeepSpeed receives it: on `torch<2.9` + ZeRO stage 1/2 + `torch.optim.AdamW`, set `foreach=False` on the optimizer defaults and every param group so the update takes the single-tensor path. ZeRO-3 (per-parameter partitioning, no oversized flat), torch≥2.9, and non-AdamW optimizers are untouched.

The fallback costs ~2% on a 2 GiB flat (ZeRO feeds the base optimizer a few large flat tensors, where foreach has little advantage), and it does not change the optimizer's group layout or checkpoint format.

### Verification

| Run                         | Loss                                         |
| --------------------------- | -------------------------------------------- |
| 4×A100, fix disabled        | 0.24 → **NaN** (step 2+)                     |
| 4×A100, fix enabled         | 0.24 → 0.15 → 0.11 → 1.20 → 0.32, **no NaN** |
| 8×A100, fix enabled (no-op) | all finite, **no NaN**                       |
