### PR TITLE
[megatron] Propagate parallel checkpoint reader errors

### DIFF
--- a/swift/megatron/init.py
+++ b/swift/megatron/init.py
@@ -59,16 +59,20 @@ def _patch_torch_FileSystemReader():
             _origin_read_data(self, plan_shard, planner)
 
         prog_bar = tqdm(total=len(plan.items), dynamic_ncols=True, desc='Loading: ')
-        plan_shards = split_list(plan.items, READER_MAX_WORKERS, contiguous=False)
-        with _patch__slice_file(prog_bar):
-            with concurrent.futures.ThreadPoolExecutor(max_workers=READER_MAX_WORKERS) as pool:
-                futures = []
-                for i in range(READER_MAX_WORKERS):
-                    plan_shard = copy(plan)
-                    plan_shard.items = plan_shards[i]
-                    futures.append(pool.submit(_worker, plan_shard))
-                concurrent.futures.wait(futures)
-        prog_bar.close()
+        try:
+            plan_shards = split_list(plan.items, READER_MAX_WORKERS, contiguous=False)
+            with _patch__slice_file(prog_bar):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=READER_MAX_WORKERS) as pool:
+                    futures = []
+                    for i in range(READER_MAX_WORKERS):
+                        plan_shard = copy(plan)
+                        plan_shard.items = plan_shards[i]
+                        futures.append(pool.submit(_worker, plan_shard))
+                    concurrent.futures.wait(futures)
+                    for future in futures:
+                        future.result()
+        finally:
+            prog_bar.close()
         fut: Future = Future()
         fut.set_result(None)
         return fut


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

A missing checkpoint data file or an exception while reading a shard can leave tensors unloaded while Megatron's patched `FileSystemReader` reports success. `concurrent.futures.wait()` waits for the workers but does not propagate their exceptions, and the reader then unconditionally returns a successful `torch.futures.Future`.

Retrieve each worker's result after the existing wait so loading errors reach the caller. Close the progress bar in `finally`, including on failure; the existing context manager continues to restore `_slice_file`.

## Experiment results

Validated the actual reader patch with CPU-only PyTorch 2.13.0 DCP save/load and `MCORE_READER_MAX_WORKERS=2`:

- Complete checkpoint: both tensors load correctly before and after the fix.
- Missing second tensor data file: before the fix, `dcp.load()` returns successfully with the second tensor still at its sentinel value; after the fix, it raises `CheckpointException` containing the original `FileNotFoundError`.
- Injected `RuntimeError('corrupted shard')`: the exception is swallowed before the fix and reaches `dcp.load()` as `CheckpointException` after the fix.
- Progress bars close and `_slice_file` is restored on both success and failure.

The regression check fails against the old reader and passes against the fix. `uvx pre-commit run --all-files` and `git diff --check` pass. Multi-rank Megatron training was not run.
