### PR TITLE
docs: fix dead anchors across EN/CN command-line and best-practice docs

### DIFF
--- a/docs/source/BestPractices/Qwen3_8-Best-Practice.md
+++ b/docs/source/BestPractices/Qwen3_8-Best-Practice.md
@@ -44,7 +44,7 @@ pip install -U "vllm>=0.17.0"
 
 使用 ms-swift 的 `TransformersEngine` 进行推理：
 
-- 其中特定模型参数，例如 `VIDEO_MAX_TOKEN_NUM` 等环境变量的含义与Qwen3-VL相同，参考[命令行参数文档](../Instruction/Command-line-parameters.md#qwen3_vl,qwen3_5)。
+- 其中特定模型参数，例如 `VIDEO_MAX_TOKEN_NUM` 等环境变量的含义与Qwen3-VL相同，参考[命令行参数文档](../Instruction/Command-line-parameters.md#qwen3_vl-qwen3_5)。
 
 ```python
 import os

--- a/docs/source/Instruction/Command-line-parameters.md
+++ b/docs/source/Instruction/Command-line-parameters.md
@@ -652,7 +652,7 @@ reward模型参数将在PPO、GRPO中使用；teacher模型参数在GKD与GRPO�
   - async_generate: 异步rollout以提高训练速度，注意开启时采样会使用上一轮更新的模型进行采样，不支持多轮场景。默认`false`。
   - enable_flattened_weight_sync: 是否使用 flattened tensor 进行权重同步。启用后会将多个参数打包为单个连续 tensor 进行传输，可提升同步效率，在 Server Mode 下生效，默认为 True。
   - SWIFT_UPDATE_WEIGHTS_BUCKET_SIZE: 环境变量，用于控制flattened tensor 权重同步时的传输桶大小（bucket size），适用于 Server Mode 下的全参数训练，单位为 MB，默认值为 512 MB。
-- vllm_mode colocate 参数（更多参数支持参考[vLLM参数](#vLLM参数)。）
+- vllm_mode colocate 参数（更多参数支持参考[vLLM参数](#vllm参数)。）
   - vllm_gpu_memory_utilization: vllm透传参数，默认为0.9。
   - vllm_max_model_len: vllm透传参数，默认为None。
   - vllm_enforce_eager: vllm透传参数，默认为False。

--- a/docs/source/Instruction/GRPO/DeveloperGuide/reward_function.md
+++ b/docs/source/Instruction/GRPO/DeveloperGuide/reward_function.md
@@ -3,7 +3,7 @@
 奖励函数接受模型生成的文本 completions 其他数据集中的列以及训练器状态作为参数(kwargs)进行打分, 其中[训练器状态](https://huggingface.co/docs/transformers/main/main_classes/callback#transformers.TrainerState)包含训练的步数等信息。
 
 注意：模型输入相关的列（比如query，response）会被处理为 messages 键，原数据集中的 assistant response 会被舍弃，请使用额外的列进行保留。
-相关处理的列名参考[文档](../../../Customization/Custom-dataset.md#query-response格式)
+相关处理的列名参考[文档](../../../Customization/Custom-dataset.md)
 
 以下是一个示例，展示了如何实现一个简单的长度奖励函数。该函数会在模型生成的文本长度超过 1024 时，给予 1.0 的奖励信号；否则，奖励信号为 0.0。
 

--- a/docs/source/Megatron-SWIFT/Command-line-parameters.md
+++ b/docs/source/Megatron-SWIFT/Command-line-parameters.md
@@ -381,7 +381,7 @@ Megatron训练参数继承自Megatron参数和基本参数（**与ms-swift共用
   - vllm_server_pass_dataset: 透传额外的数据集信息到vLLM server，用于多轮训练。
   - async_generate: 异步rollout以提高训练速度，注意开启时采样会使用上一轮更新的模型进行采样，不支持多轮场景。默认`false`.
   - SWIFT_UPDATE_WEIGHTS_BUCKET_SIZE: 环境变量，用于控制权重同步时的传输桶大小（bucket size），适用于 Server Mode 下的全参数训练，单位为 MB，默认值为 512 MB。
-- vllm_mode colocate 参数（更多参数支持参考[vLLM参数](#vLLM参数)。）
+- vllm_mode colocate 参数（更多参数支持参考[vLLM参数](../Instruction/Command-line-parameters.md#vllm参数)。）
   - vllm_gpu_memory_utilization: vllm透传参数，默认为0.9。
   - vllm_max_model_len: vllm透传参数，默认为None。
   - vllm_enforce_eager: vllm透传参数，默认为False。

--- a/docs/source_en/BestPractices/NPU-support.md
+++ b/docs/source_en/BestPractices/NPU-support.md
@@ -746,7 +746,7 @@ After training, inference, or deployment, you can evaluate the original model or
 
 ## Release
 
-If you need to publish NPU-trained checkpoints, merged models, or quantized models to ModelScope/HuggingFace, use the push capability in `swift export`. For complete arguments and examples, see [Export and Push](../Instruction/Export-and-push.md#push-models).
+If you need to publish NPU-trained checkpoints, merged models, or quantized models to ModelScope/HuggingFace, use the push capability in `swift export`. For complete arguments and examples, see [Export and Push](../Instruction/Export-and-push.md#push-model).
 
 ## FAQ
 

--- a/docs/source_en/BestPractices/Qwen3_8-Best-Practice.md
+++ b/docs/source_en/BestPractices/Qwen3_8-Best-Practice.md
@@ -43,7 +43,7 @@ pip install -U "vllm>=0.17.0"
 
 Using ms-swift's `TransformersEngine` for inference:
 
-- The meaning of model-specific parameters such as `VIDEO_MAX_TOKEN_NUM` environment variables is the same as Qwen3-VL, refer to [Command-line Parameters Documentation](../Instruction/Command-line-parameters.md#qwen3_vl,qwen3_5).
+- The meaning of model-specific parameters such as `VIDEO_MAX_TOKEN_NUM` environment variables is the same as Qwen3-VL, refer to [Command-line Parameters Documentation](../Instruction/Command-line-parameters.md#qwen3_vl-qwen3_5).
 
 ```python
 import os

--- a/docs/source_en/Instruction/Command-line-parameters.md
+++ b/docs/source_en/Instruction/Command-line-parameters.md
@@ -644,7 +644,7 @@ The meanings of the following parameters can be referenced [here](https://huggin
 - reward_funcs: Reward functions in the GRPO algorithm; options include `accuracy`,`format`,`cosine`,`repetition` and `soft_overlong`, as seen in `swift/rewards/orm.py`. You can also customize your own reward functions in the plugin. Default is `[]`.
 - reward_weights: Weights for each reward function. The number should be equal to the sum of the number of reward functions and reward models. If `None`, all rewards are weighted equally with weight `1.0`.
   - Note: If `--reward_model` is included in GRPO training, it is added to the end of the reward functions.
-- reward_model_plugin: The logic for the reward model, which defaults to ORM logic. For more information, please refer to [Customized Reward Models](./GRPO/DeveloperGuide/reward_model.md#custom-reward-model).
+- reward_model_plugin: The logic for the reward model, which defaults to ORM logic. For more information, please refer to [Customized Reward Models](./GRPO/DeveloperGuide/reward_model.md#custom-reward-models).
 - dataset_shuffle: Whether to shuffle the dataset randomly. Default is True.
 - truncation_strategy: The method to handle inputs exceeding `max_length`. Supported values are `delete` and `left`, representing deletion and left-side truncation respectively. The default is `left`. With the delete strategy, over-long or encoding-failed samples are discarded, and new samples are resampled from the original dataset to maintain the intended batch size.
 - loss_type: The type of loss normalization. Options are ['grpo', 'bnpo', 'dr_grpo', 'dapo', 'cispo', 'sapo', 'real', 'fipo'], default is 'grpo'. For details, refer to this [doc](./GRPO/DeveloperGuide/loss_types.md)
@@ -689,7 +689,7 @@ The meanings of the following parameters can be referenced [here](https://huggin
 - dynamic_sample: Exclude data within the group where the reward standard deviation is 0, and additionally sample new data. Default is False.
 - max_resample_times: Under the dynamic_sample setting, limit the number of resampling attempts to a maximum of 3. Default is 3 times.
 - overlong_filter: Skip overlong truncated samples, which will not be included in loss calculation. Default is False.
-The hyperparameters for the reward function can be found in the [Built-in Reward Functions section](#built-in-reward-functions).
+The hyperparameters for the reward function can be found in the [Reward function parameters section](#reward-function-parameters).
 - delta: Delta value for the upper clipping bound in two-sided GRPO. Recommended to be > 1 + epsilon. This method was introduced in the [INTELLECT-2 tech report](https://huggingface.co/papers/2505.07291).
 - importance_sampling_level: Controls how the importance sampling ratio is computed. Options are `token` and `sequence`. In `token` mode, the raw per-token log-probability ratios are used. In `sequence` mode, the log-probability ratios of all valid tokens in the sequence are averaged to produce a single ratio per sequence. The [GSPO paper](https://arxiv.org/abs/2507.18071) uses sequence-level importance sampling to stabilize training. The default is `token`.
 - advantage_estimator: Advantage estimator. Default is `grpo` (group-relative advantage). Options: `grpo`, [`rloo`](./GRPO/AdvancedResearch/RLOO.md), [`reinforce_plus_plus`](./GRPO/AdvancedResearch/REINFORCEPP.md).

--- a/docs/source_en/Instruction/GRPO/DeveloperGuide/reward_function.md
+++ b/docs/source_en/Instruction/GRPO/DeveloperGuide/reward_function.md
@@ -3,7 +3,7 @@
 The reward function takes as arguments (via kwargs) the model-generated completions, other columns from the dataset, and the training state, and calculates a reward score. The [trainer state](https://huggingface.co/docs/transformers/main/main_classes/callback#transformers.TrainerState) includes information such as the current training step.
 
 Note: The columns related to model input (such as query and response) are converted to the messages key. The original assistant response in the dataset will be discarded, so please use extra columns if you wish to retain it.
-The relevant column names for processing can be found in the [document](../../../Customization/Custom-dataset.md#Query-Response)
+The relevant column names for processing can be found in the [document](../../../Customization/Custom-dataset.md)
 
 Below is an example illustrating how to implement a simple length-based reward function. This function assigns a reward of 1.0 if the length of the generated completion exceeds 1024, and 0.0 otherwise.
 

--- a/docs/source_en/Megatron-SWIFT/Command-line-parameters.md
+++ b/docs/source_en/Megatron-SWIFT/Command-line-parameters.md
@@ -404,14 +404,14 @@ In addition to inheriting the training parameters, the following parameters are 
   - vllm_server_pass_dataset: Pass additional dataset information to the vLLM server for multi-round training.
   - async_generate: Asynchronous rollout to improve training speed. Note: When enabled, sampling uses the model from the previous round update, and multi-round scenarios are not supported. Default is `false`.
   - SWIFT_UPDATE_WEIGHTS_BUCKET_SIZE: Environment variable for controlling the bucket size during weight synchronization. Applicable to full-parameter training in Server Mode. Unit is MB, default value is 512 MB.
-- vllm_mode colocate parameters (for more parameter support, refer to [vLLM parameters](#vllm-parameters)):
+- vllm_mode colocate parameters (for more parameter support, refer to [vLLM parameters](../Instruction/Command-line-parameters.md#vllm-arguments)):
   - vllm_gpu_memory_utilization: vLLM passthrough parameter. Default is 0.9.
   - vllm_max_model_len: vLLM passthrough parameter. Default is None.
   - vllm_enforce_eager: vLLM passthrough parameter. Default is False.
   - vllm_limit_mm_per_prompt: vLLM passthrough parameter. Default is None.
   - vllm_enable_prefix_caching: vLLM passthrough parameter. Default is True.
   - vllm_tensor_parallel_size: Tensor parallel size. Default is `1`.
-  - vllm_enable_lora: Support loading LoRA adapters in the vLLM Engine. Default is False. Used to accelerate weight synchronization in LoRA training. See [documentation](../Instruction/GRPO/GetStarted/GRPO.md#weight-synchronization-acceleration) for details.
+  - vllm_enable_lora: Support loading LoRA adapters in the vLLM Engine. Default is False. Used to accelerate weight synchronization in LoRA training. See [documentation](../Instruction/GRPO/GetStarted/GRPO.md#weight-sync-acceleration) for details.
   - sleep_level: Release vLLM GPU memory during training. Options are `[0, 1, 2]`. Default is 0, meaning no release.
   - offload_optimizer: Whether to offload optimizer parameters during vLLM inference. Default is False.
   - offload_model: Whether to offload the model during vLLM inference. Default is False.


### PR DESCRIPTION
### ☑️ Self Check List

- [x] I have read the CONTRIBUTING and followed its rules

Fixes 9 dead anchors, each verified against the target file's actual headings (EN/CN counterpart links already pointed at the correct slugs, confirming the drift):

- Megatron GRPO weight-sync link and both Megatron vLLM-parameter links (targets exist only in the Instruction command-line docs)
- reward_model.md singular/plural anchor mismatch
- 'Built-in Reward Functions' in-page anchor (no such heading; retargeted to 'Reward function parameters')
- qwen3_vl,qwen3_5 anchor keeping the comma that slugifiers strip → `#qwen3_vl-qwen3_5`
- NPU doc push-model singular/plural mismatch
- reward_function.md linking a plain paragraph as a heading (fragment dropped, both locales)
- CN command-line doc's `#vLLM参数` uppercase fragment (readthedocs anchors lowercase)

### Type of the Changes

- [x] Document Updates