### PR TITLE
fix: preserve 2D predictions in predict_with_generate DDP eval

### DIFF
--- a/swift/trainers/seq2seq_trainer.py
+++ b/swift/trainers/seq2seq_trainer.py
@@ -18,7 +18,7 @@ from swift.sequence_parallel import sequence_parallel
 from swift.utils import HfConfigFactory, JsonlWriter, Serializer, gc_collect, get_logger, unwrap_model_for_generation
 from .arguments import Seq2SeqTrainingArguments
 from .mixin import DataLoaderMixin, SwiftMixin
-from .utils import per_token_loss_func, per_token_loss_func_sp
+from .utils import pad_for_ddp_gather, per_token_loss_func, per_token_loss_func_sp
 
 logger = get_logger()
 
@@ -96,6 +96,9 @@ class Seq2SeqTrainer(SwiftMixin, DataLoaderMixin, HfSeq2SeqTrainer):
         labels_list = [Serializer.to_tensor(labels).to(device=device) for labels in labels_list]
         response_list = pad_sequence(response_list, batch_first=True, padding_value=0)
         labels_list = pad_sequence(labels_list, batch_first=True, padding_value=0)
+        # Align seq length across DDP ranks so accelerator.gather keeps a 2D batch.
+        response_list = pad_for_ddp_gather(response_list, padding_value=0)
+        labels_list = pad_for_ddp_gather(labels_list, padding_value=0)
         return None, response_list, labels_list
 
     def _prepare_inputs(self, inputs):

--- a/swift/trainers/utils.py
+++ b/swift/trainers/utils.py
@@ -322,6 +322,31 @@ def disable_gradient_checkpointing(model: PreTrainedModel, gradient_checkpointin
             model.gradient_checkpointing_enable(gradient_checkpointing_kwargs)
 
 
+def pad_to_global_max_len(tensor: torch.Tensor, global_max_len: int, padding_value: int = 0) -> torch.Tensor:
+    """Pad a [batch, seq_len] tensor on the right to ``global_max_len``."""
+    if tensor.ndim != 2:
+        return tensor
+    pad_len = global_max_len - tensor.shape[1]
+    if pad_len <= 0:
+        return tensor
+    return F.pad(tensor, (0, pad_len), value=padding_value)
+
+
+def get_ddp_global_max_seq_len(local_seq_len: int, device: torch.device) -> int:
+    """Return the max sequence length across all DDP ranks."""
+    if dist.is_available() and dist.is_initialized():
+        max_len = torch.tensor([local_seq_len], device=device, dtype=torch.long)
+        dist.all_reduce(max_len, op=dist.ReduceOp.MAX)
+        return int(max_len.item())
+    return local_seq_len
+
+
+def pad_for_ddp_gather(tensor: torch.Tensor, padding_value: int = 0) -> torch.Tensor:
+    """Pad predictions/labels so every rank shares the same seq length before DDP gather."""
+    global_max_len = get_ddp_global_max_seq_len(tensor.shape[1], tensor.device)
+    return pad_to_global_max_len(tensor, global_max_len, padding_value=padding_value)
+
+
 def gather_for_unpadded_tensors(input_data, use_gather_object=False):
     from accelerate.utils import gather_object
     if getattr(sequence_parallel, 'dp_group', None) is not None:

--- a/tests/train/test_seq2seq_trainer_ddp.py
+++ b/tests/train/test_seq2seq_trainer_ddp.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from swift.trainers.utils import pad_for_ddp_gather, pad_to_global_max_len
+
+
+class TestSeq2SeqTrainerDdpPadding(unittest.TestCase):
+
+    def test_pad_to_global_max_len(self):
+        tensor = torch.tensor([[1, 2, 3], [4, 5, 0]])
+        padded = pad_to_global_max_len(tensor, global_max_len=5, padding_value=0)
+        self.assertEqual(padded.shape, (2, 5))
+        self.assertTrue(torch.equal(padded, torch.tensor([[1, 2, 3, 0, 0], [4, 5, 0, 0, 0]])))
+
+    def test_pad_to_global_max_len_noop_when_already_max(self):
+        tensor = torch.tensor([[1, 2], [3, 4]])
+        padded = pad_to_global_max_len(tensor, global_max_len=2, padding_value=0)
+        self.assertTrue(torch.equal(padded, tensor))
+
+    def test_ddp_gather_preserves_2d_shape_after_global_padding(self):
+        rank0 = pad_to_global_max_len(torch.tensor([[1, 2, 3], [4, 5, 0]]), global_max_len=5)
+        rank1 = pad_to_global_max_len(torch.tensor([[6, 7, 8, 9, 10], [11, 12, 0, 0, 0]]), global_max_len=5)
+        gathered = torch.cat([rank0, rank1], dim=0)
+        self.assertEqual(gathered.ndim, 2)
+        self.assertEqual(gathered.shape, (4, 5))
+
+    def test_pad_for_ddp_gather_without_dist(self):
+        tensor = torch.tensor([[1, 2, 3], [4, 5, 0]])
+        padded = pad_for_ddp_gather(tensor, padding_value=0)
+        self.assertTrue(torch.equal(padded, tensor))
+
+    def test_pad_for_ddp_gather_with_dist(self):
+        tensor = torch.tensor([[1, 2, 3], [4, 5, 0]])
+
+        def fake_all_reduce(t, op=None):
+            t.fill_(5)
+
+        with mock.patch('swift.trainers.utils.dist.is_available', return_value=True), \
+                mock.patch('swift.trainers.utils.dist.is_initialized', return_value=True), \
+                mock.patch('swift.trainers.utils.dist.all_reduce', side_effect=fake_all_reduce):
+            padded = pad_for_ddp_gather(tensor, padding_value=0)
+
+        self.assertEqual(padded.shape, (2, 5))
+        self.assertTrue(torch.equal(padded, torch.tensor([[1, 2, 3, 0, 0], [4, 5, 0, 0, 0]])))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/train/test_seq2seq_trainer_ddp.py
+++ b/tests/train/test_seq2seq_trainer_ddp.py
@@ -1,7 +1,6 @@
+import torch
 import unittest
 from unittest import mock
-
-import torch
 
 from swift.trainers.utils import pad_for_ddp_gather, pad_to_global_max_len
 


### PR DESCRIPTION
Preserve 2D (batch, seq_len) predictions when predict_with_generate gathers across DDP ranks. Fixes #8256
