### PR TITLE
fix: default `dataloader_persistent_workers=True` to avoid per-eval worker cold start

### DIFF
--- a/swift/megatron/arguments/megatron_args.py
+++ b/swift/megatron/arguments/megatron_args.py
@@ -515,7 +515,7 @@ class MegatronArguments(RLHFMegatronArgumentsMixin, MegatronTunerMixin):
     train_dataloader_shuffle: bool = True
     dataloader_num_workers: int = 4
     dataloader_pin_memory: bool = True
-    dataloader_persistent_workers: bool = False
+    dataloader_persistent_workers: bool = True
     dataloader_prefetch_factor: int = 2
     dataloader_multiprocessing_context: Optional[Literal['fork', 'spawn', 'forkserver']] = None
     data_sharding: bool = False

--- a/swift/trainers/arguments.py
+++ b/swift/trainers/arguments.py
@@ -49,7 +49,7 @@ class TrainArgumentsMixin:
             and specify the API KEY corresponding to your account through `WANDB_API_KEY`.
         dataloader_num_workers (Optional[int]): The number of subprocesses to use for data loading. Defaults to None.
         dataloader_persistent_workers (bool): If True, the data loader workers will not be shut down after a dataset
-            has been consumed once. Defaults to False.
+            has been consumed once. Defaults to True.
         dataloader_prefetch_factor (Optional[int]): The number of batches loaded in advance by each worker. Defaults
             to None.
         use_liger_kernel (bool): Whether to use the Liger kernel for optimization. Defaults to False.
@@ -148,7 +148,7 @@ class TrainArgumentsMixin:
     lr_scheduler_kwargs: Optional[Union[dict, str]] = None
     report_to: List[str] = field(default_factory=lambda: ['tensorboard'])
     dataloader_num_workers: Optional[int] = None
-    dataloader_persistent_workers: bool = False
+    dataloader_persistent_workers: bool = True
     dataloader_prefetch_factor: Optional[int] = None
     dataloader_multiprocessing_context: Optional[Literal['fork', 'spawn', 'forkserver']] = None
     use_liger_kernel: bool = False


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixes #10016 (the eval-startup stalls).

On Python 3.14 the default multiprocessing start method is forkserver, and torch's
DataLoader rebuilds its worker pool whenever the eval dataloader is re-created.
Every evaluation therefore pays a cold start: each worker re-imports the full
torch/transformers/swift stack before the first batch. Measured on a Qwen3.5-0.8B
LoRA SFT with `dataloader_num_workers=6` and an 8-sample val set, each eval took
~30 s, almost all of it worker startup.

`dataloader_persistent_workers` already fixes this (the reporter of #10016 also
observed it), but defaults to False. This PR flips the default to True in both
`swift/trainers/arguments.py` and `swift/megatron/arguments/megatron_args.py`.

Trade-off: idle workers keep their imported modules in host memory between
evaluations (on the order of a few hundred MB per worker). Users who prefer the
old behavior can pass `--dataloader_persistent_workers false`.

Note: the other observation in #10016 (worker processes holding CUDA contexts)
was not reproducible with torch 2.14, which resets CUDA state in forked children
(workers report `torch.cuda.is_initialized() == False`); the megatron-side default
flip is the same one-line semantic change but was not run on a megatron cluster.

## Experiment results

Qwen3.5-0.8B-Base LoRA SFT, 40 train / 8 val samples, 6 workers, eval every
3 steps with `eval_on_start`, Python 3.14, torch 2.14, RTX A6000:

| config | eval@0 (cold) | eval@3 | eval@6 |
|--------|---------------|--------|--------|
| main (default False) | 30.2 s | 30.1 s | 29.7 s |
| this PR (default True) | 32.3 s | 0.70 s | 0.70 s |

In the 5-eval version of this run, wall time spent in eval worker startup
dropped from ~45% to ~5%.
