### PR TITLE
Support mixed text and raw-token rollout content in Swift template

### DIFF
--- a/docs/source/Instruction/Command-line-parameters.md
+++ b/docs/source/Instruction/Command-line-parameters.md
@@ -157,6 +157,7 @@
   - 注意：eos_token会在输出respsone中被删除，额外停止词会在输出中保留。
 - logprobs: 是否输出logprobs，默认为False。
 - top_logprobs: 输出top_logprobs的数量，默认为None。
+- detokenize: 仅用于vLLM，是否将token解码为文本。默认为`None`，保留后端默认行为。部署时可设置`--detokenize false`，请求可覆盖该默认值。关闭后文本输出为空，但保留token ID和logprobs；跳过自动字符串停止词，保留token级停止，不支持显式字符串stop。
 - structured_outputs_regex: 结构化输出（引导解码）的正则表达式模式。设置后，模型生成将被约束为匹配指定的正则表达式模式。仅在`infer_backend`为`vllm`时生效。默认为`None`。
 
 ### 量化参数

--- a/docs/source_en/Instruction/Command-line-parameters.md
+++ b/docs/source_en/Instruction/Command-line-parameters.md
@@ -159,6 +159,7 @@ Refer to the [generation_config](https://huggingface.co/docs/transformers/main_c
   - Note: The `eos_token` is removed from the output response, while additional stop words are preserved in the output.
 - logprobs: Whether to return log probabilities. Default is `False`.
 - top_logprobs: Number of top log probabilities to return. Default is `None`.
+- detokenize: vLLM only. Whether to decode tokens into text. Defaults to `None` (backend default). Set `--detokenize false` when deploying; individual requests may override it. Disabling decoding leaves text output empty while preserving token IDs and logprobs. Automatic string stops are omitted, token-level stopping is retained, and explicit string stops are not supported.
 - structured_outputs_regex: A regular expression pattern for structured outputs (guided decoding). When set, the model's generation is constrained to match the specified regex pattern. Only effective when `infer_backend` is `vllm`. Default is `None`.
 
 ### Quantization Arguments

--- a/swift/arguments/base_args/generation_args.py
+++ b/swift/arguments/base_args/generation_args.py
@@ -25,6 +25,8 @@ class GenerationArguments:
         repetition_penalty (Optional[float]): The penalty applied to repeated tokens. A value of 1.0 means no penalty.
             Defaults to None (reads from 'generation_config.json').
         num_beams (Optional[int]): The number of beams to use for beam search. Defaults to 1.
+        detokenize (Optional[bool]): Whether vLLM decodes tokens to text. Defaults to None (backend default).
+            False disables text decoding and automatic string stops; explicit string stops are not supported.
         stream (bool): Whether to enable streaming output. Defaults to None, which is `True` for interactive mode and
             `False` for batch inference. Note: For ms-swift < 3.6, the default is `False`.
         stop_words (List[str]): A list of extra stop words, in addition to the end-of-sequence token. Note: The
@@ -46,6 +48,8 @@ class GenerationArguments:
     top_p: Optional[float] = None
     repetition_penalty: Optional[float] = None
     num_beams: int = 1
+    # vLLM only. None preserves the backend default; requests may override this value.
+    detokenize: Optional[bool] = None
 
     stream: Optional[bool] = None
     stop_words: List[str] = field(default_factory=list)
@@ -68,6 +72,7 @@ class GenerationArguments:
             top_p=self.top_p,
             top_k=self.top_k,
             num_beams=self.num_beams,
+            detokenize=self.detokenize,
             stop=self.stop_words,
             stream=self.stream,
             repetition_penalty=self.repetition_penalty,

--- a/swift/infer_engine/protocol.py
+++ b/swift/infer_engine/protocol.py
@@ -201,6 +201,8 @@ class RequestConfig:
     logprobs: bool = False
     top_logprobs: Optional[int] = None
     prompt_logprobs: Optional[int] = None
+    # vLLM only. None inherits the deployment default (normally True).
+    detokenize: Optional[bool] = None
 
     n: int = 1
     best_of: Optional[int] = None

--- a/swift/infer_engine/vllm_engine.py
+++ b/swift/infer_engine/vllm_engine.py
@@ -428,7 +428,9 @@ class VllmEngine(InferEngine):
     def _add_stop_words(self, generation_config: SamplingParams, request_config: RequestConfig) -> None:
         template_meta = self.template.template_meta
         stop_words = (request_config.stop or []) + (self.generation_config.stop or []) + template_meta.stop_words
-        generation_config.stop = self._get_stop_words(stop_words)
+        if not generation_config.detokenize and request_config.stop:
+            raise ValueError('String stop words require detokenize=True.')
+        generation_config.stop = self._get_stop_words(stop_words) if generation_config.detokenize else []
         # stop parameter is not effective in v1 engine (test version: vllm 0.8.5.post)
         generation_config.stop_token_ids = self._get_stop_token_ids(stop_words)
 
@@ -527,6 +529,8 @@ class VllmEngine(InferEngine):
 
     def _prepare_generation_config(self, request_config: RequestConfig) -> SamplingParams:
         kwargs = {'max_tokens': request_config.max_tokens}
+        if request_config.detokenize is not None:
+            kwargs['detokenize'] = request_config.detokenize
         for key in ['temperature', 'top_k', 'top_p', 'min_p', 'repetition_penalty']:
             new_value = getattr(request_config, key)
             if new_value is None:

--- a/swift/template/base.py
+++ b/swift/template/base.py
@@ -1421,13 +1421,30 @@ class Template(ProcessorMixin):
                 # and here we avoid adding <|user|>.
                 response_content = response
                 if not isinstance(response_content, str):
-                    if isinstance(response_content, list) and response_content and isinstance(
-                            response_content[-1], str):
-                        response_content = response_content[-1]
-                    else:
-                        token_ids = response_content if isinstance(response_content,
-                                                                   list) else response_content['token_ids']
+                    if isinstance(response_content, list):
+                        if response_content and isinstance(response_content[-1], str):
+                            response_content = response_content[-1]
+                        elif (response_content and isinstance(response_content[-1], dict)
+                              and 'token_ids' in response_content[-1]):
+                            token_ids = response_content[-1]['token_ids']
+                            if (not isinstance(token_ids, list)
+                                    or any(not isinstance(token_id, int) for token_id in token_ids)):
+                                raise TypeError(f'Invalid token_ids in mixed response content: {token_ids!r}')
+                            response_content = self.tokenizer.decode(token_ids[-20:])
+                        elif all(isinstance(token_id, int) for token_id in response_content):
+                            response_content = self.tokenizer.decode(response_content[-20:])
+                        else:
+                            raise TypeError(f'Unsupported response content list: {response_content!r}')
+                    elif isinstance(response_content, dict) and 'token_ids' in response_content:
+                        token_ids = response_content['token_ids']
+                        if (not isinstance(token_ids, list)
+                                or any(not isinstance(token_id, int) for token_id in token_ids)):
+                            raise TypeError(f'Invalid token_ids in response content: {token_ids!r}')
                         response_content = self.tokenizer.decode(token_ids[-20:])
+                    else:
+                        raise TypeError(
+                            f'Unsupported response content: type={type(response_content).__name__}, '
+                            f'value={response_content!r}')
                 endswith_stop_words = any(
                     response_content.endswith(stop_word) for stop_word in template_meta.stop_words
                     if isinstance(stop_word, str))

--- a/swift/template/base.py
+++ b/swift/template/base.py
@@ -1442,9 +1442,8 @@ class Template(ProcessorMixin):
                             raise TypeError(f'Invalid token_ids in response content: {token_ids!r}')
                         response_content = self.tokenizer.decode(token_ids[-20:])
                     else:
-                        raise TypeError(
-                            f'Unsupported response content: type={type(response_content).__name__}, '
-                            f'value={response_content!r}')
+                        raise TypeError(f'Unsupported response content: type={type(response_content).__name__}, '
+                                        f'value={response_content!r}')
                 endswith_stop_words = any(
                     response_content.endswith(stop_word) for stop_word in template_meta.stop_words
                     if isinstance(stop_word, str))

--- a/tests/general/test_template_mixed_rollout.py
+++ b/tests/general/test_template_mixed_rollout.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+
+import pytest
+
+from swift.template import StdTemplateInputs, Template
+
+
+class RecordingTokenizer:
+
+    def __init__(self):
+        self.decoded_ids = []
+
+    def decode(self, token_ids, skip_special_tokens=False):
+        self.decoded_ids.append(list(token_ids))
+        return 'decoded response'
+
+
+class RecordingTemplate(Template):
+
+    def _concat_context_list(self, context_list, res_context_list, res_context_type, **kwargs):
+        response = kwargs.get('response')
+        if response is not None:
+            self.recorded_responses.append(response)
+        return super()._concat_context_list(context_list, res_context_list, res_context_type, **kwargs)
+
+
+def make_template():
+    template = object.__new__(RecordingTemplate)
+    template.processor = RecordingTokenizer()
+    template.template_meta = SimpleNamespace(
+        auto_add_bos=False,
+        is_post_system=False,
+        prefix=[],
+        prompt=['{{QUERY}}'],
+        suffix=[],
+        stop_words=[],
+        support_multi_round=True,
+    )
+    template.use_chat_template = False
+    template.template_backend = 'swift'
+    template.mode = 'train'
+    template.task_type = 'causal_lm'
+    template.response_prefix = None
+    template._loss_scale = 'default'
+    template._loss_scale_cache = {}
+    template.is_binary_loss_scale = None
+    template.recorded_responses = []
+    return template
+
+
+def encode_response(response):
+    template = make_template()
+    inputs = StdTemplateInputs(messages=[
+        {'role': 'user', 'content': 'question'},
+        {'role': 'assistant', 'content': response},
+    ])
+    template._swift_encode(inputs)
+    return template
+
+
+def test_swift_encode_supports_mixed_text_and_raw_token_response():
+    response = [
+        'existing rollout content',
+        {
+            'loss_scale': [0] * 25,
+            'token_ids': list(range(25)),
+        },
+    ]
+
+    template = encode_response(response)
+
+    assert template.tokenizer.decoded_ids == [list(range(5, 25))]
+    assert template.recorded_responses == [response]
+    assert template.recorded_responses[0] is response
+
+
+@pytest.mark.parametrize('response, expected_decoded_ids', [
+    ('plain text response', []),
+    (['previous response', 'plain text response'], []),
+    ([1, 2, 3], [[1, 2, 3]]),
+    ({'loss_scale': [1, 1, 1], 'token_ids': [1, 2, 3]}, [[1, 2, 3]]),
+])
+def test_swift_encode_preserves_existing_response_types(response, expected_decoded_ids):
+    template = encode_response(response)
+
+    assert template.tokenizer.decoded_ids == expected_decoded_ids
+    assert template.recorded_responses == [response]
+    assert template.recorded_responses[0] is response

--- a/tests/general/test_template_mixed_rollout.py
+++ b/tests/general/test_template_mixed_rollout.py
@@ -1,6 +1,5 @@
-from types import SimpleNamespace
-
 import pytest
+from types import SimpleNamespace
 
 from swift.template import StdTemplateInputs, Template
 
@@ -51,8 +50,14 @@ def make_template():
 def encode_response(response):
     template = make_template()
     inputs = StdTemplateInputs(messages=[
-        {'role': 'user', 'content': 'question'},
-        {'role': 'assistant', 'content': response},
+        {
+            'role': 'user',
+            'content': 'question'
+        },
+        {
+            'role': 'assistant',
+            'content': response
+        },
     ])
     template._swift_encode(inputs)
     return template
@@ -78,7 +83,10 @@ def test_swift_encode_supports_mixed_text_and_raw_token_response():
     ('plain text response', []),
     (['previous response', 'plain text response'], []),
     ([1, 2, 3], [[1, 2, 3]]),
-    ({'loss_scale': [1, 1, 1], 'token_ids': [1, 2, 3]}, [[1, 2, 3]]),
+    ({
+        'loss_scale': [1, 1, 1],
+        'token_ids': [1, 2, 3]
+    }, [[1, 2, 3]]),
 ])
 def test_swift_encode_preserves_existing_response_types(response, expected_decoded_ids):
     template = encode_response(response)

--- a/tests/general/test_vllm_detokenize.py
+++ b/tests/general/test_vllm_detokenize.py
@@ -1,0 +1,42 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import pytest
+from transformers import HfArgumentParser
+from types import SimpleNamespace
+
+from swift.arguments.base_args.generation_args import GenerationArguments
+from swift.infer_engine import RequestConfig
+from swift.pipelines.infer.deploy import SwiftDeploy
+
+
+@pytest.mark.parametrize('request_value, expected', [(None, False), (False, False), (True, True)])
+def test_deploy_detokenize_default_and_override(request_value, expected):
+    args, = HfArgumentParser(GenerationArguments).parse_args_into_dataclasses(['--detokenize', 'false'])
+    args.task_type = 'causal_lm'
+    request = RequestConfig(detokenize=request_value)
+    SwiftDeploy._set_request_config(SimpleNamespace(args=args), request)
+    assert request.detokenize is expected
+
+
+@pytest.mark.parametrize('value', [None, False, True])
+def test_vllm_detokenize_sampling_and_stops(value):
+    pytest.importorskip('vllm')
+    from vllm import SamplingParams
+
+    from swift.infer_engine.vllm_engine import VllmEngine
+
+    engine = object.__new__(VllmEngine)
+    engine.generation_config = SamplingParams()
+    engine.template = SimpleNamespace(template_meta=SimpleNamespace(stop_words=['END', [42]]))
+    engine._get_stop_words = lambda words: [word for word in words if isinstance(word, str)]
+    engine._get_stop_token_ids = lambda words: [42]
+    request = RequestConfig(max_tokens=1, detokenize=value, prompt_logprobs=64)
+    config = engine._prepare_generation_config(request)
+    assert config.detokenize is (True if value is None else value)
+    assert config.prompt_logprobs == 64
+    engine._add_stop_words(config, request)
+    assert config.stop == ([] if value is False else ['END'])
+    assert config.stop_token_ids == [42]
+    if value is False:
+        request.stop = ['explicit stop']
+        with pytest.raises(ValueError, match='detokenize=True'):
+            engine._add_stop_words(config, request)


### PR DESCRIPTION
## Summary

Support mixed rollout response content in `Template._swift_encode()`.

Rollout responses may contain multiple content components, including a text segment followed by a raw-token segment, for example:

```python
[
    "<think>...</think><tool_call>...</tool_call>",
    {
        "loss_scale": [...],
        "token_ids": [...]
    }
]
```

The current Swift template encoding path assumes that a list whose final item is not a string can be treated directly as `List[int]`. For mixed content such as `List[str, dict]`, this passes the entire list to `tokenizer.decode()`, causing a type error.

This change recognizes a trailing raw-token component and uses its `token_ids` only for suffix inspection. The original response representation is preserved for template encoding, so raw-token rollout semantics are unchanged.

## Tests

- `tests/general/test_template_mixed_rollout.py`: 5 passed
- Existing exact-token rollout tests: 33 passed; one unrelated existing test requires a missing `trainer_name` fixture
