### PR TITLE
fix(metrics): mask ignored labels in padding-free seq_acc

### DIFF
--- a/swift/metrics/acc.py
+++ b/swift/metrics/acc.py
@@ -34,7 +34,8 @@ def compute_acc(preds,
             # padding_free
             for i in range(cu_seqlens.shape[0] - 1):
                 start, end = cu_seqlens[i], cu_seqlens[i + 1]
-                acc_list.append(np.all(preds[0, start:end] == labels[0, start:end]))
+                mask = masks[0, start:end]
+                acc_list.append(np.all(preds[0, start:end][mask] == labels[0, start:end][mask]))
         else:
             for i, m in enumerate(masks):
                 acc_list.append(np.all(preds[i, m] == labels[i, m]))

--- a/tests/utils/test_acc_metrics.py
+++ b/tests/utils/test_acc_metrics.py
@@ -1,0 +1,32 @@
+import torch
+import unittest
+
+from swift.metrics import compute_acc
+
+# Two sequences, each two prompt tokens (label -100) followed by two response tokens.
+# The prediction at position i is the guess for token i + 1, so the first sequence is
+# answered correctly and the second one gets its final token wrong.
+PACKED_LABELS = torch.tensor([[-100, -100, 5, 6, -100, -100, 7, 8]])
+PACKED_PREDS = torch.tensor([[0, 5, 6, 0, 0, 7, 9, 0]])
+CU_SEQLENS = torch.tensor([0, 4, 8])
+
+BATCH_LABELS = torch.tensor([[-100, -100, 5, 6], [-100, -100, 7, 8]])
+BATCH_PREDS = torch.tensor([[0, 5, 6, 0], [0, 7, 9, 0]])
+
+
+class TestComputeAcc(unittest.TestCase):
+
+    def test_padding_free_seq_acc_skips_ignored_labels(self):
+        metrics = compute_acc(PACKED_PREDS, PACKED_LABELS, acc_strategy='seq', cu_seqlens=CU_SEQLENS)
+
+        self.assertEqual([bool(acc) for acc in metrics['seq_acc']], [True, False])
+
+    def test_padding_free_seq_acc_matches_the_padded_batch(self):
+        packed = compute_acc(PACKED_PREDS, PACKED_LABELS, acc_strategy='seq', cu_seqlens=CU_SEQLENS)
+        padded = compute_acc(BATCH_PREDS, BATCH_LABELS, acc_strategy='seq')
+
+        self.assertEqual([bool(acc) for acc in packed['seq_acc']], [bool(acc) for acc in padded['seq_acc']])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

`seq_acc` is always 0 when training with `--padding_free true --acc_strategy seq`, even for sequences the model predicts perfectly.

`compute_acc` in `swift/metrics/acc.py` builds `masks = labels != -100` and then splits in two. The padded branch scores `np.all(preds[i, m] == labels[i, m])`, so it only looks at supervised positions. The padding-free branch, which `Seq2SeqTrainer.compute_loss` reaches by passing `cu_seqlens`, scores `np.all(preds[0, start:end] == labels[0, start:end])` and never touches `masks`. Prompt tokens carry the label -100 and `preds` holds token ids, so any packed sequence with a prompt in front of it compares -100 against a token id, `np.all` is False, and the metric reports 0.

The fix slices `masks` alongside `preds` and `labels`, so the padding-free branch scores the same positions the padded branch already scores. `acc_strategy=token` and the padded `seq` path do not reach this branch and are unchanged.

`tests/utils/test_acc_metrics.py` packs two sequences of two prompt tokens plus two response tokens, the first answered correctly and the second not. It asserts the result is `[True, False]`, and that it equals the result for the same data laid out as an ordinary padded batch.

## Experiment results

Both new tests fail on main and pass with this change.

`python -m pytest tests/utils/test_acc_metrics.py -q` on unmodified main: `2 failed`, the assertion diff being `- [False, False]` against `+ [True, False]`.

`python -m pytest tests/utils/test_acc_metrics.py -q` with this change: `2 passed`.

`python -m pytest tests/utils -q`: `1 failed, 89 passed, 22 skipped`. The single failure is `test_opsd_teacher_images.py::test_real_qwen2_vl_template_handles_fewer_teacher_images_than_tags`, which fails identically on unmodified main in my environment because `qwen_vl_utils` is not installed.

`pre-commit run --files swift/metrics/acc.py tests/utils/test_acc_metrics.py`: flake8, isort and yapf all pass.
