### PR TITLE
fix(utils): handle empty JSONL output

### DIFF
--- a/swift/utils/io_utils.py
+++ b/swift/utils/io_utils.py
@@ -28,7 +28,9 @@ def write_to_jsonl(fpath: str, obj_list: List[Any], encoding: str = 'utf-8') -> 
         res.append(json.dumps(obj, ensure_ascii=False))
     with open(fpath, 'w', encoding=encoding) as f:
         text = '\n'.join(res)
-        f.write(f'{text}\n')
+        if text:
+            text += '\n'
+        f.write(text)
 
 
 class JsonlWriter:

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -30,6 +30,11 @@ class TestIOUtils(unittest.TestCase):
         new_obj_list = read_from_jsonl(fpath)
         self.assertTrue(new_obj_list == obj_list)
 
+    def test_empty_jsonl(self):
+        fpath = os.path.join(self.tmp_dir, 'empty.jsonl')
+        write_to_jsonl(fpath, [])
+        self.assertEqual(read_from_jsonl(fpath), [])
+
     def test_jsonl2(self):
         fpath = os.path.join(self.tmp_dir, '1.jsonl')
         obj_list = [{'aaa': 'bbb'}, 111, [1.1]]


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

`write_to_jsonl(path, [])` currently writes a single blank line. Reading that file with `read_from_jsonl` then passes the blank line to `json.loads` and raises `JSONDecodeError`.

This change writes an empty file for an empty input list while preserving the existing trailing newline for non-empty JSONL output. It also adds a regression test for the empty-list round trip.

## Experiment results

- Added `TestIOUtils.test_empty_jsonl`.
- `tests.utils.test_io_utils`: 6 tests passed with lightweight dependency stubs because PyTorch is unavailable in the local environment.
- `python -m compileall -q swift tests`
- `git diff --check`