### PR TITLE
Fix loss scaling with sequence parallelism

### DIFF
--- a/swift/sequence_parallel/sequence_parallel.py
+++ b/swift/sequence_parallel/sequence_parallel.py
@@ -711,7 +711,7 @@ class SequenceParallel:
         """Prepare inputs
 
         1. set extra_kwargs['text_position_ids']
-        2. split labels
+        2. split labels and loss_scale
         """
         position_ids = inputs.get('text_position_ids')
         input_ids = inputs.get('input_ids')
@@ -721,11 +721,15 @@ class SequenceParallel:
             self.extra_kwargs['text_position_ids'] = position_ids.clone()
         if input_ids is not None:
             self.extra_kwargs['input_ids'] = input_ids.clone()
-        if 'labels' in inputs:
-            labels = inputs['labels']
-            _, _, labels, _, _, _, _ = self.pad_and_split_inputs(
-                None, None, labels, None, None, None, real_position_ids=position_ids)
-            inputs['labels'] = labels
+        labels = inputs.get('labels')
+        loss_scale = inputs.get('loss_scale')
+        if labels is not None or loss_scale is not None:
+            _, _, labels, _, _, loss_scale, _ = self.pad_and_split_inputs(
+                None, None, labels, None, None, loss_scale, real_position_ids=position_ids)
+            if labels is not None:
+                inputs['labels'] = labels
+            if loss_scale is not None:
+                inputs['loss_scale'] = loss_scale
 
 
 sequence_parallel = SequenceParallel()

--- a/swift/trainers/seq2seq_trainer.py
+++ b/swift/trainers/seq2seq_trainer.py
@@ -161,11 +161,21 @@ class Seq2SeqTrainer(SwiftMixin, DataLoaderMixin, HfSeq2SeqTrainer):
                     or self.template.sequence_parallel_size > 1):
                 if self.template.sequence_parallel_size > 1:
                     outputs.loss = per_token_loss_func_sp(outputs, labels, enable_dft_loss=self.args.enable_dft_loss)
+                    if loss_scale is not None:
+                        position_ids = sequence_parallel.real_position_ids
+                        if position_ids is not None:
+                            position_ids = sequence_parallel.pad(
+                                position_ids, padding_value=-1, position_ids=position_ids)
+                        loss_scale = sequence_parallel.gather(loss_scale, dim=1, position_ids=position_ids)
+                        if position_ids is not None and position_ids.min() == -1:
+                            loss_scale = loss_scale[position_ids >= 0].contiguous()
                 else:
                     outputs.loss = per_token_loss_func(outputs, labels, enable_dft_loss=self.args.enable_dft_loss)
 
                 if loss_scale is not None:
-                    loss_scale = torch.roll(loss_scale, shifts=-1, dims=-1).view(-1)
+                    if self.template.sequence_parallel_size == 1:
+                        loss_scale = torch.roll(loss_scale, shifts=-1, dims=-1).view(-1)
+                    assert outputs.loss.shape == loss_scale.shape
                     outputs.loss = outputs.loss * loss_scale
 
                 if self.args.enable_channel_loss:


### PR DESCRIPTION
## What this PR does

- Process `loss_scale` through the same padding, causal shift, and sequence split path as labels.
- Gather `loss_scale` back to the full-sequence layout before applying it to the gathered per-token loss.
- Apply the same padding mask to both tensors and assert that their shapes match.

## Why

With sequence parallelism enabled, `per_token_loss_func_sp()` gathers the local loss shards into a full-sequence tensor. Before this change, `loss_scale` remained unsharded and was flattened independently. For a batch size greater than one and no extra SP padding, this produced incompatible shapes such as `[B, S]` and `[B * S]`, causing training to fail during broadcasting.

## Validation

- All repository pre-commit hooks pass for the changed files.
- A 2-rank CPU distributed regression check passes for `B=2, S=4`, which reproduced the original failure.
- Additional SP-padding checks pass for `B=1, S=5` and `B=2, S=5`.
- The `Seq2SeqTrainer.compute_loss()` path completes forward weighting and backward propagation.