### PR TITLE
fix(utils): handle relative TensorBoard paths

### DIFF
--- a/swift/utils/tb_utils.py
+++ b/swift/utils/tb_utils.py
@@ -56,8 +56,7 @@ def plot_images(images_dir: str,
                 matches.append(os.path.join(root, f))
     if not matches:
         return
-    fname = matches[0]
-    tb_path = os.path.join(tb_dir, fname)
+    tb_path = matches[0]
     data = read_tensorboard_file(tb_path)
 
     for k in data.keys():

--- a/tests/utils/test_tb_utils.py
+++ b/tests/utils/test_tb_utils.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from swift.utils.tb_utils import plot_images
+
+
+class TestTBUtils(unittest.TestCase):
+
+    def test_plot_images_with_relative_tensorboard_dir(self):
+        event_file = 'events.out.tfevents.test'
+        tb_dir = 'runs'
+        event_path = os.path.join(tb_dir, event_file)
+        matplotlib = types.ModuleType('matplotlib')
+        pyplot = types.ModuleType('matplotlib.pyplot')
+        matplotlib.pyplot = pyplot
+
+        with patch.dict(sys.modules, {'matplotlib': matplotlib, 'matplotlib.pyplot': pyplot}), \
+                patch('swift.utils.tb_utils.os.path.exists', return_value=True), \
+                patch('swift.utils.tb_utils.os.makedirs'), \
+                patch('swift.utils.tb_utils.os.walk', return_value=[(tb_dir, [], [event_file])]), \
+                patch('swift.utils.tb_utils.read_tensorboard_file', return_value={}) as mock_read:
+            plot_images('images', tb_dir)
+
+        mock_read.assert_called_once_with(event_path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

`plot_images` collects complete event-file paths from `os.walk(tb_dir)`. It then joins `tb_dir` to the collected path again, so a relative directory such as `runs` becomes `runs/runs/events.out.tfevents.*` and cannot be read.

This change passes the path returned by `os.walk` directly to `read_tensorboard_file`. Absolute-path behavior remains unchanged.

## Experiment results

- Added `TestTBUtils.test_plot_images_with_relative_tensorboard_dir`.
- Verified that the regression test fails before the fix and passes after it.
- `python3 -m unittest tests.utils.test_tb_utils -v`
- `python3 -m compileall -q swift tests`
- `git diff --check`