### PR TITLE
feat(rollout): add built-in AgentArk environment support

### DIFF
--- a/docs/source/Instruction/GRPO/DeveloperGuide/gym_env.md
+++ b/docs/source/Instruction/GRPO/DeveloperGuide/gym_env.md
@@ -358,3 +358,63 @@ swift rlhf \
 - https://github.com/alibaba/ROLL/tree/main/roll/pipeline/agentic/env/frozen_lake
 - https://github.com/huggingface/openenv
 - https://github.com/huggingface/trl/blob/main/examples/notebooks/openenv_sudoku_grpo.ipynb
+
+## AgentArk 环境训练
+
+[AgentArk](https://github.com/P90-RushB/AgentArk) 面向多模态 Agent 的强化学习与评估，环境由独立的 AgentArk Env Server 管理，实际任务运行在一个或多个 Unity runtime 中。Swift 内置的 `AgentArkEnv` 和 `AgentArkScheduler` 通过 HTTP protocol v2 完成 reset、step、reward 和 lease 回收；trainer 环境不需要安装 `agent-ark`，也不需要加载 `--external_plugins`。
+
+```text
+swift rlhf + AgentArkScheduler ──HTTP──> AgentArk Env Server ──> Unity runtime pool
+```
+
+### 1. 准备 AgentArk Server
+
+Env Server、Unity 包、runtime 配置与预热在 AgentArk 仓库中完成。首次使用建议直接按照 [AgentArk 的中文 Snake 教程](https://github.com/P90-RushB/AgentArk/blob/main/integrations/ms_swift/tutorial/README.zh-CN.md) 操作；该教程包含一个先将 Snake 地图缩小为 `8×8`、再运行 1-step smoke test 的完整示例。缩小地图只是为了降低早期探索难度、尽快验证训练链路，并非正式评测配置。
+
+Server 和 Swift trainer 可以使用不同的 Python 环境。Server 环境安装 AgentArk 和 ML-Agents，trainer 环境只安装 ms-swift。训练开始前应确认 Server health 正常、protocol v2 runtime 已预热，并且 idle runtime 数量不少于 `generation_batch_size`。
+
+### 2. 生成 ticket 数据集
+
+数据集中的行是轻量 ticket，真正的 system/user 消息和图片在环境 reset 后由 Unity 返回。每行代表一个 GRPO group；Swift 将该行复制为 `num_generations` 条 sibling trajectory，它们共享 `group_uid` 与初始 seed，但各自获得独立 lease。
+
+使用示例生成器创建唯一 ticket：
+
+```bash
+python examples/train/grpo/plugin/agentark/generate_tickets.py \
+    --output /path/to/agentark-tickets.jsonl \
+    --run-id snake-smoke \
+    --count 100 \
+    --task-name Snake \
+    --group-seed-base 1234
+```
+
+不要用数据集重复语法反复复制同一个 `group_uid`；长时间训练应准备足够多的唯一 ticket。
+
+### 3. 运行 1-step smoke test
+
+保持 Env Server 运行，在 trainer 终端设置必要变量：
+
+```bash
+export AGENTARK_MODEL=/path/to/a/swift-supported-multimodal-model
+export AGENTARK_TICKET_DATASET=/path/to/agentark-tickets.jsonl
+export AGENTARK_RUNTIME_CONFIG=/path/to/agentark_runtime_config.yaml
+export AGENTARK_SERVER_URL=http://127.0.0.1:18080
+
+bash examples/train/grpo/plugin/agentark/run_grpo.sh
+```
+
+示例默认使用内置的 `agentark_scheduler`、LoRA、vLLM colocate 和 `max_steps=1`。它只是最小链路检查；模型、GPU 数量、上下文长度、generation batch 和 vLLM 显存比例应按机器调整。至少检查训练到达 step 1、梯度有限、reward/completion 已写入、checkpoint 已生成，并且 Server 的 active lease 最终回到 0。跑通不要求复现固定 reward。
+
+核心 Swift 参数为：
+
+```bash
+swift rlhf ... \
+    --use_gym_env true \
+    --gym_env agentark \
+    --multi_turn_scheduler agentark_scheduler \
+    --max_turns 6
+```
+
+`AgentArkScheduler` 保留 rollout 返回的精确 token IDs 和逐 token loss mask，支持多轮 inline `image_url` 消息，并在正常结束、异常或取消时释放 lease。`assistant_loss_scope` 可在 ticket 的 `env_config` 中设为 `all_turns`（默认）或 `last_round`。
+
+完整示例文件：[`examples/train/grpo/plugin/agentark`](https://github.com/modelscope/ms-swift/tree/main/examples/train/grpo/plugin/agentark)。

--- a/docs/source_en/Instruction/GRPO/DeveloperGuide/gym_env.md
+++ b/docs/source_en/Instruction/GRPO/DeveloperGuide/gym_env.md
@@ -359,3 +359,63 @@ Runnable script: [`examples/train/grpo/plugin/openenv/run_grpo_sudoku.sh`](https
 4. **First-turn timing**: `on_trajectory_start` is called BEFORE the first rollout, ensuring the model sees the actual environment observation (e.g., Sudoku board) rather than the placeholder text from the dataset.
 5. **enable_thinking**: When using Qwen3.5 series models, set `--enable_thinking false` to skip `<think>` block generation.
 6. **Sync I/O**: `OpenEnvWrapper`'s `reset()`/`step()` are synchronous WebSocket calls. `OpenEnvScheduler` subclasses should wrap these calls with `asyncio.to_thread()` to avoid blocking the event loop.
+
+## AgentArk Environment Training
+
+[AgentArk](https://github.com/P90-RushB/AgentArk) provides multimodal agent environments for reinforcement learning and evaluation. A standalone AgentArk Env Server manages the environments, while one or more Unity runtimes execute the tasks. Swift's built-in `AgentArkEnv` and `AgentArkScheduler` use HTTP protocol v2 for reset, step, reward, and lease cleanup. The trainer environment does not need the `agent-ark` package or `--external_plugins`.
+
+```text
+swift rlhf + AgentArkScheduler ──HTTP──> AgentArk Env Server ──> Unity runtime pool
+```
+
+### 1. Prepare the AgentArk Server
+
+Prepare the Env Server, Unity package, runtime configuration, and warm pool from the AgentArk repository. First-time users should follow the complete [AgentArk Snake tutorial](https://github.com/P90-RushB/AgentArk/blob/main/integrations/ms_swift/tutorial/README.md). It temporarily reduces Snake from its default map to `8×8` and starts with a one-step smoke test. The smaller map reduces early exploration and helps validate the pipeline quickly; it is not the official evaluation configuration.
+
+The Server and Swift trainer may use separate Python environments. Install AgentArk and ML-Agents in the Server environment, and ms-swift in the trainer environment. Before training, require a healthy Server, pre-warmed protocol-v2 runtimes, and at least `generation_batch_size` idle runtimes.
+
+### 2. Generate a ticket dataset
+
+Dataset rows are lightweight tickets. Unity supplies the real system/user messages and images after reset. Each row identifies one GRPO group; Swift expands it into `num_generations` sibling trajectories that share a `group_uid` and initial seed while holding separate leases.
+
+Generate unique tickets with the included helper:
+
+```bash
+python examples/train/grpo/plugin/agentark/generate_tickets.py \
+    --output /path/to/agentark-tickets.jsonl \
+    --run-id snake-smoke \
+    --count 100 \
+    --task-name Snake \
+    --group-seed-base 1234
+```
+
+Do not use dataset repetition syntax to duplicate one `group_uid`. Prepare enough unique tickets for a longer run.
+
+### 3. Run a one-step smoke test
+
+Keep the Env Server running and set the required variables in the trainer terminal:
+
+```bash
+export AGENTARK_MODEL=/path/to/a/swift-supported-multimodal-model
+export AGENTARK_TICKET_DATASET=/path/to/agentark-tickets.jsonl
+export AGENTARK_RUNTIME_CONFIG=/path/to/agentark_runtime_config.yaml
+export AGENTARK_SERVER_URL=http://127.0.0.1:18080
+
+bash examples/train/grpo/plugin/agentark/run_grpo.sh
+```
+
+The example defaults to the built-in `agentark_scheduler`, LoRA, colocated vLLM, and `max_steps=1`. It is a minimal pipeline check, so adjust the model, GPU count, context length, generation batch, and vLLM memory fraction for the machine. At minimum, verify that training reaches step 1, gradients are finite, reward/completion logs and a checkpoint are written, and the Server eventually reports zero active leases. No exact reward needs to be reproduced.
+
+The essential Swift arguments are:
+
+```bash
+swift rlhf ... \
+    --use_gym_env true \
+    --gym_env agentark \
+    --multi_turn_scheduler agentark_scheduler \
+    --max_turns 6
+```
+
+`AgentArkScheduler` preserves the rollout's exact token IDs and per-token loss masks, supports multi-turn inline `image_url` messages, and releases leases after success, failure, or cancellation. Set `assistant_loss_scope` in a ticket's `env_config` to `all_turns` (default) or `last_round`.
+
+Example files: [`examples/train/grpo/plugin/agentark`](https://github.com/modelscope/ms-swift/tree/main/examples/train/grpo/plugin/agentark).

--- a/examples/train/grpo/plugin/agentark/generate_tickets.py
+++ b/examples/train/grpo/plugin/agentark/generate_tickets.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Generate placeholder-only AgentArk datasets for ms-swift GRPO."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+_RUN_ID_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._:-]*$')
+_MAX_GROUP_SEED = 2**31 - 2
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=('Generate unique AgentArk sampling tickets. Each JSONL row represents '
+                     'one GRPO prompt group; ms-swift repeats it num_generations times.'))
+    parser.add_argument('--output', type=Path, required=True, help='Output JSONL path')
+    parser.add_argument('--run-id', required=True, help='Unique experiment/run prefix')
+    parser.add_argument('--count', type=int, required=True, help='Number of unique group tickets')
+    parser.add_argument(
+        '--start-index',
+        type=int,
+        default=0,
+        help='First numeric ticket index (useful when extending a run)',
+    )
+    parser.add_argument(
+        '--task-name',
+        default=None,
+        help='Optionally pin every ticket to one AgentArk task',
+    )
+    seed_group = parser.add_mutually_exclusive_group()
+    seed_group.add_argument(
+        '--group-seed',
+        type=int,
+        default=None,
+        help='Optionally pin every ticket to the same group seed',
+    )
+    seed_group.add_argument(
+        '--group-seed-base',
+        type=int,
+        default=None,
+        help='Assign group_seed = base + ticket index',
+    )
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Replace an existing output file atomically',
+    )
+    return parser.parse_args()
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not _RUN_ID_RE.fullmatch(args.run_id):
+        raise SystemExit('--run-id must start with an alphanumeric character and contain only '
+                         "letters, digits, '.', '_', ':', or '-'")
+    if args.count <= 0:
+        raise SystemExit('--count must be greater than zero')
+    if args.start_index < 0:
+        raise SystemExit('--start-index must be non-negative')
+    if args.output.exists() and not args.force:
+        raise SystemExit(f'Output already exists (pass --force to replace it): {args.output}')
+    if args.task_name is not None and not args.task_name.strip():
+        raise SystemExit('--task-name cannot be empty')
+    for option, value in (
+        ('--group-seed', args.group_seed),
+        ('--group-seed-base', args.group_seed_base),
+    ):
+        if value is not None and not 1 <= value <= _MAX_GROUP_SEED:
+            raise SystemExit(f'{option} must be in [1, {_MAX_GROUP_SEED}]')
+    if args.group_seed_base is not None:
+        final_seed = args.group_seed_base + args.start_index + args.count - 1
+        if final_seed > _MAX_GROUP_SEED:
+            raise SystemExit(f'Sequential group seeds end at {final_seed}, above the maximum {_MAX_GROUP_SEED}')
+
+
+def _stable_group_seed(group_uid: str) -> int:
+    digest = hashlib.sha256(group_uid.encode('utf-8')).digest()
+    return int.from_bytes(digest[:8], 'big') % _MAX_GROUP_SEED + 1
+
+
+def _ticket(args: argparse.Namespace, index: int) -> dict[str, Any]:
+    group_uid = f'{args.run_id}:{index:08d}'
+    env_config: dict[str, Any] = {
+        'name': 'agentark',
+        'group_uid': group_uid,
+    }
+    if args.task_name is not None:
+        env_config['task_name'] = args.task_name.strip()
+    if args.group_seed is not None:
+        env_config['group_seed'] = args.group_seed
+    elif args.group_seed_base is not None:
+        env_config['group_seed'] = args.group_seed_base + index
+    elif args.task_name is not None:
+        # When task_name is pinned, the AgentArk server intentionally skips its
+        # uid -> (task, seed) selector. Derive a seed here so G sibling
+        # trajectories still reset to the same task state.
+        env_config['group_seed'] = _stable_group_seed(group_uid)
+
+    return {
+        'messages': [{
+            'role': 'user',
+            'content': f'<agentark-ticket:{group_uid}>',
+        }],
+        'env_config': env_config,
+    }
+
+
+def main() -> None:
+    args = _parse_args()
+    _validate_args(args)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+                mode='w',
+                encoding='utf-8',
+                dir=args.output.parent,
+                prefix=f'.{args.output.name}.',
+                suffix='.tmp',
+                delete=False,
+        ) as handle:
+            temp_path = Path(handle.name)
+            for offset in range(args.count):
+                index = args.start_index + offset
+                json.dump(_ticket(args, index), handle, ensure_ascii=False, separators=(',', ':'))
+                handle.write('\n')
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, args.output)
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+
+    final_index = args.start_index + args.count - 1
+    seed_mode = 'server-managed'
+    if args.group_seed is not None:
+        seed_mode = f'fixed:{args.group_seed}'
+    elif args.group_seed_base is not None:
+        seed_mode = f'sequential:{args.group_seed_base + args.start_index}..{args.group_seed_base + final_index}'
+    elif args.task_name is not None:
+        seed_mode = 'stable-derived-per-group'
+    print(
+        json.dumps(
+            {
+                'output': str(args.output),
+                'rows': args.count,
+                'first_group_uid': f'{args.run_id}:{args.start_index:08d}',
+                'last_group_uid': f'{args.run_id}:{final_index:08d}',
+                'task': args.task_name or 'server-managed',
+                'seed': seed_mode,
+            },
+            ensure_ascii=False,
+        ))
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/train/grpo/plugin/agentark/run_grpo.sh
+++ b/examples/train/grpo/plugin/agentark/run_grpo.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# AgentArk Env Server and Unity runtimes are prepared from the AgentArk repo.
+# See: https://github.com/P90-RushB/AgentArk/tree/main/integrations/ms_swift/tutorial
+: "${AGENTARK_MODEL:?Set AGENTARK_MODEL to a Swift-supported multimodal model}"
+: "${AGENTARK_TICKET_DATASET:?Set AGENTARK_TICKET_DATASET to a generated ticket JSONL file}"
+: "${AGENTARK_RUNTIME_CONFIG:?Set AGENTARK_RUNTIME_CONFIG to the AgentArk runtime YAML}"
+
+export AGENTARK_SERVER_URL="${AGENTARK_SERVER_URL:-http://127.0.0.1:18080}"
+export AGENTARK_PROTOCOL_VERSION="${AGENTARK_PROTOCOL_VERSION:-v2}"
+
+CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}" \
+NPROC_PER_NODE="${NPROC_PER_NODE:-1}" \
+swift rlhf \
+    --rlhf_type grpo \
+    --model "$AGENTARK_MODEL" \
+    --dataset "$AGENTARK_TICKET_DATASET" \
+    --split_dataset_ratio 0 \
+    --tuner_type lora \
+    --torch_dtype bfloat16 \
+    --use_gym_env true \
+    --gym_env agentark \
+    --multi_turn_scheduler agentark_scheduler \
+    --max_turns "${AGENTARK_MAX_TURNS:-6}" \
+    --num_generations "${AGENTARK_NUM_GENERATIONS:-4}" \
+    --generation_batch_size "${AGENTARK_GENERATION_BATCH_SIZE:-4}" \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 1 \
+    --max_length "${AGENTARK_MAX_LENGTH:-6144}" \
+    --max_completion_length "${AGENTARK_MAX_COMPLETION_LENGTH:-512}" \
+    --use_vllm true \
+    --vllm_mode colocate \
+    --vllm_gpu_memory_utilization "${AGENTARK_VLLM_GPU_MEMORY_UTILIZATION:-0.35}" \
+    --max_steps "${AGENTARK_MAX_STEPS:-1}" \
+    --save_steps 1 \
+    --logging_steps 1 \
+    --log_completions true \
+    --report_to none \
+    --output_dir "${AGENTARK_OUTPUT_DIR:-output/agentark-smoke}" \
+    "$@"

--- a/swift/megatron/trainers/rollout_mixin.py
+++ b/swift/megatron/trainers/rollout_mixin.py
@@ -37,7 +37,7 @@ from swift.rlhf_trainers.utils import (VLLM_LORA_INT_ID, VLLM_LORA_NAME, VLLM_LO
                                        patch_vllm_moe_model_weight_loader, profiling_context, profiling_decorator,
                                        set_expandable_segments, sleep_vllm_engine, vllm_supports_lora_load_inplace)
 from swift.rlhf_trainers.vllm_client import VLLMInferClient
-from swift.rollout import MultiTurnScheduler, invoke_async_hook, multi_turns, run_multi_turn
+from swift.rollout import MultiTurnScheduler, multi_turn_lifecycle, multi_turns, run_multi_turn
 from swift.utils import (JsonlWriter, get_current_device, get_logger, is_last_rank, is_vllm_available, remove_response,
                          synchronize, to_device)
 from .utils import (gather_object, load_megatron_model_to_gpu, load_megatron_optimizer, offload_megatron_model_to_cpu,
@@ -736,18 +736,18 @@ class MegatronRolloutMixin(BaseRolloutTrainerMixin):
 
                 if colocate_multi_turn:
                     requests = self.samples2requests(samples)
-                    invoke_async_hook(multi_turn_scheduler.on_trajectory_start(requests))
-                    request_config = self._get_request_config()
-                    outputs: List[RolloutOutput] = self._rollout_requests(requests, request_config)
-                    outputs = run_multi_turn(
-                        requests=requests,
-                        first_turn_outputs=outputs,
-                        scheduler=multi_turn_scheduler,
-                        rollout_fn=lambda reqs, cfg: self._rollout_requests(reqs, cfg),
-                        request_config=request_config,
-                        max_turns=self.args.max_turns,
-                        gather_fn=lambda x: gather_object(x, group=self._get_rollout_group()),
-                    )
+                    with multi_turn_lifecycle(multi_turn_scheduler, requests):
+                        request_config = self._get_request_config()
+                        outputs: List[RolloutOutput] = self._rollout_requests(requests, request_config)
+                        outputs = run_multi_turn(
+                            requests=requests,
+                            first_turn_outputs=outputs,
+                            scheduler=multi_turn_scheduler,
+                            rollout_fn=lambda reqs, cfg: self._rollout_requests(reqs, cfg),
+                            request_config=request_config,
+                            max_turns=self.args.max_turns,
+                            gather_fn=lambda x: gather_object(x, group=self._get_rollout_group()),
+                        )
                 else:
                     # Single-turn rollout (or server multi-turn handled by the engine).
                     outputs: List[RolloutOutput] = self._rollout(samples)

--- a/swift/ray/megatron/gkd_trainer.py
+++ b/swift/ray/megatron/gkd_trainer.py
@@ -13,7 +13,7 @@ from swift.infer_engine.protocol import RequestConfig, RolloutOutput
 from swift.rl_core.data import GKDSample
 from swift.rlhf_trainers.gkd_loss import DataSource, TeacherOutput
 from swift.rlhf_trainers.utils import parse_prompt_logprobs
-from swift.rollout import MultiTurnScheduler, invoke_async_hook, multi_turns, run_multi_turn
+from swift.rollout import MultiTurnScheduler, multi_turn_lifecycle, multi_turns, run_multi_turn
 from swift.utils import get_logger, remove_response
 from .base_trainer import BaseRayTrainer
 from .driver_utils import extract_iteration
@@ -190,19 +190,19 @@ class GKDTrainer(BaseRayTrainer):
         if self._multi_turn_scheduler is not None and not self._enable_server_multi_turn:
             # Mode A: driver-side trainer loop. run_multi_turn mutates `messages`
             # in place on RolloutInferRequest objects.
-            invoke_async_hook(self._multi_turn_scheduler.on_trajectory_start(requests))
-            first_turn = [
-                RolloutOutput(response=resp) for resp in self._distribute_to_replicas(requests, request_config)
-            ]
-            return run_multi_turn(
-                requests=requests,
-                first_turn_outputs=first_turn,
-                scheduler=self._multi_turn_scheduler,
-                rollout_fn=lambda reqs, cfg:
-                [RolloutOutput(response=resp) for resp in self._distribute_to_replicas(reqs, cfg)],
-                request_config=request_config,
-                max_turns=self._max_turns,
-            )
+            with multi_turn_lifecycle(self._multi_turn_scheduler, requests):
+                first_turn = [
+                    RolloutOutput(response=resp) for resp in self._distribute_to_replicas(requests, request_config)
+                ]
+                return run_multi_turn(
+                    requests=requests,
+                    first_turn_outputs=first_turn,
+                    scheduler=self._multi_turn_scheduler,
+                    rollout_fn=lambda reqs, cfg:
+                    [RolloutOutput(response=resp) for resp in self._distribute_to_replicas(reqs, cfg)],
+                    request_config=request_config,
+                    max_turns=self._max_turns,
+                )
 
         completions = self._distribute_to_replicas(requests, request_config)
         return [RolloutOutput(response=resp) for resp in completions]

--- a/swift/ray/megatron/grpo_trainer.py
+++ b/swift/ray/megatron/grpo_trainer.py
@@ -21,7 +21,7 @@ from swift.rlhf_trainers.gkd_helpers import (TeacherServerConfig, assemble_teach
                                              remap_teacher_logps_to_student_frame,
                                              resolve_dynamic_opd_self_distillation)
 from swift.rlhf_trainers.utils import encode_sample, make_reward_weights, resolve_reward_funcs
-from swift.rollout import MultiTurnScheduler, invoke_async_hook, multi_turns, run_multi_turn
+from swift.rollout import MultiTurnScheduler, multi_turn_lifecycle, multi_turns, run_multi_turn
 from swift.utils import get_logger, remove_response
 from .base_trainer import BaseRayTrainer
 from .driver_utils import extract_iteration
@@ -407,19 +407,19 @@ class GRPOTrainer(BaseRayTrainer):
         if self._multi_turn_scheduler is not None and not self._enable_server_multi_turn:
             # Mode A: driver-side trainer loop. run_multi_turn mutates `messages`
             # in place on RolloutInferRequest objects.
-            invoke_async_hook(self._multi_turn_scheduler.on_trajectory_start(requests))
-            first_turn = [
-                RolloutOutput(response=resp) for resp in self._distribute_to_replicas(requests, request_config)
-            ]
-            return run_multi_turn(
-                requests=requests,
-                first_turn_outputs=first_turn,
-                scheduler=self._multi_turn_scheduler,
-                rollout_fn=lambda reqs, cfg:
-                [RolloutOutput(response=resp) for resp in self._distribute_to_replicas(reqs, cfg)],
-                request_config=request_config,
-                max_turns=self._max_turns,
-            )
+            with multi_turn_lifecycle(self._multi_turn_scheduler, requests):
+                first_turn = [
+                    RolloutOutput(response=resp) for resp in self._distribute_to_replicas(requests, request_config)
+                ]
+                return run_multi_turn(
+                    requests=requests,
+                    first_turn_outputs=first_turn,
+                    scheduler=self._multi_turn_scheduler,
+                    rollout_fn=lambda reqs, cfg:
+                    [RolloutOutput(response=resp) for resp in self._distribute_to_replicas(reqs, cfg)],
+                    request_config=request_config,
+                    max_turns=self._max_turns,
+                )
 
         # Mode B (server-side multi-turn, currently disabled) + single-turn share this path.
         completions = self._distribute_to_replicas(requests, request_config)

--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -32,7 +32,7 @@ from swift.infer_engine.protocol import ChatCompletionResponse, RolloutInferRequ
 from swift.model import MultiModelKeys
 from swift.rl_core.data import OnPolicySample
 from swift.rl_core.resample import resample_encode_failed_inputs
-from swift.rollout import MultiTurnScheduler, invoke_async_hook, multi_turns, run_multi_turn
+from swift.rollout import MultiTurnScheduler, multi_turn_lifecycle, multi_turns, run_multi_turn
 from swift.sequence_parallel import sequence_parallel
 from swift.template import Template
 from swift.tuners import Swift
@@ -1130,16 +1130,15 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
         # Multi-turn: call on_trajectory_start BEFORE first turn generation
         # so the model sees the actual environment question, not the placeholder.
         requests = self.samples2requests(samples)
-        invoke_async_hook(self.multi_turn_scheduler.on_trajectory_start(requests))
+        with multi_turn_lifecycle(self.multi_turn_scheduler, requests):
+            # Update inputs with actual messages from requests (e.g. env question)
+            for req, sample in zip(requests, samples):
+                sample.messages = req.messages
 
-        # Update inputs with actual messages from requests (e.g. env question)
-        for req, sample in zip(requests, samples):
-            sample.messages = req.messages
+            # Generate first turn with actual questions
+            first_turn_rollout_outputs: List[RolloutOutput] = self._rollout(samples, request_config, is_global_inputs)
 
-        # Generate first turn with actual questions
-        first_turn_rollout_outputs: List[RolloutOutput] = self._rollout(samples, request_config, is_global_inputs)
-
-        return self._colocate_multi_turn_infer(samples, first_turn_rollout_outputs, request_config, requests)
+            return self._colocate_multi_turn_infer(samples, first_turn_rollout_outputs, request_config, requests)
 
     def _colocate_multi_turn_infer(self,
                                    samples: List[OnPolicySample],

--- a/swift/rollout/__init__.py
+++ b/swift/rollout/__init__.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from swift.utils.import_utils import _LazyModule
 
 if TYPE_CHECKING:
-    from .agent_loop import extract_logprobs_from_choice, invoke_async_hook, run_multi_turn
+    from .agent_loop import extract_logprobs_from_choice, invoke_async_hook, multi_turn_lifecycle, run_multi_turn
     from .gym_env import Env, envs
     from .multi_turn import MultiTurnScheduler, RolloutScheduler, multi_turns
 
@@ -12,7 +12,7 @@ else:
     _import_structure = {
         'multi_turn': ['multi_turns', 'RolloutScheduler', 'MultiTurnScheduler'],
         'gym_env': ['envs', 'Env'],
-        'agent_loop': ['run_multi_turn', 'extract_logprobs_from_choice', 'invoke_async_hook'],
+        'agent_loop': ['run_multi_turn', 'multi_turn_lifecycle', 'extract_logprobs_from_choice', 'invoke_async_hook'],
     }
 
     import sys

--- a/swift/rollout/__init__.py
+++ b/swift/rollout/__init__.py
@@ -6,11 +6,11 @@ from swift.utils.import_utils import _LazyModule
 if TYPE_CHECKING:
     from .agent_loop import extract_logprobs_from_choice, invoke_async_hook, multi_turn_lifecycle, run_multi_turn
     from .gym_env import Env, envs
-    from .multi_turn import MultiTurnScheduler, RolloutScheduler, multi_turns
+    from .multi_turn import AgentArkScheduler, MultiTurnScheduler, RolloutScheduler, multi_turns
 
 else:
     _import_structure = {
-        'multi_turn': ['multi_turns', 'RolloutScheduler', 'MultiTurnScheduler'],
+        'multi_turn': ['multi_turns', 'RolloutScheduler', 'MultiTurnScheduler', 'AgentArkScheduler'],
         'gym_env': ['envs', 'Env'],
         'agent_loop': ['run_multi_turn', 'multi_turn_lifecycle', 'extract_logprobs_from_choice', 'invoke_async_hook'],
     }

--- a/swift/rollout/agent_loop.py
+++ b/swift/rollout/agent_loop.py
@@ -12,11 +12,12 @@ Megatron-Ray driver process:
                     all ranks can agree on the termination condition.
 """
 import asyncio
+from contextlib import contextmanager
 from typing import Callable, List, Optional
 
 from swift.infer_engine import RequestConfig
 from swift.infer_engine.protocol import ChatCompletionResponseChoice, RolloutInferRequest, RolloutOutput
-from swift.utils import remove_response
+from swift.utils import get_logger, remove_response
 from .multi_turn import MultiTurnScheduler
 
 RolloutFn = Callable[[List[RolloutInferRequest], RequestConfig], List[RolloutOutput]]
@@ -25,6 +26,7 @@ RolloutFn = Callable[[List[RolloutInferRequest], RequestConfig], List[RolloutOut
 # concatenated flat list across all ranks. Passing a scalar would crash
 # accelerate's implementation (it iterates each rank's contribution).
 GatherFn = Callable[[List[bool]], List[bool]]
+logger = get_logger()
 
 
 def _identity_gather(values: List[bool]) -> List[bool]:
@@ -43,6 +45,30 @@ def invoke_async_hook(coro):
         return loop.run_until_complete(coro)
     finally:
         loop.close()
+
+
+@contextmanager
+def multi_turn_lifecycle(scheduler: MultiTurnScheduler, requests: List[RolloutInferRequest]):
+    """Run colocate multi-turn initialization and finalization as one boundary.
+
+    Finalization runs even when initialization or first-turn generation fails.
+    A finalization error is raised after a successful rollout, but cannot mask
+    an exception that is already propagating from the rollout itself.
+    """
+    rollout_error = None
+    try:
+        invoke_async_hook(scheduler.on_trajectory_start(requests))
+        yield
+    except BaseException as error:
+        rollout_error = error
+        raise
+    finally:
+        try:
+            invoke_async_hook(scheduler.on_trajectory_end(requests, rollout_error))
+        except BaseException:
+            if rollout_error is None:
+                raise
+            logger.exception('Trajectory finalization failed while preserving the original rollout error')
 
 
 def extract_logprobs_from_choice(response_choice: ChatCompletionResponseChoice) -> List[float]:

--- a/swift/rollout/agentark/__init__.py
+++ b/swift/rollout/agentark/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""HTTP protocol support for the built-in AgentArk rollout scheduler."""
+
+from .client import AgentArkHttpClient, AgentArkHttpError, AgentArkStaleLeaseError
+from .env import AgentArkEnv
+
+__all__ = [
+    'AgentArkEnv',
+    'AgentArkHttpClient',
+    'AgentArkHttpError',
+    'AgentArkStaleLeaseError',
+]

--- a/swift/rollout/agentark/client.py
+++ b/swift/rollout/agentark/client.py
@@ -1,0 +1,484 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Asynchronous, dependency-light client for the AgentArk HTTP protocol."""
+
+from __future__ import annotations
+
+import aiohttp
+import asyncio
+import json
+import os
+import socket
+import threading
+import uuid
+from copy import deepcopy
+from typing import Any, Mapping
+
+from .heartbeat import LeaseHandle
+
+
+class AgentArkHttpError(RuntimeError):
+    """An AgentArk request failed or returned an invalid response."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        method: str | None = None,
+        path: str | None = None,
+        status_code: int | None = None,
+        response_body: str | None = None,
+        code: str | None = None,
+        retryable: bool | None = None,
+        retry_after_s: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.method = method
+        self.path = path
+        self.status_code = status_code
+        self.response_body = response_body
+        self.code = code
+        self.retryable = retryable
+        self.retry_after_s = retry_after_s
+
+
+class AgentArkStaleLeaseError(AgentArkHttpError):
+    """The server rejected a request using an obsolete lease identity."""
+
+
+_CLIENT_ID_LOCK = threading.Lock()
+_CLIENT_ID_PID: int | None = None
+_CLIENT_ID: str | None = None
+_OPERATION_NAMESPACE = uuid.UUID('6770be85-41ef-4dc0-a1a4-df9f3b21f84d')
+
+
+def process_client_id() -> str:
+    """Return a process-local identity and regenerate it after ``fork``."""
+
+    configured = str(os.getenv('AGENTARK_CLIENT_ID') or '').strip()
+    if configured:
+        return configured
+    global _CLIENT_ID, _CLIENT_ID_PID
+    pid = os.getpid()
+    with _CLIENT_ID_LOCK:
+        if _CLIENT_ID is None or _CLIENT_ID_PID != pid:
+            host = socket.gethostname().split('.', 1)[0] or 'host'
+            _CLIENT_ID = f'swift-{host}-{pid}-{uuid.uuid4().hex[:12]}'
+            _CLIENT_ID_PID = pid
+        return _CLIENT_ID
+
+
+def stable_operation_id(kind: str, *parts: str) -> str:
+    """Build a compact deterministic idempotency id from stable inputs."""
+
+    name = '\x1f'.join([str(kind), *(str(part) for part in parts)])
+    return f'{kind}-{uuid.uuid5(_OPERATION_NAMESPACE, name).hex}'
+
+
+def _error_detail(payload: Any) -> tuple[str | None, bool | None, str | None]:
+    if not isinstance(payload, Mapping):
+        return None, None, None
+    detail: Any = payload.get('error')
+    if not isinstance(detail, Mapping):
+        detail = payload.get('detail')
+    if isinstance(detail, Mapping) and isinstance(detail.get('error'), Mapping):
+        detail = detail['error']
+    if not isinstance(detail, Mapping):
+        # Some endpoints may return the stable error shape at top level.
+        detail = payload if 'code' in payload else None
+    if not isinstance(detail, Mapping):
+        return None, None, None
+    code_value = detail.get('code')
+    code = None if code_value in (None, '') else str(code_value)
+    retryable_value = detail.get('retryable')
+    retryable = None if retryable_value is None else bool(retryable_value)
+    message_value = detail.get('message')
+    message = None if message_value in (None, '') else str(message_value)
+    return code, retryable, message
+
+
+def _is_stale_lease_conflict(
+    *,
+    status_code: int | None,
+    code: str | None,
+    message: str | None,
+    response_body: str | None,
+) -> bool:
+    """Recognize ownership conflicts without treating every HTTP 409 as stale.
+
+    A 409 such as ``operation_in_progress`` or a semantic turn conflict is
+    handled by the normal HTTP client policy.  The server versions used by
+    AgentArk have emitted both structured and plain-text stale-ownership
+    messages, so keep the fallback deliberately narrow.
+    """
+
+    if status_code not in {409, 410}:
+        return False
+    normalized_code = (code or '').strip().lower()
+    if normalized_code in {
+            'lease_gone',
+            'stale_lease',
+            'lease_stale',
+            'lease_identity_conflict',
+            'lease_generation_conflict',
+            'server_epoch_conflict',
+    }:
+        return True
+    text = ' '.join(part.strip().lower() for part in (message or '', response_body or '') if part)
+    return ('lease identity does not own env_id' in text or 'belongs to an older generation' in text
+            or 'older lease generation' in text or 'server epoch' in text and 'lease' in text)
+
+
+def _http_error(
+    *,
+    message: str,
+    path: str,
+    status_code: int | None,
+    response_body: str | None,
+    code: str | None = None,
+    retryable: bool | None = None,
+    retry_after_s: float | None = None,
+) -> AgentArkHttpError:
+    error_type = (
+        AgentArkStaleLeaseError if _is_stale_lease_conflict(
+            status_code=status_code,
+            code=code,
+            message=message,
+            response_body=response_body,
+        ) else AgentArkHttpError)
+    return error_type(
+        message,
+        method='POST',
+        path=path,
+        status_code=status_code,
+        response_body=response_body,
+        code=code,
+        retryable=retryable,
+        retry_after_s=retry_after_s,
+    )
+
+
+class AgentArkHttpClient:
+    """Async client for v2 leases with an explicit v1 compatibility mode.
+
+    V2 acquire, step, and release carry idempotency IDs, so transport failures,
+    HTTP 5xx responses, and ``operation_in_progress`` may be retried with the
+    exact same payload.  V1 keeps its original no-retry behavior because a lost
+    response could otherwise acquire twice or execute an action twice.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout_s: float = 600.0,
+        release_timeout_s: float = 30.0,
+        protocol_version: str | None = None,
+        client_id: str | None = None,
+        v2_max_attempts: int = 3,
+        v2_retry_base_delay_s: float = 0.1,
+        v2_retry_max_delay_s: float = 1.0,
+        client: aiohttp.ClientSession | None = None,
+    ) -> None:
+        base_url = str(base_url or '').strip().rstrip('/')
+        if not base_url:
+            raise ValueError('AgentArk server base_url must not be empty')
+        if timeout_s <= 0:
+            raise ValueError('timeout_s must be positive')
+        if release_timeout_s <= 0:
+            raise ValueError('release_timeout_s must be positive')
+        resolved_protocol = str(protocol_version or os.getenv('AGENTARK_PROTOCOL_VERSION') or 'v2').strip().lower()
+        if resolved_protocol not in {'v1', 'v2'}:
+            raise ValueError("protocol_version must be 'v1' or 'v2'")
+        if int(v2_max_attempts) <= 0:
+            raise ValueError('v2_max_attempts must be positive')
+        if float(v2_retry_base_delay_s) < 0 or float(v2_retry_max_delay_s) < 0:
+            raise ValueError('v2 retry delays must not be negative')
+
+        self.base_url = base_url
+        self.timeout_s = float(timeout_s)
+        self.release_timeout_s = float(release_timeout_s)
+        self.protocol_version = resolved_protocol
+        self._explicit_client_id = None if client_id in (None, '') else str(client_id)
+        self.v2_max_attempts = int(v2_max_attempts)
+        self.v2_retry_base_delay_s = float(v2_retry_base_delay_s)
+        self.v2_retry_max_delay_s = float(v2_retry_max_delay_s)
+        # Swift colocate may drive reset, turn-end, and cleanup hooks through
+        # separate short-lived asyncio loops. A pooled
+        # ClientSession opened during reset retains transports bound to that
+        # first loop and fails later with ``Event loop is closed``. The normal
+        # path therefore creates one client per request in the *current* loop.
+        # An explicitly injected client is retained for transport-level tests;
+        # its lifecycle and loop affinity remain the caller's responsibility.
+        self._client = client
+        self._closed = False
+
+    @property
+    def client_id(self) -> str:
+        return self._explicit_client_id or process_client_id()
+
+    async def _post_once(
+        self,
+        path: str,
+        payload: Mapping[str, Any],
+        *,
+        timeout_s: float,
+    ) -> dict[str, Any]:
+        if self._closed:
+            raise RuntimeError('AgentArkHttpClient is closed')
+        try:
+            if self._client is None:
+                timeout = aiohttp.ClientTimeout(total=timeout_s)
+                async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as request_client:
+                    async with request_client.post(f'{self.base_url}{path}', json=dict(payload)) as response:
+                        status_code = response.status
+                        headers = response.headers
+                        response_bytes = await response.read()
+            else:
+                timeout = aiohttp.ClientTimeout(total=timeout_s)
+                async with self._client.post(f'{self.base_url}{path}', json=dict(payload), timeout=timeout) as response:
+                    status_code = response.status
+                    headers = response.headers
+                    response_bytes = await response.read()
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            raise AgentArkHttpError(
+                f'AgentArk POST {path} failed: {type(exc).__name__}: {exc}',
+                method='POST',
+                path=path,
+            ) from exc
+
+        body = response_bytes.decode('utf-8', errors='replace')[:4000]
+        try:
+            result = json.loads(response_bytes)
+        except (TypeError, ValueError) as exc:
+            if status_code >= 400:
+                raise _http_error(
+                    message=f'AgentArk POST {path} returned HTTP {status_code}: {body}',
+                    path=path,
+                    status_code=status_code,
+                    response_body=body,
+                    retry_after_s=self._retry_after(headers),
+                ) from exc
+            raise AgentArkHttpError(
+                f'AgentArk POST {path} returned non-JSON data: {body}',
+                method='POST',
+                path=path,
+                status_code=status_code,
+                response_body=body,
+            ) from exc
+
+        code, retryable, detail_message = _error_detail(result)
+        if status_code >= 400:
+            suffix = detail_message or body
+            raise _http_error(
+                message=f'AgentArk POST {path} returned HTTP {status_code}: {suffix}',
+                path=path,
+                status_code=status_code,
+                response_body=body,
+                code=code,
+                retryable=retryable,
+                retry_after_s=self._retry_after(headers),
+            )
+        if not isinstance(result, dict):
+            raise AgentArkHttpError(
+                f'AgentArk POST {path} returned {type(result).__name__}, expected an object',
+                method='POST',
+                path=path,
+                status_code=status_code,
+                response_body=body,
+            )
+        if code == 'operation_in_progress':
+            raise AgentArkHttpError(
+                f'AgentArk POST {path} reported operation_in_progress: {detail_message or body}',
+                method='POST',
+                path=path,
+                status_code=status_code,
+                response_body=body,
+                code=code,
+                retryable=True,
+                retry_after_s=self._retry_after(headers),
+            )
+        return result
+
+    async def _post(
+        self,
+        path: str,
+        payload: Mapping[str, Any],
+        *,
+        timeout_s: float | None = None,
+        allow_v2_retry: bool = False,
+    ) -> dict[str, Any]:
+        request_timeout = self.timeout_s if timeout_s is None else float(timeout_s)
+        stable_payload = deepcopy(dict(payload))
+        attempts = self.v2_max_attempts if allow_v2_retry else 1
+        for attempt in range(1, attempts + 1):
+            try:
+                return await self._post_once(path, stable_payload, timeout_s=request_timeout)
+            except AgentArkHttpError as exc:
+                should_retry = (
+                    allow_v2_retry and attempt < attempts and
+                    (exc.status_code is None or
+                     (exc.status_code is not None and exc.status_code >= 500) or exc.code == 'operation_in_progress'))
+                if not should_retry:
+                    raise
+                delay = min(
+                    self.v2_retry_max_delay_s,
+                    self.v2_retry_base_delay_s * (2**(attempt - 1)),
+                )
+                if exc.retry_after_s is not None:
+                    delay = min(self.v2_retry_max_delay_s, max(delay, exc.retry_after_s))
+                if delay > 0:
+                    await asyncio.sleep(delay)
+        raise AssertionError('unreachable')
+
+    @staticmethod
+    def _retry_after(headers: Mapping[str, str]) -> float | None:
+        value = headers.get('Retry-After')
+        if value in (None, ''):
+            return None
+        try:
+            return max(0.0, float(value))
+        except ValueError:
+            return None
+
+    async def acquire_start(
+        self,
+        env_cfg: Mapping[str, Any],
+        *,
+        uid: str,
+        task_name: str | None = None,
+        group_seed: int | None = None,
+        env_id: str | None = None,
+        unity_env_id: int | None = None,
+        acquire_request_id: str | None = None,
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Lease a runtime and reset it in one server operation."""
+
+        payload = {
+            'cfg': deepcopy(dict(env_cfg)),
+            'env_id': env_id,
+            'task_name': task_name,
+            'group_seed': group_seed,
+            'unity_env_id': unity_env_id,
+            'uid': uid,
+        }
+        if self.protocol_version == 'v1':
+            return await self._post('/v1/envs/acquire_start', payload)
+        request_id = str(acquire_request_id or '').strip()
+        if not request_id:
+            raise ValueError('acquire_request_id is required by AgentArk protocol v2')
+        payload = {
+            'acquire_request_id': request_id,
+            'client_id': str(client_id or self.client_id),
+            **payload,
+        }
+        return await self._post('/v2/envs/acquire_start', payload, allow_v2_retry=True)
+
+    async def step(
+        self,
+        lease: LeaseHandle | str,
+        *,
+        action: str | None,
+        assistant: str,
+        action_id: str | None = None,
+        turn_index: int | None = None,
+    ) -> dict[str, Any]:
+        """Execute one model action, replay-safe under protocol v2."""
+
+        if self.protocol_version == 'v1':
+            env_id = lease.env_id if isinstance(lease, LeaseHandle) else str(lease)
+            return await self._post(
+                f'/v1/envs/{env_id}/step',
+                {
+                    'action': action,
+                    'assistant': assistant
+                },
+            )
+        if not isinstance(lease, LeaseHandle):
+            raise TypeError('AgentArk protocol v2 step requires a LeaseHandle')
+        resolved_action_id = str(action_id or '').strip()
+        if not resolved_action_id:
+            raise ValueError('action_id is required by AgentArk protocol v2')
+        if turn_index is None or int(turn_index) <= 0:
+            raise ValueError('turn_index must be positive for AgentArk protocol v2')
+        lease.assert_active()
+        payload = {
+            **lease.request_identity(),
+            'action_id': resolved_action_id,
+            'turn_index': int(turn_index),
+            'action': action,
+            'assistant': assistant,
+        }
+        try:
+            result = await self._post(
+                f'/v2/envs/{lease.env_id}/step',
+                payload,
+                allow_v2_retry=True,
+            )
+        except AgentArkStaleLeaseError as exc:
+            lease.mark_expired(f'server rejected stale lease identity: {exc}')
+            raise
+        if bool(result.get('lease_expired_after_step')):
+            lease.mark_expired('server expired the lease while this step was in progress')
+        else:
+            lease.mark_alive(
+                lease_ttl_s=self._optional_number(result.get('lease_ttl_s')),
+                lease_expires_in_s=self._optional_number(result.get('lease_expires_in_s')),
+            )
+        return result
+
+    async def release(
+        self,
+        lease: LeaseHandle | str,
+        *,
+        release_request_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Return one exact leased runtime to AgentArk's pool."""
+
+        if self.protocol_version == 'v1':
+            env_id = lease.env_id if isinstance(lease, LeaseHandle) else str(lease)
+            return await self._post(
+                f'/v1/envs/{env_id}/release',
+                {},
+                timeout_s=self.release_timeout_s,
+            )
+        if not isinstance(lease, LeaseHandle):
+            raise TypeError('AgentArk protocol v2 release requires a LeaseHandle')
+        request_id = str(release_request_id or lease.release_request_id).strip()
+        if not request_id:
+            raise ValueError('release_request_id is required by AgentArk protocol v2')
+        try:
+            return await self._post(
+                f'/v2/envs/{lease.env_id}/release',
+                {
+                    **lease.request_identity(), 'release_request_id': request_id
+                },
+                timeout_s=self.release_timeout_s,
+                allow_v2_retry=True,
+            )
+        except AgentArkStaleLeaseError:
+            # The server no longer recognizes this identity.  From the
+            # client's perspective the lease is already gone; do not turn
+            # cleanup of an obsolete lease into a second failure.
+            lease.mark_expired('server rejected stale lease during release')
+            return {'ok': True, 'stale_lease': True}
+
+    @staticmethod
+    def _optional_number(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+    async def __aenter__(self) -> 'AgentArkHttpClient':
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        await self.aclose()

--- a/swift/rollout/agentark/env.py
+++ b/swift/rollout/agentark/env.py
@@ -1,0 +1,364 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Swift Env implementation backed by the existing AgentArk HTTP server."""
+
+from __future__ import annotations
+
+import logging
+import os
+import yaml
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Mapping
+
+from swift.infer_engine.protocol import RolloutInferRequest
+from swift.rollout.gym_env import Env
+from swift.template import Messages
+from .client import AgentArkHttpClient, AgentArkStaleLeaseError, stable_operation_id
+from .heartbeat import HeartbeatSupervisor, LeaseExpiredError, LeaseHandle, get_heartbeat_supervisor
+from .messages import copy_messages, extract_action, latest_assistant_text
+
+logger = logging.getLogger(__name__)
+
+
+def _optional_float(value: Any, *, default: float, name: str) -> float:
+    resolved = default if value in (None, '') else float(value)
+    if resolved <= 0:
+        raise ValueError(f'{name} must be positive')
+    return resolved
+
+
+def _expand_paths_and_vars(value: Any) -> Any:
+    """Recursively expand shell variables and ``~`` in config strings."""
+
+    if isinstance(value, str):
+        return os.path.expanduser(os.path.expandvars(value))
+    if isinstance(value, Mapping):
+        return {str(key): _expand_paths_and_vars(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_expand_paths_and_vars(item) for item in value]
+    if isinstance(value, tuple):
+        return [_expand_paths_and_vars(item) for item in value]
+    return value
+
+
+def _deep_merge(base: Mapping[str, Any], override: Mapping[str, Any]) -> dict[str, Any]:
+    """Merge mappings recursively; non-mapping override values replace base."""
+
+    result = deepcopy(dict(base))
+    for key, value in override.items():
+        current = result.get(key)
+        if isinstance(current, Mapping) and isinstance(value, Mapping):
+            result[key] = _deep_merge(current, value)
+        else:
+            result[key] = deepcopy(value)
+    return result
+
+
+def _load_runtime_config(path_value: str | os.PathLike[str] | None) -> dict[str, Any]:
+    if path_value in (None, ''):
+        return {}
+    path = Path(str(path_value)).expanduser()
+    if not path.is_file():
+        raise FileNotFoundError(f'AgentArk runtime config not found: {path}')
+    with path.open('r', encoding='utf-8') as stream:
+        data = yaml.safe_load(stream)
+    if data is None:
+        return {}
+    if not isinstance(data, Mapping):
+        raise ValueError(f'AgentArk runtime config must contain a mapping: {path}')
+    expanded = _expand_paths_and_vars(data)
+    assert isinstance(expanded, dict)
+    return expanded
+
+
+def resolve_runtime_config(env_config: Mapping[str, Any]) -> dict[str, Any]:
+    """Resolve the file's ``env_cfg`` plus an optional per-row deep override."""
+
+    config_path = env_config.get('runtime_config_path') or os.getenv('AGENTARK_RUNTIME_CONFIG')
+    document = _load_runtime_config(config_path)
+    # The shared AgentArk runtime file also contains server/warmup/interaction
+    # sections. acquire_start expects only its nested env_cfg payload so it can
+    # match a pre-warmed pool runtime.
+    file_env_cfg = document.get('env_cfg', document)
+    if not isinstance(file_env_cfg, Mapping):
+        raise ValueError('AgentArk runtime config env_cfg must be a mapping')
+    result = deepcopy(dict(file_env_cfg))
+    inline = env_config.get('agentark_env_cfg')
+    if inline is None:
+        inline = env_config.get('runtime_cfg')
+    if inline is None:
+        inline = env_config.get('cfg')
+    if inline is not None:
+        if not isinstance(inline, Mapping):
+            raise ValueError('env_config.agentark_env_cfg must be a mapping')
+        result = _deep_merge(result, _expand_paths_and_vars(inline))
+    if not result:
+        raise ValueError('AgentArk runtime config is empty; set AGENTARK_RUNTIME_CONFIG or '
+                         'env_config.agentark_env_cfg')
+    return result
+
+
+class AgentArkEnv(Env):
+    """One Swift rollout trajectory backed by one leased AgentArk runtime."""
+
+    def __init__(
+        self,
+        env_config: dict[str, Any],
+        *,
+        client: AgentArkHttpClient | Any | None = None,
+        heartbeat_supervisor: HeartbeatSupervisor | Any | None = None,
+    ) -> None:
+        super().__init__(deepcopy(env_config))
+        self.agentark_env_cfg = resolve_runtime_config(env_config)
+        self.group_uid = str(env_config.get('group_uid') or env_config.get('uid') or '').strip()
+        if not self.group_uid:
+            raise ValueError('env_config.group_uid is required for GRPO group-consistent reset')
+
+        loss_scope = env_config.get('assistant_loss_scope') or os.getenv('AGENTARK_ASSISTANT_LOSS_SCOPE', 'all_turns')
+        self.assistant_loss_scope = str(loss_scope).strip().lower()
+        if self.assistant_loss_scope not in {'all_turns', 'last_round'}:
+            raise ValueError("assistant_loss_scope must be 'all_turns' or 'last_round'")
+
+        self.task_name = env_config.get('task_name')
+        seed = env_config.get('group_seed')
+        self.group_seed = None if seed in (None, '') else int(seed)
+        self.requested_env_id = env_config.get('env_id')
+        unity_env_id = env_config.get('unity_env_id')
+        self.unity_env_id = None if unity_env_id in (None, '') else int(unity_env_id)
+
+        server_url = env_config.get('server_url') or os.getenv('AGENTARK_SERVER_URL', 'http://127.0.0.1:18080')
+        timeout_s = _optional_float(
+            env_config.get('http_timeout_s') or os.getenv('AGENTARK_HTTP_TIMEOUT'),
+            default=600.0,
+            name='http_timeout_s',
+        )
+        release_timeout_s = _optional_float(
+            env_config.get('release_timeout_s') or os.getenv('AGENTARK_RELEASE_TIMEOUT'),
+            default=30.0,
+            name='release_timeout_s',
+        )
+        heartbeat_timeout_s = _optional_float(
+            env_config.get('heartbeat_timeout_s') or os.getenv('AGENTARK_HEARTBEAT_TIMEOUT'),
+            default=5.0,
+            name='heartbeat_timeout_s',
+        )
+        configured_protocol = str(env_config.get('protocol_version') or os.getenv('AGENTARK_PROTOCOL_VERSION')
+                                  or 'v2').strip().lower()
+        if configured_protocol not in {'v1', 'v2'}:
+            raise ValueError("protocol_version must be 'v1' or 'v2'")
+        self._owns_client = client is None
+        self.client = client or AgentArkHttpClient(
+            str(server_url),
+            timeout_s=timeout_s,
+            release_timeout_s=release_timeout_s,
+            protocol_version=configured_protocol,
+        )
+        self.protocol_version = str(getattr(self.client, 'protocol_version', configured_protocol)).lower()
+        if self.protocol_version not in {'v1', 'v2'}:
+            raise ValueError("client.protocol_version must be 'v1' or 'v2'")
+        self.server_url = str(getattr(self.client, 'base_url', server_url)).rstrip('/')
+        self.heartbeat_timeout_s = heartbeat_timeout_s
+        # A fake/injected transport may provide its own deterministic
+        # supervisor.  Production resolves the process singleton lazily after
+        # acquire, which is safe when Env objects were created before a fork.
+        self._heartbeat_supervisor = heartbeat_supervisor or getattr(self.client, 'heartbeat_supervisor', None)
+
+        self.env_id: str | None = None
+        self.unity_id: int | None = None
+        self.lease: LeaseHandle | None = None
+        self.acquire_request_id: str | None = None
+        self.release_request_id: str | None = None
+        self.initial_messages: Messages = []
+        self.pending_messages: Messages = []
+        self.reset_info: dict[str, Any] = {}
+        self.close_error: str | None = None
+        self._reset_called = False
+        self._heartbeat_registered = False
+        self._release_attempted = False
+        self._closed = False
+
+    async def reset(self, config: RolloutInferRequest) -> tuple[str, dict[str, Any], str]:
+        if self._reset_called:
+            raise RuntimeError('AgentArkEnv.reset may only be called once per trajectory')
+        self._reset_called = True
+        try:
+            acquire_kwargs = {
+                'uid': self.group_uid,
+                'task_name': self.task_name,
+                'group_seed': self.group_seed,
+                'env_id': self.requested_env_id,
+                'unity_env_id': self.unity_env_id,
+            }
+            if self.protocol_version == 'v2':
+                trajectory_uuid = str(config.uuid or '').strip()
+                if not trajectory_uuid:
+                    raise ValueError('RolloutInferRequest.uuid is required for AgentArk protocol v2')
+                client_id = str(getattr(self.client, 'client_id', '') or '').strip()
+                if not client_id:
+                    raise ValueError('AgentArk protocol v2 client_id must not be empty')
+                # group_uid selects a shared GRPO task; request.uuid selects one
+                # concrete trajectory lease and must never be replaced by it.
+                self.acquire_request_id = stable_operation_id('acquire', client_id, trajectory_uuid)
+                acquire_kwargs.update(
+                    acquire_request_id=self.acquire_request_id,
+                    client_id=client_id,
+                )
+            payload = await self.client.acquire_start(
+                self.agentark_env_cfg,
+                **acquire_kwargs,
+            )
+            env_id = payload.get('env_id')
+            if not isinstance(env_id, str) or not env_id:
+                raise ValueError('AgentArk acquire_start response is missing env_id')
+            self.env_id = env_id
+            if self.protocol_version == 'v2':
+                assert self.acquire_request_id is not None
+                echoed_acquire_id = payload.get('acquire_request_id')
+                if (echoed_acquire_id is not None and str(echoed_acquire_id) != self.acquire_request_id):
+                    raise ValueError('AgentArk v2 acquire response echoed a different acquire_request_id')
+                client_id = str(getattr(self.client, 'client_id', '') or '')
+                self.release_request_id = stable_operation_id(
+                    'release',
+                    self.acquire_request_id,
+                    str(payload.get('server_epoch') or ''),
+                    env_id,
+                    str(payload.get('lease_generation') or ''),
+                    str(payload.get('lease_id') or ''),
+                )
+                self.lease = LeaseHandle.from_acquire_response(
+                    payload,
+                    client_id=client_id,
+                    acquire_request_id=self.acquire_request_id,
+                    release_request_id=self.release_request_id,
+                )
+            unity_id = payload.get('unity_id')
+            self.unity_id = int(unity_id) if unity_id is not None else None
+            obs = payload.get('obs')
+            if not isinstance(obs, Mapping):
+                raise ValueError('AgentArk acquire_start response is missing obs')
+            self.initial_messages = copy_messages(
+                obs.get('messages'),
+                field_name='acquire_start.obs.messages',
+                require_nonempty=True,
+            )
+            info = payload.get('info') or {}
+            if not isinstance(info, Mapping):
+                raise ValueError('AgentArk acquire_start response info must be an object')
+            self.reset_info = deepcopy(dict(info))
+            if self.lease is not None and self.lease.heartbeat_enabled:
+                if self._heartbeat_supervisor is None:
+                    self._heartbeat_supervisor = get_heartbeat_supervisor()
+                self._heartbeat_supervisor.register(
+                    self.lease,
+                    self.server_url,
+                    timeout_s=self.heartbeat_timeout_s,
+                )
+                self._heartbeat_registered = True
+        except BaseException:
+            # If acquire succeeded but response validation failed, return the
+            # lease before propagating the malformed-response error.
+            await self.close()
+            raise
+
+        # The generic Env API only admits string observation/system fields.
+        # AgentArkScheduler deliberately ignores these placeholders and copies
+        # initial_messages directly, preserving inline image_url blocks.
+        return '', deepcopy(self.reset_info), ''
+
+    async def step(
+        self,
+        action: Messages,
+        *,
+        action_id: str | None = None,
+        turn_index: int | None = None,
+    ) -> tuple[str, float, bool, dict[str, Any]]:
+        if self._closed or self.env_id is None:
+            raise RuntimeError('AgentArkEnv.step called without an active lease')
+        assistant_raw = latest_assistant_text(action)
+        action_extracted = extract_action(assistant_raw)
+        if self.protocol_version == 'v2':
+            if self.lease is None:
+                raise RuntimeError('AgentArkEnv.step called without a protocol-v2 LeaseHandle')
+            self.lease.assert_active()
+            payload = await self.client.step(
+                self.lease,
+                action=action_extracted,
+                assistant=assistant_raw,
+                action_id=action_id,
+                turn_index=turn_index,
+            )
+            if self.lease.expired:
+                raise LeaseExpiredError(self.lease.expired_reason
+                                        or 'AgentArk server expired the lease while the step was in progress')
+        else:
+            payload = await self.client.step(
+                self.env_id,
+                action=action_extracted,
+                assistant=assistant_raw,
+            )
+        obs = payload.get('obs') or {}
+        if not isinstance(obs, Mapping):
+            raise ValueError('AgentArk step response obs must be an object')
+        raw_messages = obs.get('messages', [])
+        self.pending_messages = copy_messages(
+            raw_messages,
+            field_name='step.obs.messages',
+            require_nonempty=False,
+        )
+        info = payload.get('info') or {}
+        if not isinstance(info, Mapping):
+            raise ValueError('AgentArk step response info must be an object')
+        try:
+            reward = float(payload.get('reward', 0.0))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"AgentArk step reward is not numeric: {payload.get('reward')!r}") from exc
+        done = bool(payload.get('done', False))
+        return '', reward, done, deepcopy(dict(info))
+
+    async def close(self) -> None:
+        """Best-effort, locally idempotent release of this trajectory's lease."""
+
+        if self._closed:
+            return
+        self._closed = True
+        if self._heartbeat_registered and self.lease is not None:
+            self._heartbeat_registered = False
+            try:
+                assert self._heartbeat_supervisor is not None
+                self._heartbeat_supervisor.unregister(self.lease, self.server_url)
+            except BaseException as exc:  # noqa: B036
+                logger.warning(
+                    'Failed to unregister AgentArk heartbeat env_id=%s: %s',
+                    self.env_id,
+                    exc,
+                )
+        release_target: LeaseHandle | str | None
+        release_target = self.lease if self.protocol_version == 'v2' else self.env_id
+        if release_target is not None and not self._release_attempted:
+            self._release_attempted = True
+            try:
+                if self.protocol_version == 'v2':
+                    assert isinstance(release_target, LeaseHandle)
+                    if release_target.owner_pid != os.getpid():
+                        raise RuntimeError('refusing to release a lease inherited across fork')
+                    await self.client.release(
+                        release_target,
+                        release_request_id=self.release_request_id,
+                    )
+                else:
+                    await self.client.release(release_target)
+            except AgentArkStaleLeaseError:
+                logger.info(
+                    'AgentArk lease env_id=%s was already stale during release',
+                    self.env_id,
+                )
+            except BaseException as exc:  # noqa: B036
+                self.close_error = f'{type(exc).__name__}: {exc}'
+                logger.warning('Failed to release AgentArk env_id=%s: %s', self.env_id, self.close_error)
+        if self._owns_client:
+            try:
+                await self.client.aclose()
+            except BaseException as exc:  # noqa: B036
+                if self.close_error is None:
+                    self.close_error = f'{type(exc).__name__}: {exc}'
+                logger.warning('Failed to close AgentArk HTTP client: %s', exc)

--- a/swift/rollout/agentark/heartbeat.py
+++ b/swift/rollout/agentark/heartbeat.py
@@ -1,0 +1,497 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Process-wide lease heartbeats for AgentArk protocol v2.
+
+Swift's colocate rollout driver enters several short-lived asyncio event loops
+during one trajectory.  Heartbeats therefore live in one synchronous daemon
+thread instead of being attached to any of those loops.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import requests
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+class LeaseExpiredError(RuntimeError):
+    """The server lease is no longer safe to use for another action."""
+
+
+@dataclass
+class LeaseHandle:
+    """Capability and liveness state for one exact protocol-v2 lease."""
+
+    server_epoch: str
+    env_id: str
+    lease_id: str
+    lease_generation: int
+    lease_ttl_s: float
+    heartbeat_interval_s: float | None
+    client_id: str
+    acquire_request_id: str
+    release_request_id: str
+    owner_pid: int = field(default_factory=os.getpid)
+    _expired: bool = field(default=False, init=False, repr=False, compare=False)
+    _expired_reason: str | None = field(default=None, init=False, repr=False, compare=False)
+    _deadline_monotonic: float = field(default=float('inf'), init=False, repr=False, compare=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        self.server_epoch = str(self.server_epoch or '').strip()
+        self.env_id = str(self.env_id or '').strip()
+        self.lease_id = str(self.lease_id or '').strip()
+        self.client_id = str(self.client_id or '').strip()
+        self.acquire_request_id = str(self.acquire_request_id or '').strip()
+        self.release_request_id = str(self.release_request_id or '').strip()
+        self.lease_generation = int(self.lease_generation)
+        self.lease_ttl_s = float(self.lease_ttl_s)
+        if self.heartbeat_interval_s is not None:
+            self.heartbeat_interval_s = float(self.heartbeat_interval_s)
+
+        missing = [
+            name for name in (
+                'server_epoch',
+                'env_id',
+                'lease_id',
+                'client_id',
+                'acquire_request_id',
+                'release_request_id',
+            ) if not getattr(self, name)
+        ]
+        if missing:
+            raise ValueError(f"LeaseHandle is missing required fields: {', '.join(missing)}")
+        if self.lease_generation <= 0:
+            raise ValueError('LeaseHandle.lease_generation must be positive')
+        if self.lease_ttl_s < 0:
+            raise ValueError('LeaseHandle.lease_ttl_s must not be negative')
+        if self.heartbeat_interval_s is not None and self.heartbeat_interval_s <= 0:
+            raise ValueError('LeaseHandle.heartbeat_interval_s must be positive when set')
+        self._set_deadline(self.lease_ttl_s)
+
+    @classmethod
+    def from_acquire_response(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        client_id: str,
+        acquire_request_id: str,
+        release_request_id: str,
+    ) -> 'LeaseHandle':
+        """Validate the flat v2 acquire identity returned by the server."""
+
+        try:
+            ttl = float(payload['lease_ttl_s'])
+            generation = int(payload['lease_generation'])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError('AgentArk v2 acquire response has an invalid lease identity') from exc
+        interval_value = payload.get('heartbeat_interval_s')
+        interval = None if interval_value is None else float(interval_value)
+        return cls(
+            server_epoch=str(payload.get('server_epoch') or ''),
+            env_id=str(payload.get('env_id') or ''),
+            lease_id=str(payload.get('lease_id') or ''),
+            lease_generation=generation,
+            lease_ttl_s=ttl,
+            heartbeat_interval_s=interval,
+            client_id=client_id,
+            acquire_request_id=acquire_request_id,
+            release_request_id=release_request_id,
+        )
+
+    @property
+    def key(self) -> tuple[str, str, int, str]:
+        return (self.server_epoch, self.env_id, self.lease_generation, self.lease_id)
+
+    @property
+    def heartbeat_enabled(self) -> bool:
+        return self.lease_ttl_s > 0 and self.heartbeat_interval_s is not None
+
+    @property
+    def expired(self) -> bool:
+        with self._lock:
+            return self._expired
+
+    @property
+    def expired_reason(self) -> str | None:
+        with self._lock:
+            return self._expired_reason
+
+    @property
+    def deadline_monotonic(self) -> float:
+        with self._lock:
+            return self._deadline_monotonic
+
+    def identity(self) -> dict[str, Any]:
+        return {
+            'server_epoch': self.server_epoch,
+            'env_id': self.env_id,
+            'lease_id': self.lease_id,
+            'lease_generation': self.lease_generation,
+        }
+
+    def request_identity(self) -> dict[str, Any]:
+        """Identity fields for a path that already carries ``env_id``."""
+
+        identity = self.identity()
+        identity.pop('env_id')
+        return identity
+
+    def heartbeat_payload(self, heartbeat_id: str) -> dict[str, Any]:
+        return {**self.identity(), 'heartbeat_id': heartbeat_id}
+
+    def mark_alive(
+        self,
+        *,
+        lease_ttl_s: float | None = None,
+        lease_expires_in_s: float | None = None,
+    ) -> None:
+        """Refresh the local safety deadline after a successful server call."""
+
+        with self._lock:
+            if self._expired:
+                return
+            if lease_ttl_s is not None:
+                ttl = float(lease_ttl_s)
+                if ttl >= 0:
+                    self.lease_ttl_s = ttl
+            expires_in = self.lease_ttl_s if lease_expires_in_s is None else float(lease_expires_in_s)
+            self._deadline_monotonic = (
+                float('inf') if self.lease_ttl_s == 0 else time.monotonic() + max(0.0, expires_in))
+
+    def mark_expired(self, reason: str) -> None:
+        with self._lock:
+            if self._expired:
+                return
+            self._expired = True
+            self._expired_reason = str(reason or 'lease expired')
+
+    def expire_if_deadline_elapsed(self, now: float | None = None) -> bool:
+        resolved_now = time.monotonic() if now is None else float(now)
+        with self._lock:
+            if self._expired:
+                return True
+            if resolved_now < self._deadline_monotonic:
+                return False
+            self._expired = True
+            self._expired_reason = 'lease heartbeat deadline elapsed locally'
+            return True
+
+    def assert_active(self) -> None:
+        if self.owner_pid != os.getpid():
+            raise LeaseExpiredError(f'AgentArk lease env_id={self.env_id!r} belongs to process {self.owner_pid}, '
+                                    f'not forked process {os.getpid()}')
+        self.expire_if_deadline_elapsed()
+        with self._lock:
+            if self._expired:
+                raise LeaseExpiredError(f'AgentArk lease env_id={self.env_id!r} is no longer active: '
+                                        f"{self._expired_reason or 'unknown reason'}")
+
+    def _set_deadline(self, expires_in_s: float) -> None:
+        self._deadline_monotonic = (
+            float('inf') if self.lease_ttl_s == 0 else time.monotonic() + max(0.0, expires_in_s))
+
+
+@dataclass
+class _Registration:
+    handle: LeaseHandle
+    base_url: str
+    timeout_s: float
+    next_due: float
+
+
+class HeartbeatSupervisor:
+    """One synchronous daemon batching all protocol-v2 leases in a process."""
+
+    def __init__(self, *, default_timeout_s: float = 5.0) -> None:
+        if default_timeout_s <= 0:
+            raise ValueError('default_timeout_s must be positive')
+        self._pid = os.getpid()
+        self._default_timeout_s = float(default_timeout_s)
+        self._condition = threading.Condition()
+        self._registrations: dict[tuple[str, str, str, int, str], _Registration] = {}
+        self._thread: threading.Thread | None = None
+        self._shutdown = False
+
+    @property
+    def pid(self) -> int:
+        return self._pid
+
+    @property
+    def thread(self) -> threading.Thread | None:
+        return self._thread
+
+    def register(
+        self,
+        handle: LeaseHandle,
+        base_url: str,
+        *,
+        timeout_s: float | None = None,
+    ) -> None:
+        self._assert_current_process()
+        if not handle.heartbeat_enabled:
+            return
+        handle.assert_active()
+        resolved_url = str(base_url or '').strip().rstrip('/')
+        if not resolved_url:
+            raise ValueError('heartbeat base_url must not be empty')
+        resolved_timeout = self._default_timeout_s if timeout_s is None else float(timeout_s)
+        if resolved_timeout <= 0:
+            raise ValueError('heartbeat timeout_s must be positive')
+        interval = self._effective_interval(handle)
+        registration = _Registration(
+            handle=handle,
+            base_url=resolved_url,
+            timeout_s=resolved_timeout,
+            next_due=time.monotonic() + interval,
+        )
+        key = self._registration_key(resolved_url, handle)
+        with self._condition:
+            if self._shutdown:
+                raise RuntimeError('HeartbeatSupervisor is shut down')
+            self._registrations[key] = registration
+            if self._thread is None or not self._thread.is_alive():
+                self._thread = threading.Thread(
+                    target=self._run,
+                    name='agentark-lease-heartbeats',
+                    daemon=True,
+                )
+                self._thread.start()
+            self._condition.notify_all()
+
+    def unregister(self, handle: LeaseHandle, base_url: str | None = None) -> None:
+        # A daemon thread inherited through fork is gone in the child.  Do not
+        # mutate the parent's conceptual registration from that child.
+        if self._pid != os.getpid():
+            return
+        with self._condition:
+            if base_url is None:
+                doomed = [key for key, item in self._registrations.items() if item.handle is handle]
+                for key in doomed:
+                    self._registrations.pop(key, None)
+            else:
+                self._registrations.pop(
+                    self._registration_key(str(base_url).rstrip('/'), handle),
+                    None,
+                )
+            self._condition.notify_all()
+
+    def shutdown(self, *, join_timeout_s: float = 5.0) -> None:
+        if self._pid != os.getpid():
+            return
+        with self._condition:
+            self._shutdown = True
+            self._registrations.clear()
+            thread = self._thread
+            self._condition.notify_all()
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=max(0.0, float(join_timeout_s)))
+
+    def _assert_current_process(self) -> None:
+        if self._pid != os.getpid():
+            raise RuntimeError('HeartbeatSupervisor cannot be reused after fork')
+
+    @staticmethod
+    def _registration_key(
+        base_url: str,
+        handle: LeaseHandle,
+    ) -> tuple[str, str, str, int, str]:
+        return (base_url, handle.server_epoch, handle.env_id, handle.lease_generation, handle.lease_id)
+
+    @staticmethod
+    def _effective_interval(handle: LeaseHandle) -> float:
+        assert handle.heartbeat_interval_s is not None
+        # Never schedule later than one third of the current TTL.  A tiny
+        # positive floor prevents a malformed server value from busy-spinning.
+        ttl_interval = handle.lease_ttl_s / 3.0
+        return max(0.01, min(float(handle.heartbeat_interval_s), ttl_interval))
+
+    def _run(self) -> None:
+        clients: dict[str, requests.Session] = {}
+        try:
+            while True:
+                due = self._wait_for_due()
+                if due is None:
+                    return
+                grouped: dict[str, list[_Registration]] = {}
+                for registration in due:
+                    grouped.setdefault(registration.base_url, []).append(registration)
+                for base_url, registrations in grouped.items():
+                    client = clients.get(base_url)
+                    if client is None:
+                        client = requests.Session()
+                        clients[base_url] = client
+                    self._heartbeat_group(client, base_url, registrations)
+        finally:
+            for client in clients.values():
+                try:
+                    client.close()
+                except Exception:
+                    logger.debug('Failed to close heartbeat HTTP client', exc_info=True)
+
+    def _wait_for_due(self) -> list[_Registration] | None:
+        with self._condition:
+            while True:
+                if self._shutdown:
+                    return None
+                now = time.monotonic()
+                expired_keys = [
+                    key for key, registration in self._registrations.items()
+                    if registration.handle.expire_if_deadline_elapsed(now)
+                ]
+                for key in expired_keys:
+                    self._registrations.pop(key, None)
+                if not self._registrations:
+                    self._condition.wait()
+                    continue
+                due = [
+                    registration for registration in self._registrations.values()
+                    # Coalesce leases whose deadlines are only a few
+                    # milliseconds apart into one request per server URL.
+                    if registration.next_due <= now + 0.01
+                ]
+                if due:
+                    for registration in due:
+                        registration.next_due = now + self._effective_interval(registration.handle)
+                    return due
+                next_wakeup = min(
+                    min(registration.next_due, registration.handle.deadline_monotonic)
+                    for registration in self._registrations.values())
+                self._condition.wait(timeout=max(0.001, next_wakeup - now))
+
+    def _heartbeat_group(
+        self,
+        client: requests.Session,
+        base_url: str,
+        registrations: list[_Registration],
+    ) -> None:
+        heartbeat_ids = [f'heartbeat-{uuid.uuid4().hex}' for _ in registrations]
+        leases = [
+            registration.handle.heartbeat_payload(heartbeat_id)
+            for registration, heartbeat_id in zip(registrations, heartbeat_ids)  # noqa: B905
+        ]
+        timeout_s = max(registration.timeout_s for registration in registrations)
+        try:
+            response = client.post(
+                f'{base_url}/v2/leases/heartbeat',
+                json={'leases': leases},
+                timeout=timeout_s,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, Mapping):
+                raise ValueError('heartbeat response must be an object')
+            items = payload.get('items')
+            if not isinstance(items, list):
+                raise ValueError('heartbeat response items must be a list')
+        except Exception as exc:
+            # A lost response is ambiguous.  The next scheduled batch uses a
+            # fresh heartbeat id; the local TTL deadline is the final fence.
+            logger.warning(
+                'AgentArk lease heartbeat failed for %s (%d leases): %s: %s',
+                registrations[0].base_url,
+                len(registrations),
+                type(exc).__name__,
+                exc,
+            )
+            return
+
+        response_epoch = str(payload.get('server_epoch') or '')
+        if not response_epoch:
+            logger.warning(
+                'AgentArk lease heartbeat response from %s omitted server_epoch',
+                registrations[0].base_url,
+            )
+            return
+        for index, (registration, heartbeat_id) in enumerate(zip(registrations, heartbeat_ids)):  # noqa: B905
+            handle = registration.handle
+            if response_epoch and response_epoch != handle.server_epoch:
+                handle.mark_expired(f'server epoch changed from {handle.server_epoch!r} to {response_epoch!r}')
+                self.unregister(handle, registration.base_url)
+                continue
+            item = self._find_item(items, index, handle, heartbeat_id)
+            if item is None:
+                continue
+            if bool(item.get('ok')):
+                if not self._success_identity_matches(item, handle, heartbeat_id):
+                    handle.mark_expired('heartbeat response returned a mismatched lease identity')
+                    self.unregister(handle, registration.base_url)
+                    continue
+                handle.mark_alive(
+                    lease_ttl_s=self._optional_number(item.get('lease_ttl_s')),
+                    lease_expires_in_s=self._optional_number(item.get('lease_expires_in_s')),
+                )
+                continue
+            error = item.get('error')
+            error = error if isinstance(error, Mapping) else {}
+            code = str(error.get('code') or 'heartbeat_failed')
+            retryable = bool(error.get('retryable', False))
+            if not retryable:
+                handle.mark_expired(f"heartbeat rejected with {code}: {error.get('message', '')}")
+                self.unregister(handle, registration.base_url)
+
+    @staticmethod
+    def _find_item(
+        items: list[Any],
+        index: int,
+        handle: LeaseHandle,
+        heartbeat_id: str,
+    ) -> Mapping[str, Any] | None:
+        for raw_item in items:
+            if isinstance(raw_item, Mapping) and raw_item.get('heartbeat_id') == heartbeat_id:
+                return raw_item
+        # Failed items intentionally contain only env_id and error.  The server
+        # preserves request order, so use that before the less-specific env id.
+        if index < len(items) and isinstance(items[index], Mapping):
+            return items[index]
+        for raw_item in items:
+            if isinstance(raw_item, Mapping) and raw_item.get('env_id') == handle.env_id:
+                return raw_item
+        return None
+
+    @staticmethod
+    def _success_identity_matches(
+        item: Mapping[str, Any],
+        handle: LeaseHandle,
+        heartbeat_id: str,
+    ) -> bool:
+        try:
+            generation = int(item.get('lease_generation'))
+        except (TypeError, ValueError):
+            return False
+        return (str(item.get('server_epoch') or '') == handle.server_epoch
+                and str(item.get('env_id') or '') == handle.env_id
+                and str(item.get('lease_id') or '') == handle.lease_id and generation == handle.lease_generation
+                and str(item.get('heartbeat_id') or '') == heartbeat_id)
+
+    @staticmethod
+    def _optional_number(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+
+_SUPERVISOR_LOCK = threading.Lock()
+_SUPERVISOR: HeartbeatSupervisor | None = None
+_SUPERVISOR_PID: int | None = None
+
+
+def get_heartbeat_supervisor() -> HeartbeatSupervisor:
+    """Return the one lazy, fork-safe supervisor for the current process."""
+
+    global _SUPERVISOR, _SUPERVISOR_PID
+    pid = os.getpid()
+    with _SUPERVISOR_LOCK:
+        if _SUPERVISOR is None or _SUPERVISOR_PID != pid:
+            _SUPERVISOR = HeartbeatSupervisor()
+            _SUPERVISOR_PID = pid
+        return _SUPERVISOR

--- a/swift/rollout/agentark/messages.py
+++ b/swift/rollout/agentark/messages.py
@@ -1,0 +1,119 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Message helpers shared by the AgentArk Env and scheduler."""
+
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from typing import Any, Iterable, Mapping
+
+
+def copy_messages(value: Any, *, field_name: str, require_nonempty: bool = False) -> list[dict[str, Any]]:
+    """Validate and copy an OpenAI-style message list without touching media."""
+
+    if not isinstance(value, list):
+        raise ValueError(f'{field_name} must be a list of messages')
+    if require_nonempty and not value:
+        raise ValueError(f'{field_name} must not be empty')
+    result: list[dict[str, Any]] = []
+    for index, message in enumerate(value):
+        if not isinstance(message, Mapping):
+            raise ValueError(f'{field_name}[{index}] must be an object')
+        role = message.get('role')
+        if role not in {'system', 'user', 'assistant', 'tool'}:
+            raise ValueError(f'{field_name}[{index}].role is invalid: {role!r}')
+        if 'content' not in message:
+            raise ValueError(f'{field_name}[{index}] is missing content')
+        result.append(deepcopy(dict(message)))
+    return result
+
+
+def content_to_text(content: Any) -> str:
+    """Convert an assistant content value to the text sent to AgentArk."""
+
+    if content is None:
+        return ''
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, Mapping):
+                text = item.get('text', item.get('content', ''))
+                if text is not None and str(text):
+                    parts.append(str(text))
+            elif item is not None:
+                parts.append(str(item))
+        return '\n'.join(parts)
+    try:
+        return json.dumps(content, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(content)
+
+
+def latest_assistant_text(messages: Iterable[Mapping[str, Any]]) -> str:
+    for message in reversed(list(messages)):
+        if message.get('role') == 'assistant':
+            return content_to_text(message.get('content'))
+    raise ValueError('AgentArk step requires a generated assistant message')
+
+
+def _extract_tag_content(text: str, tag: str) -> list[str]:
+    pattern = rf'<{re.escape(tag)}\b[^>]*>(.*?)</{re.escape(tag)}>'
+    return re.findall(pattern, text, re.IGNORECASE | re.DOTALL)
+
+
+def extract_action(assistant_raw: str) -> str | None:
+    """Match AgentArk's current API-agent action extraction semantics.
+
+    The raw assistant response is preserved separately for conversation history;
+    only this extracted value is submitted as executable environment action.
+    """
+
+    if not assistant_raw:
+        return None
+
+    tool_calls = _extract_tag_content(assistant_raw, 'tool_call')
+    if tool_calls:
+        if len(tool_calls) == 1:
+            return f'<tool_call>{tool_calls[0].strip()}</tool_call>'
+        joined = '\n'.join(block.strip() for block in tool_calls if block.strip())
+        return f'<tool_call>{joined}</tool_call>' if joined else None
+
+    params = _extract_tag_content(assistant_raw, 'params')
+    if params:
+        if len(params) == 1:
+            return f'<params>{params[0].strip()}</params>'
+        joined = '\n'.join(block.strip() for block in params if block.strip())
+        return f'<params>{joined}</params>' if joined else None
+
+    code = _extract_tag_content(assistant_raw, 'code')
+    if code:
+        if len(code) == 1:
+            return code[0].strip('\n')
+        return '\n\n'.join(block.strip('\n') for block in code if block.strip()) or None
+
+    return assistant_raw
+
+
+def new_environment_messages(
+    conversation: list[dict[str, Any]],
+    returned_messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Select the environment delta and remove AgentArk's assistant echo.
+
+    AgentArk is normally configured for append-only delta messages and returns
+    ``[assistant echo, user observation]``. The longest common-prefix removal
+    also tolerates a server configured to return the full transcript.
+    """
+
+    messages = deepcopy(returned_messages)
+    common = 0
+    for existing, returned in zip(conversation, messages):  # noqa: B905
+        if existing != returned:
+            break
+        common += 1
+    if common:
+        messages = messages[common:]
+    return [message for message in messages if message.get('role') != 'assistant']

--- a/swift/rollout/agentark/scheduler.py
+++ b/swift/rollout/agentark/scheduler.py
@@ -1,0 +1,280 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""AgentArk behavior mixed into Swift's generic gym scheduler."""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from typing import Any, Mapping
+
+from swift.infer_engine.protocol import ChatCompletionResponseChoice, RolloutInferRequest
+from .client import AgentArkStaleLeaseError
+from .env import AgentArkEnv
+from .messages import new_environment_messages
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+class AgentArkSchedulerMixin:
+    """Drive AgentArk while preserving rollout-produced IDs and inline media."""
+
+    def __init__(self, infer_engine=None, max_turns: int | None = None, **kwargs: Any) -> None:
+        super().__init__(infer_engine, max_turns, **kwargs)
+        self._step_infos: dict[str, list[dict[str, Any]]] = {}
+        self._reset_infos: dict[str, dict[str, Any]] = {}
+        self._pending_messages: dict[str, list[dict[str, Any]]] = {}
+        self._loss_scopes: dict[str, str] = {}
+        self._metadata: dict[str, dict[str, Any]] = {}
+
+    def _create_env(self, env_config: dict[str, Any]) -> AgentArkEnv:
+        return AgentArkEnv(env_config)
+
+    async def on_trajectory_start(self, requests: list[RolloutInferRequest]) -> None:
+        """Acquire all leases and replace dataset tickets with AgentArk messages."""
+
+        async def _init_single(req: RolloutInferRequest) -> BaseException | None:
+            uuid = req.uuid
+            if not uuid:
+                return ValueError('RolloutInferRequest.uuid is required by AgentArkScheduler')
+            if uuid in self._envs:
+                await self.finalize_trajectory(uuid, reason='reinitialized')
+
+            env_config = (req.data_dict or {}).get('env_config', {})
+            if not isinstance(env_config, dict):
+                return ValueError('RolloutInferRequest.data_dict.env_config must be an object')
+            try:
+                env = self._create_env(env_config)
+                if not isinstance(env, AgentArkEnv):
+                    # Tests and advanced callers may provide a compatible subclass,
+                    # but an unrelated Swift Env cannot expose AgentArk messages.
+                    required = ('initial_messages', 'pending_messages', 'assistant_loss_scope')
+                    if not all(hasattr(env, name) for name in required):
+                        raise TypeError('AgentArkScheduler requires an AgentArkEnv-compatible environment')
+                self._envs[uuid] = env
+                self._total_rewards[uuid] = 0.0
+                self._step_rewards[uuid] = []
+                self._step_infos[uuid] = []
+                self._pending_obs[uuid] = None
+                self._pending_messages[uuid] = []
+                await env.reset(req)
+                req.messages = deepcopy(env.initial_messages)
+                # AgentArk uses only OpenAI inline media blocks. Clearing ticket
+                # media prevents Swift TemplateInputs from seeing both forms.
+                req.images = []
+                req.audios = []
+                req.videos = []
+                self._reset_infos[uuid] = _json_safe(env.reset_info)
+                self._loss_scopes[uuid] = env.assistant_loss_scope
+                self._metadata[uuid] = {
+                    'agentark_env_id':
+                    env.env_id,
+                    'agentark_unity_id':
+                    env.unity_id,
+                    'group_uid':
+                    env.group_uid,
+                    'agentark_server_epoch':
+                    (env.lease.server_epoch if getattr(env, 'lease', None) is not None else None),
+                    'agentark_lease_generation':
+                    (env.lease.lease_generation if getattr(env, 'lease', None) is not None else None),
+                }
+            except BaseException as exc:  # noqa: B036
+                await self.finalize_trajectory(uuid, reason='reset_error')
+                return exc
+            return None
+
+        results = await asyncio.gather(*[_init_single(req) for req in requests])
+        errors = [result for result in results if isinstance(result, BaseException)]
+        if errors:
+            # A rollout batch is not usable when one ticket failed to reset. Do
+            # not leave the successfully initialized sibling leases behind.
+            await asyncio.gather(
+                *[self.finalize_trajectory(req.uuid, reason='batch_reset_error') for req in requests if req.uuid])
+            raise errors[0]
+
+    def _rollout_infos(
+        self,
+        uuid: str,
+        *,
+        gym_done: bool,
+        termination_reason: str | None = None,
+        finish_reason: str | None = None,
+        end_turn: int | None = None,
+    ) -> dict[str, Any]:
+        infos: dict[str, Any] = {
+            **deepcopy(self._metadata.get(uuid, {})),
+            'reset_info': deepcopy(self._reset_infos.get(uuid, {})),
+            'total_reward': float(self._total_rewards.get(uuid, 0.0)),
+            'step_rewards': list(self._step_rewards.get(uuid, [])),
+            'step_infos': deepcopy(self._step_infos.get(uuid, [])),
+            'gym_done': bool(gym_done),
+            'termination_reason': termination_reason or 'unknown',
+            'finish_reason': finish_reason or 'unknown',
+            'end_turn': end_turn if end_turn is not None else len(self._step_rewards.get(uuid, [])),
+        }
+        return _json_safe(infos)
+
+    async def on_turn_end(
+        self,
+        infer_request: RolloutInferRequest,
+        response_choice: ChatCompletionResponseChoice,
+        current_turn: int,
+    ) -> dict[str, Any]:
+        uuid = infer_request.uuid
+        if not uuid or uuid not in self._envs:
+            return {
+                'done': True,
+                'rollout_infos': {
+                    'gym_done': False,
+                    'termination_reason': 'missing_env',
+                    'finish_reason': response_choice.finish_reason or 'unknown',
+                    'end_turn': current_turn,
+                },
+            }
+
+        token_ids = response_choice.token_ids
+        if token_ids is None:
+            infos = await self.finalize_trajectory(uuid, reason='missing_response_token_ids')
+            raise RuntimeError('AgentArkScheduler requires exact response_choice.token_ids; '
+                               f'trajectory {uuid} was released. infos={infos}')
+
+        # A length-truncated code/tool call is not a valid action. Releasing it
+        # here also avoids GYMScheduler's done override bypassing check_finished.
+        if response_choice.finish_reason == 'length':
+            infos = self._rollout_infos(
+                uuid,
+                gym_done=False,
+                termination_reason='length',
+                finish_reason=response_choice.finish_reason,
+                end_turn=current_turn,
+            )
+            finalized = await self.finalize_trajectory(uuid, reason='length')
+            if 'release_error' in finalized:
+                infos['release_error'] = finalized['release_error']
+            return {'done': True, 'rollout_infos': infos}
+
+        env = self._envs[uuid]
+        try:
+            _, reward, env_done, step_info = await env.step(
+                deepcopy(infer_request.messages),
+                action_id=f'{uuid}:{current_turn}',
+                turn_index=current_turn,
+            )
+        except AgentArkStaleLeaseError as exc:
+            infos = await self.finalize_trajectory(uuid, reason='stale_lease')
+            infos['trajectory_invalid'] = True
+            infos['lease_recovery'] = 'discard_trajectory'
+            infos['stale_lease_error'] = str(exc)
+            infos['finish_reason'] = response_choice.finish_reason or 'unknown'
+            infos['end_turn'] = current_turn
+            return {'done': True, 'rollout_infos': _json_safe(infos)}
+        except BaseException:
+            await self.finalize_trajectory(uuid, reason='step_error')
+            raise
+
+        reward = float(reward)
+        safe_step_info = _json_safe(step_info)
+        self._total_rewards[uuid] = self._total_rewards.get(uuid, 0.0) + reward
+        self._step_rewards.setdefault(uuid, []).append(reward)
+        self._step_infos.setdefault(uuid, []).append(safe_step_info)
+
+        hit_max_turns = bool(self.max_turns and current_turn >= self.max_turns)
+        should_stop = bool(env_done or hit_max_turns)
+        self._pending_messages[uuid] = [] if should_stop else new_environment_messages(
+            infer_request.messages,
+            env.pending_messages,
+        )
+
+        termination_reason = None
+        if env_done:
+            termination_reason = 'env_done'
+        elif hit_max_turns:
+            termination_reason = 'max_turns'
+        infos = self._rollout_infos(
+            uuid,
+            gym_done=bool(env_done),
+            termination_reason=termination_reason,
+            finish_reason=response_choice.finish_reason,
+            end_turn=current_turn,
+        )
+        if should_stop:
+            finalized = await self.finalize_trajectory(uuid, reason=termination_reason or 'finished')
+            if 'release_error' in finalized:
+                infos['release_error'] = finalized['release_error']
+        return {'done': should_stop, 'rollout_infos': infos}
+
+    def step(
+        self,
+        infer_request: RolloutInferRequest,
+        response_choice: ChatCompletionResponseChoice,
+        current_turn: int,
+    ) -> dict[str, Any]:
+        """Append only environment messages and return this turn's exact IDs."""
+
+        uuid = infer_request.uuid
+        if not uuid:
+            raise ValueError('RolloutInferRequest.uuid is required by AgentArkScheduler')
+        for message in self._pending_messages.pop(uuid, []):
+            infer_request.messages.append(deepcopy(message))
+
+        token_ids = response_choice.token_ids
+        if token_ids is None:
+            # on_turn_end validates this first in the supported Swift drivers.
+            raise RuntimeError('AgentArkScheduler requires exact response_choice.token_ids')
+        ids = list(token_ids)
+        loss_scope = self._loss_scopes.get(uuid, 'all_turns')
+        mask_value = 0 if loss_scope == 'last_round' else 1
+        return {
+            'infer_request': infer_request,
+            'response_token_ids': ids,
+            'response_loss_mask': [mask_value] * len(ids),
+        }
+
+    async def finalize_trajectory(self, uuid: str, *, reason: str) -> dict[str, Any]:
+        """Public best-effort cleanup hook for errors, cancellation, and tests."""
+
+        infos = self._rollout_infos(uuid, gym_done=False, termination_reason=reason)
+        env = self._envs.pop(uuid, None)
+        if env is not None:
+            await env.close()
+            if getattr(env, 'close_error', None):
+                infos['release_error'] = env.close_error
+        self._total_rewards.pop(uuid, None)
+        self._step_rewards.pop(uuid, None)
+        self._step_infos.pop(uuid, None)
+        self._reset_infos.pop(uuid, None)
+        self._pending_obs.pop(uuid, None)
+        self._pending_messages.pop(uuid, None)
+        self._loss_scopes.pop(uuid, None)
+        self._metadata.pop(uuid, None)
+        return _json_safe(infos)
+
+    async def finalize_all(self, *, reason: str = 'scheduler_shutdown') -> None:
+        """Release every live trajectory known to this scheduler."""
+
+        await asyncio.gather(*[self.finalize_trajectory(uuid, reason=reason) for uuid in list(self._envs)])
+
+    async def on_trajectory_end(
+        self,
+        requests: list[RolloutInferRequest],
+        error: BaseException | None = None,
+    ) -> None:
+        """Release leases left alive at the rollout lifecycle boundary."""
+
+        reason = 'rollout_error' if error is not None else 'rollout_boundary'
+        await asyncio.gather(
+            *[self.finalize_trajectory(request.uuid, reason=reason) for request in requests if request.uuid])
+
+    async def _close_and_remove(self, uuid: str) -> None:
+        # Preserve GYMScheduler's helper name for callers in ms-swift.
+        await self.finalize_trajectory(uuid, reason='closed')
+
+
+__all__ = ['AgentArkSchedulerMixin']

--- a/swift/rollout/multi_turn.py
+++ b/swift/rollout/multi_turn.py
@@ -11,13 +11,14 @@ from swift.infer_engine.protocol import (ChatCompletionResponse, ChatCompletionR
 from swift.template import Messages
 from swift.template.utils import get_token_backed_response_ids
 from swift.utils import get_logger, remove_response
+from .agentark.env import AgentArkEnv
+from .agentark.scheduler import AgentArkSchedulerMixin
 from .gym_env import Env, envs
 
 if TYPE_CHECKING:
     # Imported only for type hints; importing it at runtime pulls in vllm, which would make
     # `swift.rollout` (and thus GRPO trainer init) hard-require vllm even when use_vllm=False.
     from swift.infer_engine import GRPOVllmEngine
-
 
 logger = get_logger()
 
@@ -1111,7 +1112,14 @@ class OpenEnvScheduler(GYMScheduler):
             return str(observation)
 
 
+class AgentArkScheduler(AgentArkSchedulerMixin, GYMScheduler):
+    """Drive multimodal AgentArk environments over the protocol-v2 HTTP API."""
+
+
+envs['agentark'] = AgentArkEnv
+
 multi_turns = {
+    'agentark_scheduler': AgentArkScheduler,
     'math_tip_trick': MathTipsScheduler,
     'gym_scheduler': GYMScheduler,
     'openenv_scheduler': OpenEnvScheduler,

--- a/swift/rollout/multi_turn.py
+++ b/swift/rollout/multi_turn.py
@@ -10,13 +10,16 @@ from swift.infer_engine.protocol import (ChatCompletionResponse, ChatCompletionR
                                          RolloutInferRequest, RolloutOutput)
 from swift.template import Messages
 from swift.template.utils import get_token_backed_response_ids
-from swift.utils import remove_response
+from swift.utils import get_logger, remove_response
 from .gym_env import Env, envs
 
 if TYPE_CHECKING:
     # Imported only for type hints; importing it at runtime pulls in vllm, which would make
     # `swift.rollout` (and thus GRPO trainer init) hard-require vllm even when use_vllm=False.
     from swift.infer_engine import GRPOVllmEngine
+
+
+logger = get_logger()
 
 
 class RolloutScheduler(ABC):
@@ -168,6 +171,26 @@ class RolloutScheduler(ABC):
         """
         return {}
 
+    async def on_trajectory_end(self,
+                                requests: List['RolloutInferRequest'],
+                                error: Optional[BaseException] = None) -> None:
+        """Called once after a server-side or colocate trajectory batch ends.
+
+        The hook runs after successful completion and after failures, including
+        failures during ``on_trajectory_start`` or the first generation. Use it
+        to release environment sessions and other per-trajectory resources.
+
+        Args:
+            requests: All requests passed to the lifecycle boundary. A request
+                may have completed before another request in the batch failed.
+            error: The original rollout exception, or ``None`` after success.
+
+        The default implementation is a no-op. If this hook also fails while a
+        rollout exception is already active, the driver logs the cleanup error
+        and preserves the original exception.
+        """
+        pass
+
     async def async_infer(self,
                           infer_requests: List[Union['RolloutInferRequest', Dict[str, Any]]],
                           request_config: 'RequestConfig',
@@ -224,7 +247,19 @@ class RolloutScheduler(ABC):
             if isinstance(infer_request, Dict):
                 infer_request = RolloutInferRequest(**infer_request)
 
-            return await self.run(infer_request, request_config, **kwargs)
+            rollout_error = None
+            try:
+                return await self.run(infer_request, request_config, **kwargs)
+            except BaseException as error:
+                rollout_error = error
+                raise
+            finally:
+                try:
+                    await self.on_trajectory_end([infer_request], rollout_error)
+                except BaseException:
+                    if rollout_error is None:
+                        raise
+                    logger.exception('Trajectory finalization failed while preserving the original rollout error')
 
         tasks = [_infer_async_single(infer_request, request_config, **kwargs) for infer_request in infer_requests]
         if use_tqdm is None:
@@ -863,6 +898,12 @@ class GYMScheduler(MultiTurnScheduler):
         self._total_rewards.pop(uuid, None)
         self._step_rewards.pop(uuid, None)
         self._pending_obs.pop(uuid, None)
+
+    async def on_trajectory_end(self,
+                                requests: List['RolloutInferRequest'],
+                                error: Optional[BaseException] = None) -> None:
+        """Close every environment still owned by the completed batch."""
+        await asyncio.gather(*[self._close_and_remove(request.uuid) for request in requests if request.uuid])
 
     # ------------------------------------------------------------------
     # Universal async hooks (called by both run() and run_multi_turn())

--- a/tests/rollout/agentark/_fakes.py
+++ b/tests/rollout/agentark/_fakes.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from typing import Any
+
+IMAGE_URL = 'data:image/png;base64,iVBORw0KGgo='
+
+
+def initial_messages(label: str = 'initial') -> list[dict[str, Any]]:
+    return [
+        {
+            'role': 'system',
+            'content': 'AgentArk system prompt'
+        },
+        {
+            'role': 'user',
+            'content': [
+                {
+                    'type': 'text',
+                    'text': label
+                },
+                {
+                    'type': 'image_url',
+                    'image_url': {
+                        'url': IMAGE_URL
+                    }
+                },
+            ],
+        },
+    ]
+
+
+def delta_messages(assistant: str, label: str = 'next') -> list[dict[str, Any]]:
+    return [
+        {
+            'role': 'assistant',
+            'content': assistant
+        },
+        {
+            'role': 'user',
+            'content': [
+                {
+                    'type': 'text',
+                    'text': label
+                },
+                {
+                    'type': 'image_url',
+                    'image_url': {
+                        'url': IMAGE_URL
+                    }
+                },
+            ],
+        },
+    ]
+
+
+def make_request(*, uuid: str, group_uid: str, loss_scope: str = 'all_turns'):
+    from swift.infer_engine.protocol import RolloutInferRequest
+
+    env_config = {
+        'name': 'agentark',
+        'group_uid': group_uid,
+        'assistant_loss_scope': loss_scope,
+        'server_url': 'http://unused.test',
+        'agentark_env_cfg': {
+            'runtime': 'fake'
+        },
+    }
+    return RolloutInferRequest(
+        messages=[{
+            'role': 'user',
+            'content': f'<agentark-ticket:{group_uid}>'
+        }],
+        data_dict={'env_config': env_config},
+        uuid=uuid,
+    )
+
+
+def make_choice(
+    content: str,
+    *,
+    token_ids: list[int] | None = None,
+    finish_reason: str = 'stop',
+):
+    return SimpleNamespace(
+        message=SimpleNamespace(content=content),
+        token_ids=list(token_ids or [101, 102]),
+        finish_reason=finish_reason,
+        logprobs=None,
+    )
+
+
+class FakeAgentArkClient:
+    """In-memory transport with the same async surface as AgentArkHttpClient."""
+
+    def __init__(
+        self,
+        *,
+        step_payloads: list[Any] | None = None,
+        protocol_version: str = 'v2',
+    ):
+        self.protocol_version = protocol_version
+        self.client_id = 'fake-swift-client'
+        self.base_url = 'http://unused.test'
+        self.acquire_calls: list[dict[str, Any]] = []
+        self.step_calls: list[dict[str, Any]] = []
+        self.release_calls: list[str] = []
+        self.release_payloads: list[dict[str, Any]] = []
+        self.aclose_calls = 0
+        self._step_payloads = list(step_payloads or [])
+        self._next_env = 1
+        self.heartbeat_supervisor = FakeHeartbeatSupervisor()
+
+    async def acquire_start(
+        self,
+        env_cfg: dict[str, Any],
+        *,
+        uid: str,
+        task_name: str | None = None,
+        group_seed: int | None = None,
+        env_id: str | None = None,
+        unity_env_id: int | None = None,
+        acquire_request_id: str | None = None,
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
+        call = {
+            'env_cfg': copy.deepcopy(env_cfg),
+            'uid': uid,
+            'task_name': task_name,
+            'group_seed': group_seed,
+            'env_id': env_id,
+            'unity_env_id': unity_env_id,
+            'acquire_request_id': acquire_request_id,
+            'client_id': client_id,
+        }
+        self.acquire_calls.append(call)
+        leased_env_id = env_id or f'env-{self._next_env}'
+        self._next_env += 1
+        response = {
+            'env_id': leased_env_id,
+            'unity_id': 0,
+            'obs': {
+                'messages': initial_messages(f'initial:{uid}')
+            },
+            'info': {
+                'task_name': f'task-for:{uid}',
+                'rollout_group_seed': 31415,
+            },
+        }
+        if self.protocol_version == 'v2':
+            response.update({
+                'server_epoch': 'fake-server-epoch',
+                'lease_id': f'lease-capability-{leased_env_id}',
+                'lease_generation': 1,
+                'lease_ttl_s': 60.0,
+                'heartbeat_interval_s': 20.0,
+                'acquire_request_id': acquire_request_id,
+                'replayed': False,
+            })
+        return response
+
+    async def step(
+        self,
+        lease,
+        *,
+        action: str,
+        assistant: str,
+        action_id: str | None = None,
+        turn_index: int | None = None,
+    ) -> dict[str, Any]:
+        env_id = lease.env_id if hasattr(lease, 'env_id') else str(lease)
+        call = {
+            'env_id': env_id,
+            'action': action,
+            'assistant': assistant,
+            'action_id': action_id,
+            'turn_index': turn_index,
+        }
+        if hasattr(lease, 'identity'):
+            call.update(lease.identity())
+        self.step_calls.append(call)
+        if not self._step_payloads:
+            return {
+                'unity_id': 0,
+                'obs': {
+                    'messages': delta_messages(assistant)
+                },
+                'reward': 0.25,
+                'done': False,
+                'info': {
+                    'status': 'running'
+                },
+            }
+        result = self._step_payloads.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return copy.deepcopy(result)
+
+    async def release(self, lease, *, release_request_id: str | None = None) -> dict[str, Any]:
+        env_id = lease.env_id if hasattr(lease, 'env_id') else str(lease)
+        self.release_calls.append(env_id)
+        payload = {'env_id': env_id, 'release_request_id': release_request_id}
+        if hasattr(lease, 'identity'):
+            payload.update(lease.identity())
+        self.release_payloads.append(payload)
+        return {'ok': True}
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+
+class FakeHeartbeatSupervisor:
+
+    def __init__(self):
+        self.register_calls: list[dict[str, Any]] = []
+        self.unregister_calls: list[dict[str, Any]] = []
+
+    def register(self, lease, base_url: str, *, timeout_s: float | None = None) -> None:
+        self.register_calls.append({'lease': lease, 'base_url': base_url, 'timeout_s': timeout_s})
+
+    def unregister(self, lease, base_url: str | None = None) -> None:
+        self.unregister_calls.append({'lease': lease, 'base_url': base_url})
+
+
+def append_generated_assistant(request, content: str) -> None:
+    request.messages.append({'role': 'assistant', 'content': content})

--- a/tests/rollout/agentark/test_env.py
+++ b/tests/rollout/agentark/test_env.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from ._fakes import IMAGE_URL, FakeAgentArkClient, delta_messages, initial_messages, make_request
+
+
+class AgentArkEnvTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_reset_keeps_complete_multimodal_messages(self):
+        from swift.rollout.agentark.env import AgentArkEnv
+
+        client = FakeAgentArkClient()
+        request = make_request(uuid='trajectory-1', group_uid='group-1')
+        env_config = request.data_dict['env_config']
+        env = AgentArkEnv(env_config, client=client)
+
+        observation, info, system_message = await env.reset(request)
+
+        self.assertEqual(observation, '')
+        self.assertEqual(system_message, '')
+        self.assertEqual(info['task_name'], 'task-for:group-1')
+        self.assertEqual(env.env_id, 'env-1')
+        self.assertEqual(env.initial_messages, initial_messages('initial:group-1'))
+        image_part = env.initial_messages[1]['content'][1]
+        self.assertEqual(image_part, {'type': 'image_url', 'image_url': {'url': IMAGE_URL}})
+        self.assertEqual(client.acquire_calls[0]['uid'], 'group-1')
+        self.assertEqual(client.acquire_calls[0]['env_cfg'], {'runtime': 'fake'})
+        self.assertEqual(client.acquire_calls[0]['client_id'], 'fake-swift-client')
+        self.assertTrue(client.acquire_calls[0]['acquire_request_id'].startswith('acquire-'))
+        self.assertEqual(env.lease.server_epoch, 'fake-server-epoch')
+        self.assertEqual(len(client.heartbeat_supervisor.register_calls), 1)
+
+    async def test_two_rollouts_share_group_but_lease_distinct_envs(self):
+        from swift.rollout.agentark.env import AgentArkEnv
+
+        client = FakeAgentArkClient()
+        first_request = make_request(uuid='trajectory-a', group_uid='shared-group')
+        second_request = make_request(uuid='trajectory-b', group_uid='shared-group')
+        first = AgentArkEnv(first_request.data_dict['env_config'], client=client)
+        second = AgentArkEnv(second_request.data_dict['env_config'], client=client)
+
+        first_reset, second_reset = await asyncio.gather(
+            first.reset(first_request),
+            second.reset(second_request),
+        )
+
+        self.assertNotEqual(first.env_id, second.env_id)
+        self.assertEqual([call['uid'] for call in client.acquire_calls], ['shared-group', 'shared-group'])
+        self.assertEqual(first_reset[1]['task_name'], second_reset[1]['task_name'])
+        self.assertEqual(first_reset[1]['rollout_group_seed'], second_reset[1]['rollout_group_seed'])
+        self.assertEqual(first.initial_messages, second.initial_messages)
+        self.assertNotEqual(first.acquire_request_id, second.acquire_request_id)
+
+        # Reconstructing the same trajectory produces the same acquire id;
+        # group siblings never share it.
+        replay = AgentArkEnv(first_request.data_dict['env_config'], client=client)
+        await replay.reset(first_request)
+        self.assertEqual(first.acquire_request_id, replay.acquire_request_id)
+        await asyncio.gather(first.close(), second.close(), replay.close())
+
+    async def test_step_preserves_delta_reward_done_and_info(self):
+        from swift.rollout.agentark.env import AgentArkEnv
+
+        assistant = '<tool_call>{"name":"ExecutePlan","arguments":{"plan":"R1"}}</tool_call>'
+        payload = {
+            'unity_id': 0,
+            'obs': {
+                'messages': delta_messages(assistant, 'terminal frame')
+            },
+            'reward': 0.75,
+            'done': True,
+            'info': {
+                'status': 'success',
+                'attempt': 2
+            },
+        }
+        client = FakeAgentArkClient(step_payloads=[payload])
+        request = make_request(uuid='trajectory-1', group_uid='group-1')
+        env = AgentArkEnv(request.data_dict['env_config'], client=client)
+        await env.reset(request)
+
+        observation, reward, done, info = await env.step(
+            [*copy.deepcopy(env.initial_messages), {
+                'role': 'assistant',
+                'content': assistant
+            }],
+            action_id='trajectory-1:1',
+            turn_index=1,
+        )
+
+        self.assertEqual(observation, '')
+        self.assertEqual(reward, 0.75)
+        self.assertTrue(done)
+        self.assertEqual(info['status'], 'success')
+        self.assertEqual(env.pending_messages, payload['obs']['messages'])
+        self.assertEqual(client.step_calls[0]['assistant'], assistant)
+        self.assertEqual(client.step_calls[0]['action_id'], 'trajectory-1:1')
+        self.assertEqual(client.step_calls[0]['turn_index'], 1)
+
+    async def test_close_releases_only_once(self):
+        from swift.rollout.agentark.env import AgentArkEnv
+
+        client = FakeAgentArkClient()
+        request = make_request(uuid='trajectory-1', group_uid='group-1')
+        env = AgentArkEnv(request.data_dict['env_config'], client=client)
+        await env.reset(request)
+
+        await env.close()
+        await env.close()
+
+        self.assertEqual(client.release_calls, ['env-1'])
+        self.assertEqual(len(client.heartbeat_supervisor.unregister_calls), 1)
+        self.assertEqual(
+            client.release_payloads[0]['release_request_id'],
+            env.release_request_id,
+        )
+
+    async def test_expired_heartbeat_fences_next_step_locally(self):
+        from swift.rollout.agentark.env import AgentArkEnv
+        from swift.rollout.agentark.heartbeat import LeaseExpiredError
+
+        client = FakeAgentArkClient()
+        request = make_request(uuid='trajectory-expired', group_uid='group-expired')
+        env = AgentArkEnv(request.data_dict['env_config'], client=client)
+        await env.reset(request)
+        env.lease.mark_expired('synthetic stale generation')
+
+        with self.assertRaisesRegex(LeaseExpiredError, 'synthetic stale generation'):
+            await env.step(
+                [*copy.deepcopy(env.initial_messages), {
+                    'role': 'assistant',
+                    'content': 'R1'
+                }],
+                action_id='trajectory-expired:1',
+                turn_index=1,
+            )
+
+        self.assertEqual(client.step_calls, [])
+        await env.close()
+
+    async def test_protocol_v1_compatibility_uses_no_lease_or_heartbeat(self):
+        from swift.rollout.agentark.env import AgentArkEnv
+
+        client = FakeAgentArkClient(protocol_version='v1')
+        request = make_request(uuid='legacy-trajectory', group_uid='legacy-group')
+        request.data_dict['env_config']['protocol_version'] = 'v1'
+        env = AgentArkEnv(request.data_dict['env_config'], client=client)
+        await env.reset(request)
+
+        self.assertIsNone(env.lease)
+        self.assertIsNone(env.acquire_request_id)
+        self.assertEqual(client.heartbeat_supervisor.register_calls, [])
+        await env.step([*copy.deepcopy(env.initial_messages), {'role': 'assistant', 'content': 'legacy R1'}])
+        await env.close()
+
+        self.assertIsNone(client.step_calls[0]['action_id'])
+        self.assertEqual(client.release_calls, ['env-1'])
+
+
+class RuntimeConfigTests(unittest.TestCase):
+
+    def test_full_runtime_yaml_selects_env_cfg_expands_values_and_deep_merges(self):
+        from swift.rollout.agentark.env import resolve_runtime_config
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_path = Path(temp_dir) / 'agentark-runtime.yaml'
+            runtime_path.write_text(
+                """
+server:
+  host: 127.0.0.1
+  port: 18080
+env_cfg:
+  mod_path: ${AGENTARK_TEST_ROOT}/mods/base
+  nested:
+    keep: from-file
+    override: from-file
+    home_path: ~/agentark-assets
+  paths:
+    - ${AGENTARK_TEST_ROOT}/one
+interaction:
+  enabled: true
+""".lstrip(),
+                encoding='utf-8',
+            )
+            env_config = {
+                'runtime_config_path': str(runtime_path),
+                'agentark_env_cfg': {
+                    'nested': {
+                        'override': 'from-inline',
+                        'inline_path': '${AGENTARK_TEST_ROOT}/inline',
+                    },
+                    'paths': ['${AGENTARK_TEST_ROOT}/replacement'],
+                },
+            }
+            with patch.dict(os.environ, {'AGENTARK_TEST_ROOT': '/tmp/agentark-test-root'}):
+                resolved = resolve_runtime_config(env_config)
+
+        self.assertNotIn('server', resolved)
+        self.assertNotIn('interaction', resolved)
+        self.assertEqual(resolved['mod_path'], '/tmp/agentark-test-root/mods/base')
+        self.assertEqual(resolved['nested']['keep'], 'from-file')
+        self.assertEqual(resolved['nested']['override'], 'from-inline')
+        self.assertEqual(Path(resolved['nested']['home_path']), Path.home() / 'agentark-assets')
+        self.assertEqual(resolved['nested']['inline_path'], '/tmp/agentark-test-root/inline')
+        self.assertEqual(resolved['paths'], ['/tmp/agentark-test-root/replacement'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/rollout/agentark/test_heartbeat.py
+++ b/tests/rollout/agentark/test_heartbeat.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import patch
+
+
+class _HeartbeatHandler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+    requests: list[dict] = []
+    lock = threading.Lock()
+
+    def log_message(self, _format, *args):
+        return
+
+    def _send_json(self, status: int, payload: dict):
+        body = json.dumps(payload).encode('utf-8')
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', '0'))
+        payload = json.loads(self.rfile.read(length) or b'{}')
+        with type(self).lock:
+            type(self).requests.append(payload)
+        if self.path != '/v2/leases/heartbeat':
+            self._send_json(404, {'detail': 'not found'})
+            return
+        items = []
+        for lease in payload.get('leases', []):
+            env_id = lease.get('env_id')
+            if env_id == 'expired-env':
+                items.append({
+                    'env_id': env_id,
+                    'ok': False,
+                    'error': {
+                        'code': 'lease_gone',
+                        'message': 'synthetic expiry',
+                        'retryable': False,
+                    },
+                })
+            elif env_id == 'retryable-env':
+                items.append({
+                    'env_id': env_id,
+                    'ok': False,
+                    'error': {
+                        'code': 'operation_in_progress',
+                        'message': 'synthetic busy lease',
+                        'retryable': True,
+                    },
+                })
+            else:
+                items.append({
+                    **lease,
+                    'ok': True,
+                    'lease_ttl_s': 0.3,
+                    'lease_expires_in_s': 0.3,
+                    'replayed': False,
+                })
+        self._send_json(200, {'server_epoch': 'heartbeat-epoch', 'items': items})
+
+
+def _wait_until(predicate, *, timeout_s: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return bool(predicate())
+
+
+class HeartbeatSupervisorTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        _HeartbeatHandler.requests = []
+        cls.server = ThreadingHTTPServer(('127.0.0.1', 0), _HeartbeatHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        cls.base_url = f'http://127.0.0.1:{cls.server.server_port}'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join(timeout=5)
+
+    def setUp(self):
+        with _HeartbeatHandler.lock:
+            _HeartbeatHandler.requests = []
+
+    @staticmethod
+    def _lease(env_id: str, generation: int = 1, *, ttl: float = 0.3):
+        from swift.rollout.agentark.heartbeat import LeaseHandle
+
+        return LeaseHandle(
+            server_epoch='heartbeat-epoch',
+            env_id=env_id,
+            lease_id=f'secret-{env_id}-{generation}',
+            lease_generation=generation,
+            lease_ttl_s=ttl,
+            heartbeat_interval_s=0.05 if ttl >= 0.15 else 0.02,
+            client_id='heartbeat-test-client',
+            acquire_request_id=f'acquire-{env_id}-{generation}',
+            release_request_id=f'release-{env_id}-{generation}',
+        )
+
+    def test_one_daemon_batches_leases_by_server_url(self):
+        from swift.rollout.agentark.heartbeat import HeartbeatSupervisor
+
+        supervisor = HeartbeatSupervisor(default_timeout_s=1)
+        first = self._lease('batch-env-1')
+        second = self._lease('batch-env-2')
+        try:
+            supervisor.register(first, self.base_url)
+            daemon = supervisor.thread
+            supervisor.register(second, self.base_url)
+            self.assertIs(supervisor.thread, daemon)
+            self.assertTrue(daemon.daemon)
+            self.assertTrue(
+                _wait_until(lambda: any(len(request.get('leases', [])) == 2 for request in _HeartbeatHandler.requests)))
+            batch = next(request for request in _HeartbeatHandler.requests if len(request.get('leases', [])) == 2)
+            self.assertEqual(
+                {lease['env_id']
+                 for lease in batch['leases']},
+                {'batch-env-1', 'batch-env-2'},
+            )
+            self.assertTrue(all(lease['heartbeat_id'] for lease in batch['leases']))
+        finally:
+            supervisor.shutdown()
+
+    def test_nonretryable_item_marks_only_that_lease_expired(self):
+        from swift.rollout.agentark.heartbeat import HeartbeatSupervisor, LeaseExpiredError
+
+        supervisor = HeartbeatSupervisor(default_timeout_s=1)
+        healthy = self._lease('healthy-env')
+        expired = self._lease('expired-env')
+        try:
+            supervisor.register(healthy, self.base_url)
+            supervisor.register(expired, self.base_url)
+            self.assertTrue(_wait_until(lambda: expired.expired))
+            self.assertFalse(healthy.expired)
+            with self.assertRaisesRegex(LeaseExpiredError, 'lease_gone'):
+                expired.assert_active()
+            healthy.assert_active()
+        finally:
+            supervisor.shutdown()
+
+    def test_retryable_failures_use_local_ttl_as_final_fence(self):
+        from swift.rollout.agentark.heartbeat import HeartbeatSupervisor, LeaseExpiredError
+
+        supervisor = HeartbeatSupervisor(default_timeout_s=1)
+        lease = self._lease('retryable-env', ttl=0.12)
+        try:
+            supervisor.register(lease, self.base_url)
+            self.assertTrue(_wait_until(lambda: lease.expired))
+            with self.assertRaisesRegex(LeaseExpiredError, 'deadline elapsed'):
+                lease.assert_active()
+            self.assertGreaterEqual(len(_HeartbeatHandler.requests), 1)
+        finally:
+            supervisor.shutdown()
+
+    def test_supervisor_instance_is_not_reused_after_fork(self):
+        import os
+
+        from swift.rollout.agentark.heartbeat import HeartbeatSupervisor
+
+        supervisor = HeartbeatSupervisor(default_timeout_s=1)
+        lease = self._lease('forked-env')
+        with patch('swift.rollout.agentark.heartbeat.os.getpid', return_value=os.getpid() + 1000):
+            with self.assertRaisesRegex(RuntimeError, 'after fork'):
+                supervisor.register(lease, self.base_url)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/rollout/agentark/test_http_client.py
+++ b/tests/rollout/agentark/test_http_client.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from ._fakes import append_generated_assistant, delta_messages, initial_messages, make_choice, make_request
+
+
+class _AgentArkHandler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+    requests: list[tuple[str, dict]] = []
+    lock = threading.Lock()
+    next_env = 1
+    v2_action_attempts: dict[str, int] = {}
+
+    def log_message(self, _format, *args):
+        return
+
+    def _send_json(self, status: int, payload: dict):
+        body = json.dumps(payload).encode('utf-8')
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', '0'))
+        payload = json.loads(self.rfile.read(length) or b'{}')
+        with type(self).lock:
+            type(self).requests.append((self.path, payload))
+
+        if self.path == '/v1/envs/acquire_start':
+            with type(self).lock:
+                env_id = f'http-env-{type(self).next_env}'
+                type(self).next_env += 1
+            self._send_json(
+                200,
+                {
+                    'env_id': env_id,
+                    'unity_id': 0,
+                    'obs': {
+                        'messages': initial_messages('from-http')
+                    },
+                    'info': {
+                        'task_name': 'http-task',
+                        'rollout_group_seed': 99
+                    },
+                },
+            )
+            return
+
+        if self.path == '/v2/envs/acquire_start':
+            with type(self).lock:
+                env_id = f'v2-http-env-{type(self).next_env}'
+                type(self).next_env += 1
+            self._send_json(
+                200,
+                {
+                    'server_epoch': 'http-server-epoch',
+                    'env_id': env_id,
+                    'lease_id': f'lease-token-{env_id}',
+                    'lease_generation': 7,
+                    'lease_ttl_s': 30.0,
+                    'heartbeat_interval_s': 10.0,
+                    'acquire_request_id': payload['acquire_request_id'],
+                    'unity_id': 0,
+                    'obs': {
+                        'messages': initial_messages('from-v2-http')
+                    },
+                    'info': {
+                        'task_name': 'v2-http-task'
+                    },
+                },
+            )
+            return
+
+        if self.path == '/v1/envs/fail-env/step':
+            self._send_json(503, {'detail': 'synthetic timeout'})
+            return
+
+        if self.path.startswith('/v2/envs/') and self.path.endswith('/step'):
+            action_id = str(payload.get('action_id') or '')
+            with type(self).lock:
+                attempt = type(self).v2_action_attempts.get(action_id, 0) + 1
+                type(self).v2_action_attempts[action_id] = attempt
+            if action_id == 'retry-503' and attempt == 1:
+                self._send_json(
+                    503,
+                    {'detail': {
+                        'code': 'operation_timeout',
+                        'message': 'lost',
+                        'retryable': True
+                    }},
+                )
+                return
+            if action_id == 'retry-in-progress' and attempt == 1:
+                self._send_json(
+                    409,
+                    {'detail': {
+                        'code': 'operation_in_progress',
+                        'message': 'still running',
+                        'retryable': True,
+                    }},
+                )
+                return
+            if action_id == 'semantic-conflict':
+                self._send_json(
+                    409,
+                    {'detail': {
+                        'code': 'lease_conflict',
+                        'message': 'wrong turn',
+                        'retryable': False,
+                    }},
+                )
+                return
+            if action_id == 'stale-identity' or action_id.startswith('e2e-stale:'):
+                self._send_json(
+                    409,
+                    {
+                        'detail': ('lease identity does not own env_id '
+                                   "'v2-http-env'; it may belong to an older generation")
+                    },
+                )
+                return
+            if action_id == 'semantic-gone':
+                self._send_json(
+                    410,
+                    {'detail': {
+                        'code': 'lease_gone',
+                        'message': 'expired',
+                        'retryable': False,
+                    }},
+                )
+                return
+            self._send_json(
+                200,
+                {
+                    'unity_id': 0,
+                    'obs': {
+                        'messages': delta_messages(payload.get('assistant', ''))
+                    },
+                    'reward': 0.75,
+                    'done': False,
+                    'info': {
+                        'status': 'v2-ok'
+                    },
+                    'replayed': attempt > 1,
+                },
+            )
+            return
+
+        if self.path.endswith('/step'):
+            self._send_json(
+                200,
+                {
+                    'unity_id': 0,
+                    'obs': {
+                        'messages': delta_messages(payload.get('assistant', ''))
+                    },
+                    'reward': 0.5,
+                    'done': False,
+                    'info': {
+                        'status': 'ok'
+                    },
+                },
+            )
+            return
+
+        if self.path.endswith('/release'):
+            if payload.get('release_request_id') == 'gone-release':
+                self._send_json(
+                    410,
+                    {
+                        'detail': {
+                            'code': 'lease_gone',
+                            'message': 'server_epoch does not match this env-server process',
+                            'retryable': False,
+                        }
+                    },
+                )
+                return
+            self._send_json(200, {'ok': True, **payload})
+            return
+
+        self._send_json(404, {'detail': 'not found'})
+
+
+class AgentArkHttpClientTests(unittest.IsolatedAsyncioTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        _AgentArkHandler.requests = []
+        _AgentArkHandler.next_env = 1
+        _AgentArkHandler.v2_action_attempts = {}
+        cls.server = ThreadingHTTPServer(('127.0.0.1', 0), _AgentArkHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        cls.base_url = f'http://127.0.0.1:{cls.server.server_port}'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join(timeout=5)
+
+    async def test_protocol_paths_and_payloads(self):
+        from swift.rollout.agentark.client import AgentArkHttpClient
+
+        client = AgentArkHttpClient(
+            self.base_url,
+            timeout_s=2,
+            release_timeout_s=2,
+            protocol_version='v1',
+        )
+        try:
+            started = await client.acquire_start(
+                {'mod_path': '/fake/mod'},
+                uid='group-http',
+                task_name='PinnedTask',
+                group_seed=17,
+            )
+            stepped = await client.step(
+                started['env_id'],
+                action='compiled action',
+                assistant='raw assistant',
+            )
+            released = await client.release(started['env_id'])
+        finally:
+            await client.aclose()
+
+        self.assertTrue(started['env_id'].startswith('http-env-'))
+        self.assertEqual(stepped['reward'], 0.5)
+        self.assertEqual(released, {'ok': True})
+        acquire_path, acquire_body = _AgentArkHandler.requests[-3]
+        step_path, step_body = _AgentArkHandler.requests[-2]
+        release_path, release_body = _AgentArkHandler.requests[-1]
+        self.assertEqual(acquire_path, '/v1/envs/acquire_start')
+        self.assertEqual(acquire_body['cfg'], {'mod_path': '/fake/mod'})
+        self.assertEqual(acquire_body['uid'], 'group-http')
+        self.assertEqual(acquire_body['task_name'], 'PinnedTask')
+        self.assertEqual(acquire_body['group_seed'], 17)
+        self.assertEqual(step_path, f"/v1/envs/{started['env_id']}/step")
+        self.assertEqual(step_body, {'action': 'compiled action', 'assistant': 'raw assistant'})
+        self.assertEqual(release_path, f"/v1/envs/{started['env_id']}/release")
+        self.assertEqual(release_body, {})
+
+    async def test_step_error_is_not_blindly_retried(self):
+        from swift.rollout.agentark.client import AgentArkHttpClient, AgentArkHttpError
+
+        before = sum(path == '/v1/envs/fail-env/step' for path, _ in _AgentArkHandler.requests)
+        client = AgentArkHttpClient(
+            self.base_url,
+            timeout_s=2,
+            release_timeout_s=2,
+            protocol_version='v1',
+        )
+        try:
+            with self.assertRaises(AgentArkHttpError):
+                await client.step('fail-env', action='dangerous', assistant='dangerous')
+        finally:
+            await client.aclose()
+        after = sum(path == '/v1/envs/fail-env/step' for path, _ in _AgentArkHandler.requests)
+
+        self.assertEqual(after - before, 1)
+
+    async def test_default_client_works_across_closed_event_loops(self):
+        """Match Swift colocate's reset/turn/finalize temporary-loop pattern."""
+
+        from swift.rollout.agentark.client import AgentArkHttpClient
+
+        client = AgentArkHttpClient(
+            self.base_url,
+            timeout_s=2,
+            release_timeout_s=2,
+            protocol_version='v1',
+        )
+
+        def exercise_three_loops():
+            started = asyncio.run(client.acquire_start({'mod_path': '/fake/mod'}, uid='cross-loop-group'))
+            stepped = asyncio.run(
+                client.step(started['env_id'], action='cross-loop-action', assistant='cross-loop-assistant'))
+            released = asyncio.run(client.release(started['env_id']))
+            asyncio.run(client.aclose())
+            return started, stepped, released
+
+        started, stepped, released = await asyncio.to_thread(exercise_three_loops)
+        self.assertTrue(started['env_id'].startswith('http-env-'))
+        self.assertEqual(stepped['reward'], 0.5)
+        self.assertEqual(released, {'ok': True})
+
+    async def test_v2_flat_identity_and_idempotency_payloads(self):
+        from swift.rollout.agentark.client import AgentArkHttpClient
+        from swift.rollout.agentark.heartbeat import LeaseHandle
+
+        client = AgentArkHttpClient(
+            self.base_url,
+            timeout_s=2,
+            release_timeout_s=2,
+            protocol_version='v2',
+            client_id='http-test-client',
+            v2_retry_base_delay_s=0,
+            v2_retry_max_delay_s=0,
+        )
+        acquire_id = 'acquire-http-trajectory'
+        started = await client.acquire_start(
+            {'mod_path': '/fake/v2-mod'},
+            uid='v2-group',
+            task_name='V2Task',
+            group_seed=23,
+            acquire_request_id=acquire_id,
+        )
+        lease = LeaseHandle.from_acquire_response(
+            started,
+            client_id=client.client_id,
+            acquire_request_id=acquire_id,
+            release_request_id='release-http-trajectory',
+        )
+        stepped = await client.step(
+            lease,
+            action='v2 action',
+            assistant='v2 assistant',
+            action_id='v2-trajectory:1',
+            turn_index=1,
+        )
+        released = await client.release(lease)
+        await client.aclose()
+
+        self.assertEqual(stepped['reward'], 0.75)
+        self.assertTrue(released['ok'])
+        acquire_path, acquire_body = _AgentArkHandler.requests[-3]
+        step_path, step_body = _AgentArkHandler.requests[-2]
+        release_path, release_body = _AgentArkHandler.requests[-1]
+        self.assertEqual(acquire_path, '/v2/envs/acquire_start')
+        self.assertEqual(acquire_body['acquire_request_id'], acquire_id)
+        self.assertEqual(acquire_body['client_id'], 'http-test-client')
+        self.assertEqual(step_path, f'/v2/envs/{lease.env_id}/step')
+        self.assertEqual(step_body['server_epoch'], lease.server_epoch)
+        self.assertEqual(step_body['lease_id'], lease.lease_id)
+        self.assertEqual(step_body['lease_generation'], 7)
+        self.assertEqual(step_body['action_id'], 'v2-trajectory:1')
+        self.assertEqual(step_body['turn_index'], 1)
+        self.assertEqual(release_path, f'/v2/envs/{lease.env_id}/release')
+        self.assertEqual(release_body['release_request_id'], 'release-http-trajectory')
+
+    async def test_v2_retries_only_safe_cases_with_the_same_action_id(self):
+        from swift.rollout.agentark.client import AgentArkHttpClient, AgentArkHttpError
+        from swift.rollout.agentark.heartbeat import LeaseHandle
+
+        client = AgentArkHttpClient(
+            self.base_url,
+            timeout_s=2,
+            release_timeout_s=2,
+            protocol_version='v2',
+            client_id='retry-client',
+            v2_max_attempts=3,
+            v2_retry_base_delay_s=0,
+            v2_retry_max_delay_s=0,
+        )
+        started = await client.acquire_start(
+            {'runtime': 'retry'},
+            uid='retry-group',
+            acquire_request_id='retry-acquire',
+        )
+        lease = LeaseHandle.from_acquire_response(
+            started,
+            client_id=client.client_id,
+            acquire_request_id='retry-acquire',
+            release_request_id='retry-release',
+        )
+
+        for action_id in ('retry-503', 'retry-in-progress'):
+            result = await client.step(
+                lease,
+                action=action_id,
+                assistant=action_id,
+                action_id=action_id,
+                turn_index=1,
+            )
+            self.assertEqual(result['reward'], 0.75)
+            calls = [
+                body for path, body in _AgentArkHandler.requests
+                if path.endswith('/step') and body.get('action_id') == action_id
+            ]
+            self.assertEqual(len(calls), 2)
+            self.assertEqual({call['action_id'] for call in calls}, {action_id})
+            self.assertEqual(calls[0], calls[1])
+
+        for action_id, status in (('semantic-conflict', 409), ('semantic-gone', 410)):
+            with self.assertRaises(AgentArkHttpError) as raised:
+                await client.step(
+                    lease,
+                    action=action_id,
+                    assistant=action_id,
+                    action_id=action_id,
+                    turn_index=1,
+                )
+            self.assertEqual(raised.exception.status_code, status)
+            self.assertEqual(_AgentArkHandler.v2_action_attempts[action_id], 1)
+        await client.aclose()
+
+    async def test_stale_lease_conflict_is_classified_and_not_retried(self):
+        from swift.rollout.agentark.client import AgentArkHttpClient, AgentArkStaleLeaseError
+        from swift.rollout.agentark.heartbeat import LeaseHandle
+
+        client = AgentArkHttpClient(
+            self.base_url,
+            timeout_s=2,
+            release_timeout_s=2,
+            protocol_version='v2',
+            client_id='stale-client',
+            v2_max_attempts=3,
+            v2_retry_base_delay_s=0,
+            v2_retry_max_delay_s=0,
+        )
+        started = await client.acquire_start(
+            {'runtime': 'stale'},
+            uid='stale-group',
+            acquire_request_id='stale-acquire',
+        )
+        lease = LeaseHandle.from_acquire_response(
+            started,
+            client_id=client.client_id,
+            acquire_request_id='stale-acquire',
+            release_request_id='stale-release',
+        )
+
+        with self.assertRaises(AgentArkStaleLeaseError):
+            await client.step(
+                lease,
+                action='stale-identity',
+                assistant='stale-identity',
+                action_id='stale-identity',
+                turn_index=1,
+            )
+
+        calls = [
+            body for path, body in _AgentArkHandler.requests
+            if path.endswith('/step') and body.get('action_id') == 'stale-identity'
+        ]
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(lease.expired)
+        self.assertIn('stale lease identity', lease.expired_reason)
+        await client.aclose()
+
+    async def test_lease_gone_release_is_already_cleaned_up(self):
+        from swift.rollout.agentark.client import AgentArkHttpClient
+        from swift.rollout.agentark.heartbeat import LeaseHandle
+
+        client = AgentArkHttpClient(
+            self.base_url,
+            timeout_s=2,
+            release_timeout_s=2,
+            protocol_version='v2',
+            client_id='gone-client',
+            v2_max_attempts=3,
+            v2_retry_base_delay_s=0,
+            v2_retry_max_delay_s=0,
+        )
+        started = await client.acquire_start(
+            {'runtime': 'gone'},
+            uid='gone-group',
+            acquire_request_id='gone-acquire',
+        )
+        lease = LeaseHandle.from_acquire_response(
+            started,
+            client_id=client.client_id,
+            acquire_request_id='gone-acquire',
+            release_request_id='gone-release',
+        )
+
+        result = await client.release(lease)
+
+        self.assertEqual(result, {'ok': True, 'stale_lease': True})
+        self.assertTrue(lease.expired)
+        self.assertIn('stale lease during release', lease.expired_reason)
+        releases = [body for path, body in _AgentArkHandler.requests if path.endswith('/release')]
+        self.assertEqual(releases[-1]['release_request_id'], 'gone-release')
+        await client.aclose()
+
+    async def test_stale_lease_409_through_http_env_and_scheduler_is_contained(self):
+        from swift.rollout.multi_turn import AgentArkScheduler
+
+        request = make_request(uuid='e2e-stale', group_uid='e2e-stale-group')
+        request.data_dict['env_config'].update({
+            'server_url': self.base_url,
+            'http_timeout_s': 2,
+            'release_timeout_s': 2,
+            'heartbeat_timeout_s': 2,
+        })
+        scheduler = AgentArkScheduler(max_turns=4)
+        await scheduler.on_trajectory_start([request])
+        assistant = 'stale-identity'
+        choice = make_choice(assistant)
+        append_generated_assistant(request, assistant)
+        request_count_before = len(_AgentArkHandler.requests)
+
+        result = await scheduler.on_turn_end(request, choice, current_turn=1)
+
+        requests_after = _AgentArkHandler.requests[request_count_before:]
+        stale_steps = [
+            body for path, body in requests_after if path.endswith('/step') and body.get('action_id') == 'e2e-stale:1'
+        ]
+        releases = [body for path, body in requests_after if path.endswith('/release')]
+        self.assertEqual(len(stale_steps), 1)
+        self.assertEqual(len(releases), 1)
+        self.assertTrue(result['done'])
+        self.assertTrue(result['rollout_infos']['trajectory_invalid'])
+        self.assertEqual(result['rollout_infos']['termination_reason'], 'stale_lease')
+        self.assertEqual(result['rollout_infos']['lease_recovery'], 'discard_trajectory')
+        self.assertNotIn(request.uuid, scheduler._envs)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/rollout/agentark/test_messages.py
+++ b/tests/rollout/agentark/test_messages.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import unittest
+
+from ._fakes import IMAGE_URL
+
+
+class MessageHelperTests(unittest.TestCase):
+
+    def test_action_extraction_matches_agentark_api_agent_semantics(self):
+        from swift.rollout.agentark.messages import extract_action
+
+        cases = [
+            (
+                '<think>reasoning</think>\n<tool_call>{"name":"ExecutePlan","arguments":{"plan":"R1"}}</tool_call>',
+                '<tool_call>{"name":"ExecutePlan","arguments":{"plan":"R1"}}</tool_call>',
+            ),
+            ('prefix<params> L1, U2 </params>suffix', '<params>L1, U2</params>'),
+            ('explanation<code>\nvar x = 1;\n</code>', 'var x = 1;'),
+            ('raw assistant action', 'raw assistant action'),
+            ('', None),
+        ]
+        for assistant, expected in cases:
+            with self.subTest(assistant=assistant):
+                self.assertEqual(extract_action(assistant), expected)
+
+    def test_full_transcript_response_keeps_only_new_environment_delta(self):
+        from swift.rollout.agentark.messages import new_environment_messages
+
+        conversation = [
+            {
+                'role': 'system',
+                'content': 'system'
+            },
+            {
+                'role': 'user',
+                'content': 'initial'
+            },
+            {
+                'role': 'assistant',
+                'content': 'ExecutePlan R1'
+            },
+        ]
+        returned = [
+            *conversation,
+            {
+                'role': 'assistant',
+                'content': 'ExecutePlan R1'
+            },
+            {
+                'role':
+                'user',
+                'content': [
+                    {
+                        'type': 'text',
+                        'text': 'new state'
+                    },
+                    {
+                        'type': 'image_url',
+                        'image_url': {
+                            'url': IMAGE_URL
+                        }
+                    },
+                ],
+            },
+        ]
+
+        delta = new_environment_messages(conversation, returned)
+
+        self.assertEqual(len(delta), 1)
+        self.assertEqual(delta[0]['role'], 'user')
+        self.assertEqual(delta[0]['content'][1]['image_url']['url'], IMAGE_URL)
+
+
+class BuiltinRegistrationTests(unittest.TestCase):
+
+    def test_agentark_env_and_scheduler_are_registered(self):
+        from swift.rollout.agentark.env import AgentArkEnv
+        from swift.rollout.gym_env import envs
+        from swift.rollout.multi_turn import AgentArkScheduler, multi_turns
+
+        self.assertIs(envs['agentark'], AgentArkEnv)
+        self.assertIs(multi_turns['agentark_scheduler'], AgentArkScheduler)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/rollout/agentark/test_scheduler.py
+++ b/tests/rollout/agentark/test_scheduler.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from ._fakes import IMAGE_URL, FakeAgentArkClient, append_generated_assistant, delta_messages, make_choice, make_request
+
+
+def _step_payload(assistant: str, *, reward: float = 0.25, done: bool = False):
+    return {
+        'unity_id': 0,
+        'obs': {
+            'messages': delta_messages(assistant)
+        },
+        'reward': reward,
+        'done': done,
+        'info': {
+            'server_detail': 'kept'
+        },
+    }
+
+
+class AgentArkSchedulerTests(unittest.IsolatedAsyncioTestCase):
+
+    async def _started_scheduler(
+        self,
+        *,
+        loss_scope: str = 'all_turns',
+        step_payloads=None,
+        max_turns: int | None = 4,
+    ):
+        from swift.rollout.agentark.env import AgentArkEnv
+        from swift.rollout.multi_turn import AgentArkScheduler
+
+        client = FakeAgentArkClient(step_payloads=step_payloads)
+        request = make_request(uuid='trajectory-1', group_uid='group-1', loss_scope=loss_scope)
+        env = AgentArkEnv(request.data_dict['env_config'], client=client)
+        scheduler = AgentArkScheduler(max_turns=max_turns)
+        scheduler._create_env = lambda _env_config: env
+        await scheduler.on_trajectory_start([request])
+        return scheduler, request, env, client
+
+    async def test_start_replaces_ticket_with_complete_messages(self):
+        scheduler, request, _env, _client = await self._started_scheduler()
+
+        self.assertEqual([message['role'] for message in request.messages], ['system', 'user'])
+        self.assertEqual(request.images, [])
+        self.assertEqual(request.messages[1]['content'][1]['image_url']['url'], IMAGE_URL)
+        await scheduler.finalize_trajectory(request.uuid, reason='test_cleanup')
+
+    async def test_step_deduplicates_assistant_and_keeps_inline_image(self):
+        assistant = 'ExecutePlan R1'
+        scheduler, request, _env, client = await self._started_scheduler(step_payloads=[_step_payload(assistant)])
+        choice = make_choice(assistant, token_ids=[31, 32, 33])
+        append_generated_assistant(request, assistant)
+
+        turn_result = await scheduler.on_turn_end(request, choice, current_turn=1)
+        step_result = scheduler.step(request, choice, current_turn=1)
+
+        self.assertFalse(turn_result['done'])
+        self.assertEqual([message['role'] for message in request.messages], ['system', 'user', 'assistant', 'user'])
+        self.assertEqual(
+            [message['content'] for message in request.messages if message['role'] == 'assistant'],
+            [assistant],
+        )
+        self.assertEqual(request.messages[-1]['content'][1]['image_url']['url'], IMAGE_URL)
+        self.assertEqual(step_result['response_token_ids'], [31, 32, 33])
+        self.assertEqual(step_result['response_loss_mask'], [1, 1, 1])
+        self.assertEqual(client.step_calls[0]['assistant'], assistant)
+        self.assertEqual(client.step_calls[0]['action_id'], 'trajectory-1:1')
+        self.assertEqual(client.step_calls[0]['turn_index'], 1)
+        await scheduler.finalize_trajectory(request.uuid, reason='test_cleanup')
+
+    async def test_last_round_masks_nonterminal_assistant_tokens(self):
+        assistant = 'ExecutePlan L1'
+        scheduler, request, _env, _client = await self._started_scheduler(
+            loss_scope='last_round',
+            step_payloads=[_step_payload(assistant)],
+        )
+        choice = make_choice(assistant, token_ids=[41, 42])
+        append_generated_assistant(request, assistant)
+
+        turn_result = await scheduler.on_turn_end(request, choice, current_turn=1)
+        step_result = scheduler.step(request, choice, current_turn=1)
+
+        self.assertFalse(turn_result['done'])
+        self.assertEqual(step_result['response_token_ids'], [41, 42])
+        self.assertEqual(step_result['response_loss_mask'], [0, 0])
+        await scheduler.finalize_trajectory(request.uuid, reason='test_cleanup')
+
+    async def test_done_accumulates_reward_and_releases(self):
+        assistant = 'ExecutePlan U1'
+        scheduler, request, _env, client = await self._started_scheduler(
+            step_payloads=[_step_payload(assistant, reward=0.8, done=True)])
+        choice = make_choice(assistant)
+        append_generated_assistant(request, assistant)
+
+        turn_result = await scheduler.on_turn_end(request, choice, current_turn=1)
+
+        self.assertTrue(turn_result['done'])
+        infos = turn_result['rollout_infos']
+        self.assertEqual(infos['total_reward'], 0.8)
+        self.assertEqual(infos['step_rewards'], [0.8])
+        self.assertTrue(infos['gym_done'])
+        self.assertEqual(infos['step_infos'][0]['server_detail'], 'kept')
+        self.assertEqual(client.release_calls, ['env-1'])
+        self.assertNotIn(request.uuid, scheduler._envs)
+
+    async def test_release_error_is_preserved_in_terminal_rollout_info(self):
+        from swift.rollout.agentark.env import AgentArkEnv
+        from swift.rollout.multi_turn import AgentArkScheduler
+
+        class FailingReleaseClient(FakeAgentArkClient):
+
+            async def release(self, lease, **_kwargs):
+                env_id = lease.env_id if hasattr(lease, 'env_id') else str(lease)
+                self.release_calls.append(env_id)
+                raise RuntimeError('synthetic release failure')
+
+        assistant = 'ExecutePlan U1'
+        client = FailingReleaseClient(step_payloads=[_step_payload(assistant, done=True)])
+        request = make_request(uuid='release-failure', group_uid='release-failure-group')
+        env = AgentArkEnv(request.data_dict['env_config'], client=client)
+        scheduler = AgentArkScheduler(max_turns=4)
+        scheduler._create_env = lambda _env_config: env
+        await scheduler.on_trajectory_start([request])
+        choice = make_choice(assistant)
+        append_generated_assistant(request, assistant)
+
+        turn_result = await scheduler.on_turn_end(request, choice, current_turn=1)
+
+        self.assertTrue(turn_result['done'])
+        self.assertIn('synthetic release failure', turn_result['rollout_infos']['release_error'])
+        self.assertEqual(client.release_calls, ['env-1'])
+
+    async def test_length_does_not_execute_truncated_action_and_releases(self):
+        assistant = 'truncated C# code ...'
+        scheduler, request, _env, client = await self._started_scheduler()
+        choice = make_choice(assistant, finish_reason='length')
+        append_generated_assistant(request, assistant)
+
+        turn_result = await scheduler.on_turn_end(request, choice, current_turn=1)
+
+        self.assertTrue(turn_result['done'])
+        self.assertEqual(client.step_calls, [])
+        self.assertEqual(client.release_calls, ['env-1'])
+        self.assertEqual(turn_result['rollout_infos']['termination_reason'], 'length')
+
+    async def test_max_turn_executes_last_action_then_releases(self):
+        assistant = 'ExecutePlan D1'
+        scheduler, request, _env, client = await self._started_scheduler(
+            step_payloads=[_step_payload(assistant, reward=0.4, done=False)],
+            max_turns=1,
+        )
+        choice = make_choice(assistant)
+        append_generated_assistant(request, assistant)
+
+        turn_result = await scheduler.on_turn_end(request, choice, current_turn=1)
+
+        self.assertTrue(turn_result['done'])
+        self.assertEqual(len(client.step_calls), 1)
+        self.assertEqual(client.release_calls, ['env-1'])
+        self.assertEqual(turn_result['rollout_infos']['termination_reason'], 'max_turns')
+
+    async def test_step_exception_releases_before_propagating(self):
+        assistant = 'ExecutePlan R2'
+        scheduler, request, _env, client = await self._started_scheduler(
+            step_payloads=[RuntimeError('fake Unity failure')])
+        choice = make_choice(assistant)
+        append_generated_assistant(request, assistant)
+
+        with self.assertRaisesRegex(RuntimeError, 'fake Unity failure'):
+            await scheduler.on_turn_end(request, choice, current_turn=1)
+
+        self.assertEqual(client.release_calls, ['env-1'])
+        self.assertNotIn(request.uuid, scheduler._envs)
+
+    async def test_stale_lease_invalidates_trajectory_without_killing_rollout_driver(self):
+        from swift.rollout.agentark.client import AgentArkStaleLeaseError
+
+        assistant = 'ExecutePlan stale'
+        scheduler, request, _env, client = await self._started_scheduler(step_payloads=[
+            AgentArkStaleLeaseError(
+                'lease identity does not own env_id; it may belong to an older generation',
+                status_code=409,
+                code='stale_lease',
+            )
+        ])
+        choice = make_choice(assistant)
+        append_generated_assistant(request, assistant)
+
+        result = await scheduler.on_turn_end(request, choice, current_turn=1)
+
+        self.assertTrue(result['done'])
+        self.assertTrue(result['rollout_infos']['trajectory_invalid'])
+        self.assertEqual(result['rollout_infos']['lease_recovery'], 'discard_trajectory')
+        self.assertEqual(result['rollout_infos']['termination_reason'], 'stale_lease')
+        self.assertEqual(client.release_calls, ['env-1'])
+        self.assertNotIn(request.uuid, scheduler._envs)
+
+    async def test_acquire_exception_leaves_no_scheduler_state(self):
+        from swift.rollout.agentark.env import AgentArkEnv
+        from swift.rollout.multi_turn import AgentArkScheduler
+
+        class FailingAcquireClient(FakeAgentArkClient):
+
+            async def acquire_start(self, *args, **kwargs):
+                raise RuntimeError('fake acquire failure')
+
+        client = FailingAcquireClient()
+        request = make_request(uuid='failed-trajectory', group_uid='failed-group')
+        env = AgentArkEnv(request.data_dict['env_config'], client=client)
+        scheduler = AgentArkScheduler(max_turns=4)
+        scheduler._create_env = lambda _env_config: env
+
+        with self.assertRaisesRegex(RuntimeError, 'fake acquire failure'):
+            await scheduler.on_trajectory_start([request])
+
+        self.assertNotIn(request.uuid, scheduler._envs)
+        self.assertNotIn(request.uuid, scheduler._total_rewards)
+        self.assertNotIn(request.uuid, scheduler._step_rewards)
+        self.assertEqual(client.release_calls, [])
+
+    async def test_one_failed_acquire_cleans_successful_sibling_from_same_batch(self):
+        from swift.rollout.agentark.env import AgentArkEnv
+        from swift.rollout.multi_turn import AgentArkScheduler
+
+        class FailingAcquireClient(FakeAgentArkClient):
+
+            async def acquire_start(self, *args, **kwargs):
+                raise RuntimeError('second acquire failed')
+
+        successful_request = make_request(uuid='successful-trajectory', group_uid='successful-group')
+        failed_request = make_request(uuid='failed-trajectory', group_uid='failed-group')
+        successful_client = FakeAgentArkClient()
+        failed_client = FailingAcquireClient()
+        successful_env = AgentArkEnv(successful_request.data_dict['env_config'], client=successful_client)
+        failed_env = AgentArkEnv(failed_request.data_dict['env_config'], client=failed_client)
+        scheduler = AgentArkScheduler(max_turns=4)
+
+        def create_env(env_config):
+            return successful_env if env_config['group_uid'] == 'successful-group' else failed_env
+
+        scheduler._create_env = create_env
+        with self.assertRaisesRegex(RuntimeError, 'second acquire failed'):
+            await scheduler.on_trajectory_start([successful_request, failed_request])
+
+        self.assertEqual(successful_client.release_calls, ['env-1'])
+        self.assertEqual(scheduler._envs, {})
+        self.assertEqual(scheduler._total_rewards, {})
+        self.assertEqual(scheduler._step_rewards, {})
+
+    async def test_server_driver_runs_builtin_scheduler_and_releases_lease(self):
+        from swift.infer_engine.protocol import (ChatCompletionResponse, ChatCompletionResponseChoice, ChatMessage,
+                                                 RequestConfig, UsageInfo)
+        from swift.rollout.agentark.env import AgentArkEnv
+        from swift.rollout.multi_turn import AgentArkScheduler
+
+        response = ChatCompletionResponse(
+            model='fake-model',
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(role='assistant', content='ExecutePlan U1'),
+                    finish_reason='stop',
+                    token_ids=[71, 72],
+                )
+            ],
+            usage=UsageInfo(prompt_tokens=0, completion_tokens=2, total_tokens=2),
+        )
+
+        class FakeServerEngine:
+            tokenizer = None
+            template = None
+
+            async def infer_async(self, _request, _config, **_kwargs):
+                return response
+
+            async def _batch_infer_stream(self, tasks, _stream, _use_tqdm, _metrics):
+                return await asyncio.gather(*tasks)
+
+        client = FakeAgentArkClient(step_payloads=[_step_payload('ExecutePlan U1', reward=1.0, done=True)])
+        request = make_request(uuid='server-trajectory', group_uid='server-group')
+        env = AgentArkEnv(request.data_dict['env_config'], client=client)
+        scheduler = AgentArkScheduler(infer_engine=FakeServerEngine(), max_turns=4)
+        scheduler._create_env = lambda _env_config: env
+
+        outputs = await scheduler.async_infer([request], RequestConfig(), use_tqdm=False)
+
+        self.assertEqual(outputs[0].response_token_ids, [[71, 72]])
+        self.assertEqual(outputs[0].rollout_infos['total_reward'], 1.0)
+        self.assertEqual(client.release_calls, ['env-1'])
+        self.assertEqual(scheduler._envs, {})
+
+
+class SwiftMultiTurnDriverTests(unittest.TestCase):
+
+    @staticmethod
+    def _rollout_output(content: str, token_ids: list[int]):
+        from swift.infer_engine.protocol import (ChatCompletionResponse, ChatCompletionResponseChoice, ChatMessage,
+                                                 RolloutOutput, UsageInfo)
+
+        choice = ChatCompletionResponseChoice(
+            index=0,
+            message=ChatMessage(role='assistant', content=content),
+            finish_reason='stop',
+            token_ids=token_ids,
+        )
+        response = ChatCompletionResponse(
+            model='fake-model',
+            choices=[choice],
+            usage=UsageInfo(prompt_tokens=0, completion_tokens=len(token_ids), total_tokens=len(token_ids)),
+        )
+        return RolloutOutput(response=response)
+
+    def _run_two_turn_trajectory(self, loss_scope: str):
+        from swift.infer_engine.protocol import RequestConfig
+        from swift.rollout.agent_loop import run_multi_turn
+        from swift.rollout.agentark.env import AgentArkEnv
+        from swift.rollout.multi_turn import AgentArkScheduler
+
+        class FakeTokenizer:
+
+            def decode(self, token_ids, skip_special_tokens=False):
+                return f'decoded-{list(token_ids)}'
+
+        first_assistant = 'ExecutePlan R1'
+        final_assistant = 'ExecutePlan U2'
+        client = FakeAgentArkClient(step_payloads=[
+            _step_payload(first_assistant, reward=0.2, done=False),
+            _step_payload(final_assistant, reward=0.8, done=True),
+        ])
+        request = make_request(uuid=f'driver-{loss_scope}', group_uid='driver-group', loss_scope=loss_scope)
+        env = AgentArkEnv(request.data_dict['env_config'], client=client)
+        # ms-swift 4.6 materializes ID-backed assistant history before calling
+        # scheduler hooks. Production passes the real tokenizer from the
+        # trainer; the driver fixture supplies the smallest equivalent.
+        scheduler = AgentArkScheduler(max_turns=4, tokenizer=FakeTokenizer())
+        scheduler._create_env = lambda _env_config: env
+        asyncio.run(scheduler.on_trajectory_start([request]))
+
+        first_output = self._rollout_output(first_assistant, [11, 12])
+        second_output = self._rollout_output(final_assistant, [21, 22, 23])
+        rollout_calls = []
+
+        def rollout_fn(requests, _request_config):
+            rollout_calls.append(list(requests))
+            return [second_output]
+
+        outputs = run_multi_turn(
+            requests=[request],
+            first_turn_outputs=[first_output],
+            scheduler=scheduler,
+            rollout_fn=rollout_fn,
+            request_config=RequestConfig(),
+            max_turns=4,
+        )
+        return outputs[0], client, rollout_calls
+
+    def test_all_turns_exact_ids_and_masks_through_swift_driver(self):
+        output, client, rollout_calls = self._run_two_turn_trajectory('all_turns')
+
+        self.assertEqual(output.response_token_ids, [[11, 12], [21, 22, 23]])
+        self.assertEqual(output.response_loss_mask, [[1, 1], [1, 1, 1]])
+        self.assertEqual(
+            [message['role'] for message in output.messages],
+            ['system', 'user', 'assistant', 'user', 'assistant'],
+        )
+        self.assertEqual(output.rollout_infos['total_reward'], 1.0)
+        self.assertEqual(output.rollout_infos['num_turns'], 2)
+        self.assertEqual(
+            [call['action_id'] for call in client.step_calls],
+            ['driver-all_turns:1', 'driver-all_turns:2'],
+        )
+        # The Swift multi-turn driver calls rollout_fn once with the pending second turn and
+        # once more with an empty list before its distributed stop check.
+        self.assertEqual(len(rollout_calls), 2)
+        self.assertEqual(len(rollout_calls[0]), 1)
+        self.assertEqual(rollout_calls[1], [])
+        self.assertEqual(client.release_calls, ['env-1'])
+
+    def test_last_round_masks_first_turn_but_not_final_turn_in_swift_driver(self):
+        output, client, _rollout_calls = self._run_two_turn_trajectory('last_round')
+
+        self.assertEqual(output.response_token_ids, [[11, 12], [21, 22, 23]])
+        self.assertEqual(output.response_loss_mask, [[0, 0], [1, 1, 1]])
+        self.assertEqual(client.release_calls, ['env-1'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/rollout/test_trajectory_lifecycle.py
+++ b/tests/rollout/test_trajectory_lifecycle.py
@@ -1,0 +1,153 @@
+import asyncio
+import unittest
+
+from swift.infer_engine.protocol import (ChatCompletionResponse, ChatCompletionResponseChoice, ChatMessage,
+                                         RequestConfig, RolloutInferRequest, UsageInfo)
+from swift.rollout.agent_loop import multi_turn_lifecycle
+from swift.rollout.multi_turn import GYMScheduler, MultiTurnScheduler
+
+
+def make_request(uuid=None):
+    return RolloutInferRequest(messages=[{'role': 'user', 'content': 'question'}], uuid=uuid)
+
+
+def make_response():
+    choice = ChatCompletionResponseChoice(0, ChatMessage('assistant', 'answer'), 'stop', token_ids=[11, 12])
+    return ChatCompletionResponse('fake-model', [choice], UsageInfo(0, 2, 2))
+
+
+class LifecycleScheduler(MultiTurnScheduler):
+
+    def __init__(self, *args, fail_start=False, fail_end=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fail_start = fail_start
+        self.fail_end = fail_end
+        self.events = []
+
+    async def on_trajectory_start(self, requests):
+        self.events.append(('start', list(requests)))
+        if self.fail_start:
+            raise ValueError('start failed')
+
+    async def on_trajectory_end(self, requests, error=None):
+        self.events.append(('end', list(requests), error))
+        if self.fail_end:
+            raise RuntimeError('end failed')
+
+    async def on_turn_end(self, infer_request, response_choice, current_turn):
+        return {'done': True}
+
+    def step(self, infer_request, response_choice, current_turn):
+        return {'infer_request': infer_request}
+
+
+class FakeEngine:
+
+    tokenizer = None
+    template = None
+
+    def __init__(self, error=None):
+        self.error = error
+
+    async def infer_async(self, infer_request, request_config, **kwargs):
+        if self.error is not None:
+            raise self.error
+        return make_response()
+
+    async def _batch_infer_stream(self, tasks, stream, use_tqdm, metrics):
+        return [await task for task in tasks]
+
+
+class FakeEnv:
+
+    def __init__(self):
+        self.close_calls = 0
+
+    async def close(self):
+        self.close_calls += 1
+
+
+class ColocateLifecycleTest(unittest.TestCase):
+
+    def test_success_runs_start_and_end_once(self):
+        scheduler = LifecycleScheduler()
+        request = make_request()
+
+        with multi_turn_lifecycle(scheduler, [request]):
+            scheduler.events.append(('body', ))
+
+        self.assertEqual([event[0] for event in scheduler.events], ['start', 'body', 'end'])
+        self.assertIsNone(scheduler.events[-1][2])
+
+    def test_initialization_failure_still_runs_end(self):
+        scheduler = LifecycleScheduler(fail_start=True)
+        request = make_request()
+
+        with self.assertRaisesRegex(ValueError, 'start failed'):
+            with multi_turn_lifecycle(scheduler, [request]):
+                self.fail('body must not run')
+
+        self.assertEqual([event[0] for event in scheduler.events], ['start', 'end'])
+        self.assertIsInstance(scheduler.events[-1][2], ValueError)
+
+    def test_finalization_cannot_mask_rollout_error(self):
+        scheduler = LifecycleScheduler(fail_end=True)
+        request = make_request()
+        original = ValueError('rollout failed')
+
+        with self.assertRaisesRegex(ValueError, 'rollout failed') as raised:
+            with multi_turn_lifecycle(scheduler, [request]):
+                raise original
+
+        self.assertIs(raised.exception, original)
+        self.assertIs(scheduler.events[-1][2], original)
+
+    def test_finalization_failure_after_success_is_raised(self):
+        scheduler = LifecycleScheduler(fail_end=True)
+
+        with self.assertRaisesRegex(RuntimeError, 'end failed'):
+            with multi_turn_lifecycle(scheduler, [make_request()]):
+                pass
+
+
+class ServerLifecycleTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_gym_scheduler_closes_remaining_environment(self):
+        scheduler = GYMScheduler()
+        request = make_request('request-1')
+        env = FakeEnv()
+        scheduler._envs[request.uuid] = env
+        scheduler._total_rewards[request.uuid] = 0.0
+        scheduler._step_rewards[request.uuid] = []
+        scheduler._pending_obs[request.uuid] = None
+
+        await scheduler.on_trajectory_end([request])
+
+        self.assertEqual(env.close_calls, 1)
+        self.assertNotIn(request.uuid, scheduler._envs)
+
+    async def test_server_scheduler_runs_end_after_success(self):
+        scheduler = LifecycleScheduler(infer_engine=FakeEngine(), max_turns=1)
+        request = make_request()
+
+        outputs = await scheduler.async_infer([request], RequestConfig(n=1), use_tqdm=False)
+
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual([event[0] for event in scheduler.events], ['start', 'end'])
+        self.assertIsNone(scheduler.events[-1][2])
+
+    async def test_server_scheduler_runs_end_after_generation_failure(self):
+        original = ValueError('generation failed')
+        scheduler = LifecycleScheduler(infer_engine=FakeEngine(original), max_turns=1)
+        request = make_request()
+
+        with self.assertRaisesRegex(ValueError, 'generation failed') as raised:
+            await scheduler.async_infer([request], RequestConfig(n=1), use_tqdm=False)
+
+        self.assertIs(raised.exception, original)
+        self.assertEqual([event[0] for event in scheduler.events], ['start', 'end'])
+        self.assertIs(scheduler.events[-1][2], original)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Summary

This PR adds built-in [AgentArk](https://github.com/P90-RushB/AgentArk) environment support to ms-swift GRPO.

AgentArk is an Apache-2.0 open-source, extensible general-purpose environment framework for VLM/LLM agents. Coding agents are used to automatically develop and expand its task library. It currently includes more than 200 tasks spanning general 2D and 3D tasks, physics-related tasks, charts and diagrams, multi-view tasks, ARC-AGI-3-like tasks, color-related tasks, and more; the collection is continuously expanding.

The Swift trainer communicates with a standalone AgentArk Environment Server over HTTP, while the server manages the task runtime pool.

This integration was discussed with ms-swift maintainers in the official community group, where the maintainers welcomed an upstream PR.

```text
swift rlhf
  -> AgentArkScheduler / AgentArkEnv
  -> AgentArk HTTP protocol v2
  -> AgentArk Environment Server
  -> task runtime pool
```

The trainer environment does not install `agent-ark` and does not import task-runtime code. The HTTP implementation reuses ms-swift's existing `aiohttp` and `requests` dependencies, so this PR adds no new package requirement.

## Why built-in support

AgentArk was previously integrated through an external Swift plugin. Moving the trainer-side adapter into Swift provides a documented and tested environment implementation while preserving Swift's rollout contracts:

- complete multimodal `messages`, including inline `image_url` content;
- exact sampled token IDs and per-token loss masks across multiple turns;
- `all_turns` and `last_round` assistant loss scopes;
- deterministic lease acquisition, heartbeat, release, and stale-lease fencing;
- cleanup after success, initialization failure, generation failure, or cancellation;
- both colocate and server-side multi-turn rollout paths.

AgentArk Environment Server and task runtimes remain independently deployed environment components.

## Commit structure

### `feat(rollout): finalize multi-turn trajectories`

Adds a general `on_trajectory_end(requests, error)` lifecycle hook for multi-turn schedulers and invokes it from both colocate and server-side drivers.

- finalization runs after success and failure, including initialization and first-generation failures;
- cleanup failures do not hide an already active rollout exception;
- the default hook is a no-op for backward compatibility;
- `GYMScheduler` uses the hook to close any environments still owned by the completed batch;
- lifecycle behavior is covered by focused unit tests.

This generic lifecycle boundary is required so environment-backed schedulers can reliably release resources that survive beyond an individual turn.

### `feat(rollout): add built-in AgentArk integration`

Adds the complete trainer-side integration:

- `AgentArkHttpClient` for protocol-v2 acquire, step, release, retry, idempotency, and structured error handling;
- lease identity and a process-safe heartbeat supervisor;
- `AgentArkEnv` and `AgentArkScheduler` registration;
- multimodal message delta handling, action extraction, exact token IDs, and loss-mask propagation;
- stale-lease containment and terminal cleanup;
- ticket generation and a minimal one-step LoRA example;
- Chinese and English documentation;
- fake HTTP server, environment, heartbeat, message, scheduler, and end-to-end driver tests.

The final implementation uses reusable `aiohttp.ClientSession` and `requests.Session` clients and does not add `httpx`.

## Experiment results

### Automated tests

Tested after rebasing onto `modelscope/ms-swift@7d001448a`:

```text
python -m unittest \
  tests.rollout.agentark.test_env \
  tests.rollout.agentark.test_heartbeat \
  tests.rollout.agentark.test_http_client \
  tests.rollout.agentark.test_messages \
  tests.rollout.agentark.test_scheduler \
  tests.rollout.test_trajectory_lifecycle \
  tests.rollout.test_exact_token_io \
  tests.rollout.test_server_exact_token_io

Ran 61 tests in 1.572s
OK
```

All configured pre-commit hooks pass on the 25 files changed by this PR: flake8, isort, YAPF, trailing whitespace, YAML, EOF, requirements, quote, merge-conflict, and mixed-line-ending checks.

The upstream tree currently contains pre-existing CRLF files outside this diff, so running the mixed-line-ending fixer over the entire checkout rewrites unrelated files. No such line-ending-only changes are included here; every non-empty file in this PR is stored as LF in Git.

### Real AgentArk smoke test

The rebased built-in integration was tested end to end with:

- model: Qwen3.5-4B;
- hardware: 6 x RTX 3090;
- training: LoRA, AdamW, GRPO/DAPO;
- rollout: colocated vLLM, tensor parallel size 2;
- environment: Snake 8x8, six warmed task runtimes, HTTP protocol v2;
- sequence settings: `max_turns=6`, `max_length=12288`, `max_completion_length=4096` per round;
- thinking mode enabled.

Result:

```text
global_step/max_steps: 1/1
loss: -0.2237
grad_norm: 0.4919
reward: 0.3333
reward_std: 0.8165
num_turns: 2.333
completions/mean_length: 493.5
checkpoint-1: written
active leases after training: 0
idle task runtimes after training: 6/6
```

### Longer convergence run

The built-in AgentArk path was also validated with a complete 600-step, full-parameter Qwen3.5-9B Snake run on 8 x H800. The run completed successfully and showed a clear upward reward trend. RL sampling is stochastic, so the curve is evidence of end-to-end convergence rather than an exact reproduction target.

The full recipe and training curve are documented here:

- [AgentArk Snake training tutorial](https://github.com/P90-RushB/AgentArk/blob/main/integrations/ms_swift/tutorial/README.md)
- [Training curve](https://github.com/P90-RushB/AgentArk/blob/main/integrations/ms_swift/tutorial/assets/snake-8x8-adamw-training-curve.png)

## Compatibility and CI scope

- Existing schedulers retain a no-op finalization hook unless they override it.
- AgentArk protocol v2 is the recommended path; the client retains the existing protocol-v1 compatibility path.
- Unit tests use in-memory fakes and a local fake HTTP server, so official CI does not require AgentArk Environment Server or task runtimes.
- The external AgentArk plugin remains available in the AgentArk repository for released Swift versions that do not yet contain this integration.
