### PR TITLE
feat(xpu): support vllm_kunlun backend

### DIFF
--- a/swift/pipelines/infer/rollout.py
+++ b/swift/pipelines/infer/rollout.py
@@ -47,7 +47,7 @@ from swift.rlhf_trainers.utils import (VLLM_LORA_INT_ID, VLLM_LORA_NAME, VLLM_LO
                                        patch_vllm_moe_model_weight_loader, vllm_supports_lora_load_inplace)
 from swift.rollout import RolloutScheduler, multi_turns
 from swift.utils import (gc_collect, get_logger, get_physical_device_count, get_seed, ipc_collect, is_torch_rocm,
-                         is_vllm_ascend_available, is_vllm_metax_available, synchronize)
+                         is_vllm_ascend_available, is_vllm_kunlun_available, is_vllm_metax_available, synchronize)
 from ..base import SwiftPipeline
 
 try:
@@ -60,6 +60,9 @@ try:
     from vllm.distributed.utils import StatelessProcessGroup
     if is_vllm_ascend_available():
         from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator as PyNcclCommunicator  # noqa
+
+    if is_vllm_kunlun_available():
+        from vllm_kunlun.distributed.py_kunlun_communicator import PyKunlunCommunicator as PyNcclCommunicator  # noqa
 
     if is_vllm_metax_available():
         import vllm_metax.patch

--- a/swift/rlhf_trainers/vllm_client.py
+++ b/swift/rlhf_trainers/vllm_client.py
@@ -16,8 +16,8 @@ from urllib.parse import urlparse
 from swift.infer_engine import AdapterRequest, RequestConfig
 from swift.infer_engine.protocol import ChatCompletionResponse, RolloutInferRequest, RolloutOutput
 from swift.metrics import Metric
-from swift.utils import (is_trl_available, is_vllm_ascend_available, is_vllm_available, is_vllm_metax_available,
-                         synchronize)
+from swift.utils import (is_trl_available, is_vllm_ascend_available, is_vllm_available, is_vllm_kunlun_available,
+                         is_vllm_metax_available, synchronize)
 from .utils import (broadcast_tensor_for_vllm_weight_sync, format_host_for_url, is_valid_ipv6_address,
                     peft_config_to_dict, resolve_hostname)
 
@@ -27,6 +27,9 @@ if is_vllm_available():
 
     if is_vllm_ascend_available():
         from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator as PyNcclCommunicator  # noqa
+
+    if is_vllm_kunlun_available():
+        from vllm_kunlun.distributed.py_kunlun_communicator import PyKunlunCommunicator as PyNcclCommunicator  # noqa
 
     if is_vllm_metax_available():
         import vllm_metax.patch

--- a/swift/utils/__init__.py
+++ b/swift/utils/__init__.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .import_utils import (is_flash_attn_2_available, is_flash_attn_3_available, is_liger_available,
                                is_lmdeploy_available, is_megatron_available, is_swanlab_available, is_trl_available,
                                is_unsloth_available, is_vllm_ascend_available, is_vllm_available,
-                               is_vllm_metax_available, is_wandb_available)
+                               is_vllm_kunlun_available, is_vllm_metax_available, is_wandb_available)
     from .io_utils import (LAST_CHECKPOINT_SYMLINK, JsonlWriter, append_to_jsonl, get_file_mm_type, read_from_jsonl,
                            update_last_checkpoint_symlink, write_to_jsonl)
     from .logger import get_logger, ms_logger_context
@@ -50,7 +50,8 @@ else:
         'import_utils': [
             'is_flash_attn_2_available', 'is_flash_attn_3_available', 'is_liger_available', 'is_lmdeploy_available',
             'is_megatron_available', 'is_swanlab_available', 'is_trl_available', 'is_unsloth_available',
-            'is_vllm_ascend_available', 'is_vllm_available', 'is_vllm_metax_available', 'is_wandb_available'
+            'is_vllm_ascend_available', 'is_vllm_available', 'is_vllm_kunlun_available', 'is_vllm_metax_available',
+            'is_wandb_available'
         ],
         'io_utils': [
             'JsonlWriter', 'LAST_CHECKPOINT_SYMLINK', 'append_to_jsonl', 'get_file_mm_type', 'read_from_jsonl',

--- a/swift/utils/import_utils.py
+++ b/swift/utils/import_utils.py
@@ -20,6 +20,10 @@ def is_vllm_metax_available():
     return importlib.util.find_spec('vllm_metax') is not None
 
 
+def is_vllm_kunlun_available():
+    return importlib.util.find_spec('vllm_kunlun') is not None
+
+
 def is_lmdeploy_available():
     return importlib.util.find_spec('lmdeploy') is not None
 


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Add support for the `vllm_kunlun` plugin (Kunlunxin XPU backend for vLLM), following the existing `vllm_ascend` / `vllm_metax` pattern:

- `swift/utils/import_utils.py`: add `is_vllm_kunlun_available()`.
- `swift/utils/__init__.py`: export it (both `TYPE_CHECKING` and lazy import map).
- `swift/pipelines/infer/rollout.py` and `swift/rlhf_trainers/vllm_client.py`: when `vllm_kunlun` is installed, use `PyKunlunCommunicator` as `PyNcclCommunicator` for weight-sync communication.

No behavior change on other backends: the new import path is only taken when `vllm_kunlun` is importable.

## Experiment results

N/A (import-level device backend adaptation).