### PR TITLE
Report the NaN instead of a bare raise in zigzag ring attention

### DIFF
--- a/swift/sequence_parallel/zigzag_ring_attn.py
+++ b/swift/sequence_parallel/zigzag_ring_attn.py
@@ -508,7 +508,7 @@ def zigzag_ring_flash_attn_varlen_backward(
     for step in range(kv_comm.world_size):
         _, _, block_out, block_lse, _ = out_lse[step]
         if block_out.isnan().any() or block_lse.isnan().any():
-            raise
+            raise RuntimeError(f'NaN detected in block_out/block_lse at step {step}.')
         block_lse = block_lse.transpose(0, 1).squeeze(2)
 
         if step + 1 != kv_comm.world_size:
@@ -522,7 +522,7 @@ def zigzag_ring_flash_attn_varlen_backward(
             block_dout = block_gradients[step]['grad_block_out']
 
         if block_dout.isnan().any():
-            raise
+            raise RuntimeError(f'NaN detected in block_dout at step {step}.')
 
         if step == 0:
             backward(
@@ -532,7 +532,7 @@ def zigzag_ring_flash_attn_varlen_backward(
             dk = dk_buffer.to(torch.float32)
             dv = dv_buffer.to(torch.float32)
             if dq.isnan().any() or dk.isnan().any() or dv.isnan().any():
-                raise
+                raise RuntimeError(f'NaN detected in dq/dk/dv at step {step}.')
         else:
             if step <= kv_comm.rank:
                 k0 = k[half_index0]
@@ -568,7 +568,7 @@ def zigzag_ring_flash_attn_varlen_backward(
                 dk += dk_buffer
                 dv += dv_buffer
             if dq.isnan().any() or dk.isnan().any() or dv.isnan().any():
-                raise
+                raise RuntimeError(f'NaN detected in dq/dk/dv at step {step}.')
         if step + 1 != kv_comm.world_size:
             kv_comm.wait()
             k, v = next_k, next_v


### PR DESCRIPTION
### Summary

Four NaN guards in `swift/sequence_parallel/zigzag_ring_attn.py` end in a bare `raise`:

```python
for step in range(kv_comm.world_size):
    _, _, block_out, block_lse, _ = out_lse[step]
    if block_out.isnan().any() or block_lse.isnan().any():
        raise
```

There is no active exception at those points, so Python raises

```
RuntimeError: No active exception to reraise
```

The guard fires correctly — it does abort — but the error says nothing about a NaN, which tensor it was in, or which communication step produced it. For a sequence-parallel attention path, where the interesting question is usually *which rank/step* went bad, that traceback is close to useless.

Affected sites: the forward output check (`block_out` / `block_lse`), the backward gradient check (`block_dout`), and the two `dq`/`dk`/`dv` checks in the backward accumulation.

`ruff --select PLE0704` flags all four: *"Bare `raise` statement is not inside an exception handler."*

### Change

Raise a `RuntimeError` naming the tensor and the step, e.g.

```python
raise RuntimeError(f'NaN detected in block_out/block_lse at step {step}.')
```

The exception type is unchanged — it was already `RuntimeError`, just with the interpreter's own message — so anything catching `RuntimeError` behaves the same. Only the message becomes informative.

### Notes

I kept this to the message and did not change when the guards fire. If you would prefer a dedicated exception type, or the message worded differently, happy to adjust.

I checked `zigzag_ring_attn_npu.py` (touched by #10002) and it does not have the same pattern, so there is no overlap.
