### PR TITLE
[megatron] Make FileSystemReader patch idempotent

### DIFF
--- a/swift/megatron/init.py
+++ b/swift/megatron/init.py
@@ -34,6 +34,8 @@ def _patch__batched_p2p_ops():
 def _patch_torch_FileSystemReader():
     from torch.distributed.checkpoint.filesystem import FileSystemReader
     from torch.futures import Future
+    if getattr(FileSystemReader.read_data, '_swift_patched', False):
+        return
     _origin_read_data = FileSystemReader.read_data
     _origin__slice_file = FileSystemReader._slice_file
     READER_MAX_WORKERS = int(os.environ.get('MCORE_READER_MAX_WORKERS', '16'))
@@ -71,6 +73,7 @@ def _patch_torch_FileSystemReader():
         fut.set_result(None)
         return fut
 
+    read_data._swift_patched = True
     FileSystemReader.read_data = read_data
 
 


### PR DESCRIPTION
## What this PR does

- Skip `_patch_torch_FileSystemReader()` when the Swift reader wrapper is already installed.
- Prevent repeated `init_megatron_env()` calls from nesting reader thread pools.

## Why

Importing `swift.megatron` already calls `init_megatron_env()`, while the initializer is public and is also called explicitly in the NPU setup documentation. Before this change, every call captured the previously patched `FileSystemReader.read_data` and wrapped it again. With the default 16 workers, a second initialization could therefore fan out into 16 × 16 reader tasks.

## Validation

- All repository pre-commit hooks pass for `swift/megatron/init.py`.
- A focused regression check with `MCORE_READER_MAX_WORKERS=2` verifies that two patch attempts retain the same wrapper and invoke the underlying reader twice rather than four times.