### PR TITLE
docs: fix 'the penalizes' -> 'that penalizes' in ORM reward docstring

### DIFF
--- a/swift/rewards/orm.py
+++ b/swift/rewards/orm.py
@@ -187,7 +187,7 @@ class RepetitionPenalty(ORM):
 
     def __call__(self, completions, **kwargs) -> List[float]:
         """
-        reward function the penalizes repetitions
+        reward function that penalizes repetitions
 
         Args:
             completions: List of model completions


### PR DESCRIPTION
### ☑️ Self Check List

- [x] I have read the CONTRIBUTING and followed its rules

One-word docstring typo fix in `swift/rewards/orm.py`.

### Type of the Changes

- [x] Document Updates