### PR TITLE
Fix optional dependency imports in CI tests

### DIFF
--- a/swift/template/templates/gemma.py
+++ b/swift/template/templates/gemma.py
@@ -105,12 +105,12 @@ class Gemma3VisionTemplate(Gemma3Template):
         return ['<start_of_image>']
 
     def _encode(self, inputs: StdTemplateInputs) -> Dict[str, Any]:
-        from transformers.models.gemma3.processing_gemma3 import Gemma3ProcessorKwargs
-
         encoded = super()._encode(inputs)
         # Keep text-only rows aligned with multimodal rows in mixed batches.
         encoded['token_type_ids'] = [0] * len(encoded['input_ids'])
         if inputs.images:
+            from transformers.models.gemma3.processing_gemma3 import Gemma3ProcessorKwargs
+
             input_ids = encoded['input_ids']
             labels = encoded['labels']
             loss_scale = encoded.get('loss_scale', None)

--- a/tests/general/test_gemma3_template.py
+++ b/tests/general/test_gemma3_template.py
@@ -12,7 +12,8 @@ class TestGemma3VisionTemplate(unittest.TestCase):
         encoded = {'input_ids': [2, 10, 20], 'labels': [-100, 10, 20]}
         inputs = SimpleNamespace(images=[])
 
-        with patch.object(Gemma3Template, '_encode', return_value=encoded):
-            result = template._encode(inputs)
+        with patch.dict('sys.modules', {'transformers.models.gemma3.processing_gemma3': None}):
+            with patch.object(Gemma3Template, '_encode', return_value=encoded):
+                result = template._encode(inputs)
 
         self.assertEqual(result['token_type_ids'], [0, 0, 0])

--- a/tests/llm/test_web_ui.py
+++ b/tests/llm/test_web_ui.py
@@ -1,5 +1,5 @@
-from swift.arguments import WebUIArguments
-from swift.ui import webui_main
-
 if __name__ == '__main__':
+    from swift.arguments import WebUIArguments
+    from swift.ui import webui_main
+
     webui_main(WebUIArguments())


### PR DESCRIPTION
## Summary

Fix two optional-dependency import failures without skipping tests or adding dependencies to the CI environment:

- Move the imports in `tests/llm/test_web_ui.py` under its existing `__main__` guard. This file is a manual WebUI launcher, not a unittest test case. Test discovery no longer imports `swift.ui` and requires Gradio, while direct execution still launches the UI with `WebUIArguments`.
- Import `Gemma3ProcessorKwargs` only in the image branch of `Gemma3VisionTemplate._encode`. The text-only test previously failed with `ModuleNotFoundError: No module named 'transformers.models.gemma3'` in environments without that Transformers module, although the processor defaults are only used for images.
- Strengthen the existing Gemma3 text-only regression test by making the processor module unavailable. Keep the original `token_type_ids` assertion and execute the real vision-template encoding method.

Image processing still uses the same processor defaults and still raises when its required dependency is missing. No tests are skipped, no import errors are swallowed, and no dependency requirements are changed.

This is an independent CI fix based on `main`; it does not include the DPO/IPO changes from #9925 or the checkpoint-reader changes from #10045.

## Validation

- Existing Gemma3 text-only regression test passes with the processor module explicitly unavailable.
- Three additional local checks pass: WebUI discovery with Gradio/UI imports blocked, manual WebUI entry-point dispatch with stubbed UI modules, and Gemma3 image encoding with a mock image processor and the actual processor defaults (4 tests passed in total).
- Explicitly checked that, with the entire Gemma3 package unavailable, text-only encoding succeeds with unchanged IDs/labels and image encoding still raises `ModuleNotFoundError`.
- `uvx pre-commit run --all-files` passes.

Validation above is local and CPU-only; GPU/NPU CI results are pending.
