### PR TITLE
fix(model): fix NameError when loading mplug_owl2_1 with a vocab_size

### DIFF
--- a/swift/model/models/mplug.py
+++ b/swift/model/models/mplug.py
@@ -30,7 +30,9 @@ class MplugOwl2Loader(ModelLoader):
         # https://github.com/X-PLUG/mPLUG-Owl/blob/main/mPLUG-Owl2/mplug_owl2/model/modeling_mplug_owl2.py#L447
         from mplug_owl2 import MPLUGOwl2LlamaForCausalLM
         if vocab_size is not None:
-            config.vocab_size = vocab_size
+            # ModelLoader.get_model is called with (model_dir, config, processor, model_kwargs),
+            # so the framework-loaded config arrives as args[0].
+            args[0].vocab_size = vocab_size
         model = super().get_model(model_dir, *args, **kwargs)
         logger.info('Please ignore the unimported warning.')
         return model


### PR DESCRIPTION
### ☑️ Self Check List

- [x] I have read the CONTRIBUTING and followed its rules

`MplugOwl2Loader._get_model` references an undefined `config` when `vocab_size` is not None:

```python
if vocab_size is not None:
    config.vocab_size = vocab_size  # NameError: name 'config' is not defined
```

`MplugOwl2_1Loader.get_model` always passes `151851`, so loading any mplug_owl2_1 model (e.g. `iic/mPLUG-Owl2.1`) crashes deterministically; the plain mplug_owl2 path (vocab_size=None) never hits the branch, which is why it survived. `ModelLoader.get_model` is invoked with `(model_dir, config, processor, model_kwargs)` positionally (register.py:478), so the fix adjusts the framework-loaded config via `args[0]` before model creation.

### Type of the Changes

- [x] Bug Fix