### PR TITLE
feat(dev): wire Ulysses sequence parallelism into the HF SFT path

### DIFF
--- a/swift/dev/builders/__init__.py
+++ b/swift/dev/builders/__init__.py
@@ -5,11 +5,11 @@ The single place that maps swift's atomic Configs onto constructors.
 from __future__ import annotations
 
 from .dataset import build_dataset
-from .model import build_device_mesh, build_model, is_megatron_backend
+from .model import build_device_mesh, build_hf_device_mesh, build_model, is_megatron_backend
 from .sampler import build_sampler, sampled_texts, to_sampling_params
 from .template import build_template
 
 __all__ = [
-    'build_model', 'build_template', 'build_dataset', 'is_megatron_backend', 'build_device_mesh', 'build_sampler',
-    'to_sampling_params', 'sampled_texts'
+    'build_model', 'build_template', 'build_dataset', 'is_megatron_backend', 'build_device_mesh',
+    'build_hf_device_mesh', 'build_sampler', 'to_sampling_params', 'sampled_texts'
 ]

--- a/swift/dev/builders/dataset.py
+++ b/swift/dev/builders/dataset.py
@@ -5,6 +5,8 @@ import numpy as np
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 if TYPE_CHECKING:
+    from twinkle import DeviceMesh
+
     from swift.dev.config import DatasetConfig, DistributedConfig, TemplateConfig, TrainConfig
 
 logger = logging.getLogger(__name__)
@@ -16,7 +18,8 @@ def build_dataset(dataset_config: DatasetConfig,
                   distributed_config: DistributedConfig,
                   *,
                   encode: bool = True,
-                  template_config: Optional[TemplateConfig] = None) -> Any:
+                  template_config: Optional[TemplateConfig] = None,
+                  device_mesh: Optional['DeviceMesh'] = None) -> Any:
     """Load train (+val) once and return ``(train_loader, val_loader)`` (either may be None).
 
     A single call mirrors legacy ``BaseArguments.load_dataset`` (base_args.py): one ``load_dataset``
@@ -25,6 +28,10 @@ def build_dataset(dataset_config: DatasetConfig,
     encode: whether to pre-tokenize now (SFT: True) or keep the raw messages and defer tokenization
       to the training/rollout phase (RL such as GRPO/GKD: False). Mirrors legacy
       ``SwiftSft._get_dataset``'s ``pre_process = not (rlhf_type in {grpo, gkd})``.
+
+    ``device_mesh``: the HF-local Ulysses SP mesh from ``build_hf_device_mesh`` (None when SP is
+    off). When set, the loader slices by ``mesh.data_world_size`` (world/ulysses), so SP peers get
+    identical samples and DP groups get distinct ones -- see _twinkle_loader_layout.
 
     ``DatasetConfig.cached_dataset`` / ``cached_val_dataset`` point at directories written by
     ``swift export --to_cached_dataset`` (see swift/pipelines/export/cached_dataset.py). Those rows
@@ -69,7 +76,8 @@ def build_dataset(dataset_config: DatasetConfig,
         encode=encode,
         encode_mode=encode_mode,
         is_val=False,
-        cached=cached_train)
+        cached=cached_train,
+        device_mesh=device_mesh)
     val_loader = _build_split_loader(
         val_raw,
         template,
@@ -79,7 +87,8 @@ def build_dataset(dataset_config: DatasetConfig,
         encode=encode,
         encode_mode=encode_mode,
         is_val=True,
-        cached=cached_val)
+        cached=cached_val,
+        device_mesh=device_mesh)
     return train_loader, val_loader
 
 
@@ -174,7 +183,8 @@ def _build_split_loader(raw: Any,
                         encode: bool,
                         encode_mode: Optional[str],
                         is_val: bool,
-                        cached: Optional[list] = None) -> Any:
+                        cached: Optional[list] = None,
+                        device_mesh: Optional['DeviceMesh'] = None) -> Any:
     """Encode -> merge cached -> optional pack -> dataloader for one split (None+no cache -> None)."""
     if raw is None and not cached:
         return None
@@ -248,7 +258,7 @@ def _build_split_loader(raw: Any,
     # twinkle's DataLoader is handed the GLOBAL batch and slices it per DP rank (its DeviceMeshSampler),
     # unlike legacy which received the per-device batch and sharded internally. So it gets
     # per_device * dp and the mesh does the split (worker-fetcher). See _twinkle_loader_layout.
-    global_batch_size, device_mesh = _twinkle_loader_layout(distributed_config, batch_size)
+    global_batch_size, device_mesh = _twinkle_loader_layout(distributed_config, batch_size, device_mesh)
 
     from twinkle.dataloader import DataLoader
     # twinkle's DataLoader is inherently resumable (skip_consumed_samples / get_state); the training
@@ -274,13 +284,19 @@ def _identity_collate(batch):
     return list(batch)
 
 
-def _twinkle_loader_layout(distributed_config: DistributedConfig, per_device_batch_size: int) -> tuple:
+def _twinkle_loader_layout(distributed_config: DistributedConfig,
+                           per_device_batch_size: int,
+                           device_mesh: Optional['DeviceMesh'] = None) -> tuple:
     """``(global_batch_size, loader_device_mesh)`` for twinkle's ``DataLoader``.
 
     twinkle's DataLoader takes the GLOBAL batch and slices it across DP ranks (its DeviceMeshSampler),
     so it is given ``per_device * dp_world_size`` and the mesh does the per-rank split. The DP layout
     is a pure function of the config (``build_device_mesh``):
 
+      - HF Ulysses SP (``device_mesh`` given, from ``build_hf_device_mesh``): the sampler slices by
+        ``mesh.data_world_size`` (= world/ulysses), so SP peers receive IDENTICAL samples and only DP
+        groups differ -- exactly what Ulysses needs, since each SP rank re-splits the same sequence.
+        The global batch is scaled by data_world_size so twinkle's divisibility assert holds.
       - local mode: the loader owns DP sharding, so it is given the DeviceMesh and each rank takes its
         own slice (worker-fetcher). ``nproc_per_node`` MUST be set for a multi-GPU local run -- it
         sizes the DP layout; without it dp defaults to 1 (single process) and no sharding happens.
@@ -288,6 +304,8 @@ def _twinkle_loader_layout(distributed_config: DistributedConfig, per_device_bat
         later in ``model.forward_backward(dispatch='slice_dp')``, so only the global batch WIDTH is
         needed here.
     """
+    if device_mesh is not None:
+        return per_device_batch_size * device_mesh.data_world_size, device_mesh
     if distributed_config.nproc_per_node is None:
         return per_device_batch_size, None
     from swift.dev.builders.model import build_device_mesh

--- a/swift/dev/builders/model.py
+++ b/swift/dev/builders/model.py
@@ -3,19 +3,59 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
+    from twinkle import DeviceMesh
+
     from swift.dev.config import DistributedConfig, ModelConfig, TrainConfig, TunerConfig
     from swift.dev.model import TrainableModel
+
+
+def build_hf_device_mesh(distributed_config: DistributedConfig,
+                         sequence_parallel_size: int) -> Optional['DeviceMesh']:
+    """HF-backend local-mode DeviceMesh for Ulysses sequence parallelism.
+
+    Returns None unless SP is actually on in local (torchrun) mode -- an sp=1 run must reach
+    TransformersModel with no mesh, exactly as before (see the load-bearing note in
+    _build_transformers_model on why the default-mesh substitution is deliberate there).
+
+    Unlike build_device_mesh (Megatron: a pure function of the config, nproc_per_node-driven),
+    this reads the world size the same place twinkle's local mode does -- Platform.get_world_size()
+    (the torchrun WORLD_SIZE env), NOT torch.distributed, which twinkle initializes lazily and which
+    is therefore not up yet when run_sft builds the mesh.
+
+    Distinct from the Megatron mesh on purpose: no tp/pp/cp, just dp x ulysses. Note ulysses is
+    NOT a mesh dim in twinkle -- the dp dim spans ALL ranks (dp_size=world) and ``data_world_size``
+    derives world/ulysses from it (utils/device_mesh.py), so SP peers share one data rank and
+    receive identical samples.
+    """
+    if sequence_parallel_size <= 1 or distributed_config.mode != 'local':
+        return None
+
+    from twinkle import DeviceMesh
+    from twinkle.utils import Platform
+
+    world = Platform.get_world_size()
+    if world < 2:
+        raise ValueError(f'sequence_parallel_size={sequence_parallel_size} requires torchrun (WORLD_SIZE>=2); '
+                         'a single process has no ranks to split a sequence across.')
+    if world % sequence_parallel_size != 0:
+        raise ValueError(f'world_size={world} is not divisible by sequence_parallel_size={sequence_parallel_size}.')
+    return DeviceMesh.from_sizes(world_size=world, dp_size=world, ulysses_size=sequence_parallel_size)
 
 
 def build_model(model_config: ModelConfig,
                 distributed_config: DistributedConfig,
                 train_config: Optional[TrainConfig] = None,
-                tuner_config: Optional[TunerConfig] = None) -> TrainableModel:
+                tuner_config: Optional[TunerConfig] = None,
+                device_mesh: Optional['DeviceMesh'] = None) -> TrainableModel:
     """ModelConfig + DistributedConfig -> twinkle-native Model (no loss/optim yet).
 
     Thin mapping (no Registry/Factory): model_config fields -> twinkle __init__ kwargs.
     DistributedConfig.backend=='megatron' builds a MegatronModel (via the selected bridge
     backend); otherwise a TransformersModel. twinkle self-builds weights on the correct rank.
+
+    ``device_mesh`` is the HF-local Ulysses SP mesh from :func:`build_hf_device_mesh` (None when
+    SP is off); it is forwarded to the TransformersModel build only and must NOT be set for the
+    Megatron backend, which derives its own mesh from DistributedConfig.
 
     PPO's value critic is NOT a special build flag: it is a ``task_type='seq_cls', num_labels=1`` model
     forwarded with ``task='value'`` (which keeps the head's per-token output instead of pooling), so it
@@ -23,7 +63,7 @@ def build_model(model_config: ModelConfig,
     """
     if is_megatron_backend(distributed_config):
         return _build_megatron_model(model_config, distributed_config)
-    return _build_transformers_model(model_config, distributed_config, train_config, tuner_config)
+    return _build_transformers_model(model_config, distributed_config, train_config, tuner_config, device_mesh)
 
 
 def _mixed_precision_for(torch_dtype: Optional[str]) -> str:
@@ -128,6 +168,17 @@ def _apply_unsloth_kwargs(kwargs: dict, model_config: ModelConfig, tuner_config:
         kwargs['use_gradient_checkpointing'] = False
 
 
+def _apply_hf_sp_mesh(kwargs: dict, device_mesh: Optional['DeviceMesh'],
+                      distributed_config: DistributedConfig) -> None:
+    """Install the Ulysses SP mesh (from build_hf_device_mesh) on a local-mode transformers build.
+
+    A no-op for sp=1 (device_mesh is None) and for mode='ray', where validate_configs has already
+    rejected SP>1 and placement is _apply_ray_placement's business.
+    """
+    if device_mesh is not None and distributed_config.mode == 'local':
+        kwargs['device_mesh'] = device_mesh
+
+
 def _apply_ray_placement(kwargs: dict, distributed_config: DistributedConfig) -> None:
     """Place the transformers model in the remote 'model' DeviceGroup under mode='ray'.
 
@@ -170,7 +221,8 @@ def _resolve_model_loader(model_config: ModelConfig):
 def _build_transformers_model(model_config: ModelConfig,
                               distributed_config: DistributedConfig,
                               train_config: Optional[TrainConfig] = None,
-                              tuner_config: Optional[TunerConfig] = None) -> TrainableModel:
+                              tuner_config: Optional[TunerConfig] = None,
+                              device_mesh: Optional['DeviceMesh'] = None) -> TrainableModel:
     import torch
 
     from swift.dev.model import TransformersModel
@@ -225,12 +277,17 @@ def _build_transformers_model(model_config: ModelConfig,
             find_unused = not gc_on
     kwargs['ddp_config'] = {'find_unused_parameters': bool(find_unused)}
 
-    # No device_mesh passed on purpose: twinkle's local mode assigns its default one (pure data
+    # No device_mesh passed by default: twinkle's local mode assigns its default one (pure data
     # parallel over WORLD_SIZE, infra/__init__.py:538-541), which is exactly the transformers layout --
     # this backend has no TP/PP/CP (validate_configs rejects those sizes here). It is NOT optional
     # bookkeeping though: a None mesh silently changes the training objective to an avg-of-avg, so it
     # is load-bearing that run_sft calls twinkle.initialize first (see _initialize_twinkle, and the
     # 2-GPU aggregation test that pins the result).
+    #
+    # The one opt-in exception is Ulysses sequence parallelism: run_sft passes an explicit mesh from
+    # build_hf_device_mesh (dp x ulysses over the torchrun world) when sequence_parallel_size > 1,
+    # which switches twinkle's TransformersModel into its SP path (_enable_sp, transformers.py).
+    _apply_hf_sp_mesh(kwargs, device_mesh, distributed_config)
     #
     # Ray placement (RL): under mode='ray' the model lives in a remote DeviceGroup named 'model' --
     # the same group _initialize_twinkle builds -- mirroring the Megatron branch below. This is what

--- a/swift/dev/config/validate.py
+++ b/swift/dev/config/validate.py
@@ -50,6 +50,8 @@ def validate_configs(
     _check_rlhf_ref_model(model_config, tuner_config, rlhf_config)
     _check_rlhf_padding_free(template_config, dataset_config, rlhf_config)
     _check_rlhf_sequence_parallel(template_config, rlhf_config)
+    # After _check_packing (which may force padding_free=True) and after the RLHF SP guard.
+    _check_hf_sequence_parallel(model_config, template_config, dataset_config, distributed_config, is_megatron)
 
 
 def _check_muon(train_config: 'TrainConfig', distributed_config: 'DistributedConfig', is_megatron: bool) -> None:
@@ -620,16 +622,84 @@ def _check_rlhf_padding_free(template_config: 'TemplateConfig', dataset_config: 
 
 
 def _check_rlhf_sequence_parallel(template_config: 'TemplateConfig', rlhf_config: Optional['RLHFConfig']) -> None:
-    """Only some RLHF algorithms have a sequence-parallel training path.
+    """Sequence parallelism is not wired for ANY RLHF algorithm on the dev path.
 
-    Mirrors legacy rlhf_args.py::_check_sequence_parallel. `sequence_parallel_size > 1` splits each
-    sequence across ranks; only GRPO and DPO implement the loss under that split, so the others would
-    silently mis-reduce. Refused here for the same reason as padding_free above.
+    Divergence from legacy, deliberate: legacy rlhf_args.py::_check_sequence_parallel allows grpo/dpo
+    because legacy's trainers implement the sequence-parallel loss for them. dev wires NO mesh for the
+    RLHF recipes at all, so allowing grpo/dpo here would silently train with SP=1 while the config says
+    otherwise -- the exact failure mode validate.py exists to kill. Re-enable per algorithm when the
+    RLHF SP path is wired.
     """
     if rlhf_config is None or template_config.sequence_parallel_size <= 1:
         return
     rlhf_type = getattr(rlhf_config, 'rlhf_type', None)
-    if rlhf_type not in ('grpo', 'dpo'):
-        raise ValueError(f'rlhf_type={rlhf_type!r} does not support sequence_parallel_size='
-                         f'{template_config.sequence_parallel_size}: only grpo/dpo implement the sequence-parallel '
-                         'loss. Set sequence_parallel_size=1.')
+    raise ValueError(f'rlhf_type={rlhf_type!r} does not support sequence_parallel_size='
+                     f'{template_config.sequence_parallel_size} on the dev path: no device mesh is wired for the '
+                     'RLHF recipes, so the run would silently train WITHOUT sequence parallelism. '
+                     'Set sequence_parallel_size=1. (legacy allows grpo/dpo here; dev diverges until RLHF SP '
+                     'is wired -- see _check_hf_sequence_parallel for the SFT path.)')
+
+
+#: attn_impl values whose attention kernel handles the variable-length (THD) layout that
+#: padding_free produces under Ulysses SP. Mirrors legacy sft_args.py supported_impls; twinkle's
+#: SP strategy enforces the same requirement at first forward (flash_attention_2/3 only).
+_SP_PADDING_FREE_ATTN_IMPLS = ('flash_attn', 'flash_attention_2', 'flash_attention_3', 'flash_attention_4')
+
+
+def _check_hf_sequence_parallel(model_config: 'ModelConfig', template_config: 'TemplateConfig',
+                                dataset_config: 'DatasetConfig', distributed_config: 'DistributedConfig',
+                                is_megatron: bool) -> None:
+    """Guards for Ulysses sequence parallelism (TemplateConfig.sequence_parallel_size) on the HF backend.
+
+    Every check raises: SP that cannot do what the config says would otherwise SILENTLY train with
+    SP=1 (nothing on the HF path used to read this knob) or crash deep in the first forward. Called
+    after _check_packing, which may force padding_free=True, so guard 3 sees the effective value.
+    Streaming is allowed: twinkle's IterableFetcher slices by data_world_size the same way.
+    """
+    sp = template_config.sequence_parallel_size
+    if sp <= 1:
+        return
+
+    if is_megatron:
+        # TemplateConfig.sequence_parallel_size is the HF Ulysses knob; Megatron's sequence
+        # parallelism is DistributedConfig.sequence_parallel (TP-SP), a different feature.
+        raise ValueError(f'TemplateConfig.sequence_parallel_size={sp} only applies to the transformers backend, '
+                         'but the active backend is megatron. Megatron sequence parallelism is '
+                         'DistributedConfig.sequence_parallel (TP-SP over the tensor-parallel ranks) -- set that '
+                         'instead, or switch DistributedConfig.backend.')
+
+    if distributed_config.mode != 'local':
+        raise NotImplementedError(f'sequence_parallel_size={sp} is only wired for mode="local" (torchrun): under '
+                                  "mode='ray' the model gets a pure data-parallel mesh (_apply_ray_placement), so "
+                                  'SP would silently not apply. Run with torchrun, or set sequence_parallel_size=1.')
+
+    if distributed_config.fsdp:
+        raise NotImplementedError(f'sequence_parallel_size={sp} with DistributedConfig.fsdp is not supported yet: '
+                                  'the FSDP x ulysses composition in twinkle is unvalidated. Use DDP/accelerate '
+                                  '(the default strategy), or set sequence_parallel_size=1.')
+
+    # Legacy asserts this at collate time (swift/template/base.py); dev fails fast at validation.
+    if template_config.padding_side != 'right':
+        raise ValueError(f'sequence_parallel_size={sp} requires padding_side="right" (got '
+                         f'{template_config.padding_side!r}): the SP collator injects per-row position_ids that '
+                         'assume right padding. legacy asserts the same at collate time; dev refuses up front.')
+
+    if template_config.padding_free or dataset_config.packing:
+        if model_config.attn_impl not in _SP_PADDING_FREE_ATTN_IMPLS:
+            raise ValueError(f'sequence_parallel_size={sp} with padding_free requires a flash attention kernel: '
+                             f'twinkle\'s SP strategy rejects the variable-length layout under '
+                             f'attn_impl={model_config.attn_impl!r}. Use one of '
+                             f'{", ".join(repr(i) for i in _SP_PADDING_FREE_ATTN_IMPLS)}, or set padding_free=False '
+                             '(packing implies padding_free, so drop packing too).')
+
+    # twinkle.initialize(mode='local') never calls dist.init_process_group -- world size comes from
+    # Platform.get_world_size() (the WORLD_SIZE env torchrun sets), the same source initialize uses
+    # to build the default mesh. Requiring dist here would reject every real SP run.
+    from twinkle.utils import Platform
+    world = Platform.get_world_size()
+    if world < 2:
+        raise ValueError(f'sequence_parallel_size={sp} requires torchrun (WORLD_SIZE>=2): a single process has no '
+                         'ranks to split a sequence across. Set sequence_parallel_size=1 for a single-process run.')
+    if world % sp != 0:
+        raise ValueError(f'world_size={world} is not divisible by sequence_parallel_size={sp}: the SP groups must '
+                         'tile the ranks exactly. Adjust the rank count or sequence_parallel_size.')

--- a/swift/dev/recipe/assembly.py
+++ b/swift/dev/recipe/assembly.py
@@ -65,6 +65,7 @@ class TrainAssembly:
     output_dir: str = 'output'
 
     # --- stage results, in the order the stages produce them ---
+    sp_mesh: Any = field(default=None, init=False)
     processor: Any = field(default=None, init=False)
     template: Any = field(default=None, init=False)
     dataloader: Any = field(default=None, init=False)
@@ -149,6 +150,21 @@ class TrainAssembly:
             self.rlhf_config,
         )
         return self
+
+    def plan_sp_mesh(self) -> Any:
+        """Build the ONE Ulysses SP mesh all consumers share (None when SP is off).
+
+        The mesh is the only thing twinkle's SP needs: the model activates its SP strategy from
+        ``mesh.ulysses_size > 1``, and the dataloader slices by ``mesh.data_world_size`` so SP peers
+        receive identical samples. ``build_hf_device_mesh`` returns None for sp<=1 or non-local mode,
+        preserving the deliberate no-mesh local path bit-for-bit. Runs AFTER :meth:`prepare`:
+        ``_check_hf_sequence_parallel`` has already rejected the combinations where this mesh would
+        be meaningless or harmful (megatron backend, rlhf, ray, fsdp, non-divisible world).
+        """
+        from swift.dev.builders import build_hf_device_mesh
+
+        self.sp_mesh = build_hf_device_mesh(self.distributed_config, self.template_config.sequence_parallel_size)
+        return self.sp_mesh
 
     def require_task_type(self) -> str:
         """Default ``ModelConfig.task_type`` to this recipe's ``task``, and refuse a conflicting one.
@@ -259,7 +275,8 @@ class TrainAssembly:
             model_config = copy.copy(model_config)
             model_config.model = resume_dir
 
-        self.model = build_model(model_config, self.distributed_config, self.train_config, self.tuner_config)
+        self.model = build_model(
+            model_config, self.distributed_config, self.train_config, self.tuner_config, device_mesh=self.sp_mesh)
         if self.tuner_config is not None:
             apply_tuner(self.model, self.tuner_config, gradient_accumulation_steps=self.ga)
         self.model.set_processor(InputProcessor, padding_free=self.template_config.padding_free)
@@ -322,10 +339,11 @@ class TrainAssembly:
         from swift.dev.optimizer import configure_optimizer
 
         self.prepare()
+        self.plan_sp_mesh()
         if self.task:
             self.require_task_type()
         self.build_template()
-        self.build_dataset()
+        self.build_dataset(device_mesh=self.sp_mesh)
         self.plan_steps()
         self.build_model()
         configure_loss(self.model)

--- a/swift/dev/tests/_runners/hf_sp.py
+++ b/swift/dev/tests/_runners/hf_sp.py
@@ -1,0 +1,149 @@
+"""Standalone entry that runs ONE dev transformers-backend SFT shape under sequence parallelism.
+
+Launched by feature/sft/test_e2e.py::test_run_sft_hf_sp_matches_single twice over the SAME samples:
+once under ``torchrun --nproc_per_node=2`` with sequence_parallel_size=2 (--shape sp2, each rank
+holds HALF of every sequence) and once as a plain single process (--shape single). SP is a pure
+re-partition -- the gathered loss must equal the single-process loss on the same global batch.
+
+Each rank writes ``{out}.rank{RANK}.json`` with its loss trajectory plus the SP plumbing facts
+(mesh ulysses size, _enable_sp, sp_strategy constructed), read back off the model run_sft built.
+
+Usage:
+    python -m torch.distributed.run ... swift/dev/tests/_runners/hf_sp.py \
+        --shape {sp2|single} --data DATA.jsonl --out RESULT.json --out_dir DIR [--padding_free]
+
+Model/template default to the sibling dp runner's (Qwen2.5-0.5B + qwen2_5 via modelscope);
+SP_TEST_MODEL / SP_TEST_TEMPLATE override them (e.g. a local path on an offline machine).
+"""
+
+import argparse
+import os
+
+import json
+
+MODEL = os.environ.get("SP_TEST_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+TEMPLATE = os.environ.get("SP_TEST_TEMPLATE", "qwen2_5")
+
+
+def _peak_mem_mb():
+    """Peak accelerator memory (MB), NPU or CUDA; None where neither is queryable."""
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return round(torch.cuda.max_memory_allocated() / 1e6, 1)
+        import torch_npu  # noqa: F401
+
+        return round(torch.npu.max_memory_allocated() / 1e6, 1)
+    except Exception:
+        return None
+
+
+def _run(shape, data_path, out_dir, padding_free, max_length, sp_size, max_steps):
+    """run_sft with sequence_parallel_size=2 (sp2) or 1 (single); see _hf_dp_runner for the
+    capturing-build_model rationale (run_sft does not return the model it built)."""
+    import swift.dev.builders as builders
+    from swift.dev.config import (
+        CheckpointConfig,
+        DatasetConfig,
+        DistributedConfig,
+        ModelConfig,
+        TemplateConfig,
+        TrainConfig,
+        TunerConfig,
+    )
+    from swift.dev.recipe import run_sft
+
+    model_path = MODEL if os.path.isdir(MODEL) else __import__("modelscope").snapshot_download(MODEL)
+
+    captured = {}
+    orig_build_model = builders.build_model
+
+    def capturing_build_model(*args, **kwargs):
+        model = orig_build_model(*args, **kwargs)
+        captured["model"] = model
+        return model
+
+    builders.build_model = capturing_build_model
+    try:
+        history = run_sft(
+            # padding_free + SP requires a flash attention kernel (twinkle's SP strategy rejects the
+            # variable-length layout otherwise); the padded path runs on the default (sdpa) kernel.
+            ModelConfig(
+                model=model_path, torch_dtype="bfloat16", attn_impl="flash_attention_2" if padding_free else None
+            ),
+            TemplateConfig(
+                template=TEMPLATE,
+                max_length=max_length,
+                sequence_parallel_size=(sp_size if shape == "sp2" else 1),
+                padding_free=padding_free,
+            ),
+            DatasetConfig(dataset=[data_path], dataset_shuffle=False),
+            # One optimizer step on the untouched initial weights, so sp2 and single are comparable
+            # without any update/scheduler compounding. Both shapes see the SAME global batch of 2:
+            # under sp2 the loader's data_world_size is world/ulysses=1, so both SP ranks receive
+            # identical samples and each computes half of every sequence.
+            TrainConfig(
+                learning_rate=1e-5,
+                lr_scheduler_type="constant",
+                warmup_ratio=0.0,
+                per_device_train_batch_size=2,
+                gradient_accumulation_steps=1,
+                max_steps=max_steps,
+            ),
+            DistributedConfig(),
+            CheckpointConfig(),
+            # LoRA, mirroring the dp runner: exercises a second OptimizerGroup and keeps the run light.
+            tuner_config=TunerConfig(tuner_type="lora"),
+            output_dir=out_dir,
+            _save_final=False,
+        )
+    finally:
+        builders.build_model = orig_build_model
+
+    model = captured["model"]
+    mesh = model.device_mesh
+    return {
+        "shape": shape,
+        "padding_free": padding_free,
+        "rank": int(os.environ.get("RANK", "0")),
+        "world_size": int(os.environ.get("WORLD_SIZE", "1")),
+        "losses": [r["loss"] for r in history],
+        "peak_mem_mb": _peak_mem_mb(),
+        "ulysses_size": getattr(mesh, "ulysses_size", None) if mesh is not None else None,
+        "data_world_size": mesh.data_world_size if mesh is not None else None,
+        # mesh ranks come off a numpy-backed mesh tensor (np.int64) -- coerce or json.dump dies
+        # mid-write, leaving a truncated rank file that reads back as JSONDecodeError.
+        "data_rank": int(mesh.data_rank) if mesh is not None and mesh.data_rank is not None else None,
+        "enable_sp": getattr(model, "_enable_sp", None),
+        # sp_strategy is built lazily at the first forward; after training it must exist under sp2.
+        "sp_strategy_present": getattr(model, "sp_strategy", None) is not None,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--shape", choices=["sp2", "single"], required=True)
+    parser.add_argument("--data", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--out_dir", required=True)
+    parser.add_argument("--padding_free", action="store_true")
+    parser.add_argument("--max_length", type=int, default=512)
+    # SP degree when --shape sp2 (world may exceed it: torchrun x4 + --sp_size 2 is the hybrid
+    # data+sequence-parallel layout, data_world_size=2).
+    parser.add_argument("--sp_size", type=int, default=2)
+    # >1 only for the loss-curve asset script (local/run_sp_loss_curve.sh); the pytest cases keep
+    # the default single step so sp2/single compare on untouched initial weights.
+    parser.add_argument("--max_steps", type=int, default=1)
+    args = parser.parse_args()
+
+    result = _run(args.shape, args.data, args.out_dir, args.padding_free, args.max_length, args.sp_size, args.max_steps)
+    # EVERY rank writes: the sp2 ranks must be compared against each other (equal losses are what
+    # proves the SP loss gather replicated the result), not just read off rank 0.
+    with open(f"{args.out}.rank{result['rank']}.json", "w") as f:
+        json.dump(result, f)
+    print(f"RUNNER_DONE {result}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/swift/dev/tests/_runners/hf_sp_mesh.py
+++ b/swift/dev/tests/_runners/hf_sp_mesh.py
@@ -1,0 +1,74 @@
+"""torchrun entry for test_hf_sp_config.py::test_hf_sp_mesh_and_validate_over_gloo.
+
+Runs on CPU under ``torchrun --nproc_per_node=2`` with a gloo process group (no accelerator):
+  1. validate_configs ACCEPTS sp=world on the HF backend when every guard is satisfied
+     (padding_free + flash_attention_2, right padding, local mode, dist initialized);
+  2. build_hf_device_mesh returns a mesh with ulysses_size=sp and data_world_size=world/sp;
+  3. validate_configs REJECTS sp=world+1 on divisibility.
+
+Each rank writes ``{out}.rank{RANK}.json``.
+
+Usage:
+    torchrun --nproc_per_node=2 swift/dev/tests/_runners/hf_sp_mesh.py --out RESULT
+"""
+
+import argparse
+
+import json
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    import torch.distributed as dist
+
+    dist.init_process_group("gloo")
+
+    from swift.dev.builders import build_hf_device_mesh
+    from swift.dev.config import (
+        CheckpointConfig,
+        DatasetConfig,
+        DistributedConfig,
+        ModelConfig,
+        TemplateConfig,
+        TrainConfig,
+        validate_configs,
+    )
+
+    world = dist.get_world_size()
+    distributed_config = DistributedConfig()
+    result = {"rank": dist.get_rank(), "world": world}
+
+    def _validate(sp):
+        validate_configs(
+            ModelConfig(model="dummy", attn_impl="flash_attention_2"),
+            TemplateConfig(template="qwen2_5", sequence_parallel_size=sp, padding_free=True),
+            DatasetConfig(dataset=["dummy"]),
+            TrainConfig(),
+            distributed_config,
+            CheckpointConfig(),
+        )
+
+    # 1+2. accepted: pure-SP layout (sp == world, so dp=1) with all guards satisfied.
+    _validate(world)
+    result["validate_ok"] = True
+    mesh = build_hf_device_mesh(distributed_config, world)
+    result["ulysses_size"] = mesh.ulysses_size
+    result["data_world_size"] = mesh.data_world_size
+
+    # 3. rejected: world % sp != 0.
+    try:
+        _validate(world + 1)
+        result["divisibility_raised"] = False
+    except ValueError as e:
+        result["divisibility_raised"] = "not divisible" in str(e)
+
+    with open(f"{args.out}.rank{result['rank']}.json", "w") as f:
+        json.dump(result, f)
+    print(f"RUNNER_DONE {result}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/swift/dev/tests/component/config/test_hf_sp_config.py
+++ b/swift/dev/tests/component/config/test_hf_sp_config.py
@@ -1,0 +1,214 @@
+"""Ulysses sequence parallelism (TemplateConfig.sequence_parallel_size) on the HF backend.
+
+Why these guards exist. The knob was accepted by the config and forwarded to the template
+(builders/template.py) long before any training-path consumer existed: an sp>1 run SILENTLY trained
+with SP=1. Now that run_sft wires a real mesh (build_hf_device_mesh), validate_configs must reject
+every combination where the mesh would be meaningless or the twinkle SP strategy would crash at the
+first forward -- failing at validation in milliseconds instead of after the weights load.
+
+Nothing here touches an accelerator. The guard matrix is a pure function of the Configs and needs no
+process group (the rejections all fire before the divisibility check); the accepted case and the mesh
+math need world_size>=2, so they run under torchrun with a gloo (CPU) group via the hf_sp_mesh runner.
+"""
+
+from __future__ import annotations
+import os
+import sys
+
+import json
+import pytest
+
+from ..._runners import Runners
+from ...feature.sft.test_e2e import _master_port, _run_torchrun
+
+
+def _configs(*, rlhf_type=None, **overrides):
+    """HF-backend config dict for validate_configs; overrides key on 'field=value' via setattrs."""
+    from swift.dev.config import (
+        CheckpointConfig,
+        DatasetConfig,
+        DistributedConfig,
+        ModelConfig,
+        TemplateConfig,
+        TrainConfig,
+    )
+
+    configs = {
+        "model_config": ModelConfig(model="dummy"),
+        "template_config": TemplateConfig(template="qwen2_5"),
+        "dataset_config": DatasetConfig(dataset=["dummy"]),
+        "train_config": TrainConfig(),
+        "distributed_config": DistributedConfig(),
+        "checkpoint_config": CheckpointConfig(),
+    }
+    if rlhf_type is not None:
+        from swift.dev.config import RLHFConfig
+
+        configs["rlhf_config"] = RLHFConfig(rlhf_type=rlhf_type)
+    for dotted, value in overrides.items():
+        holder_name, _, attr = dotted.partition(".")
+        setattr(configs[holder_name], attr, value)
+    return configs
+
+
+def _validate(**overrides):
+    from swift.dev.config import validate_configs
+
+    validate_configs(**_configs(**overrides))
+
+
+def test_sp_off_by_default_is_accepted():
+    """sp=1 must pass with no process group at all -- the guard returns before touching dist."""
+    _validate()
+
+
+def test_sp_on_megatron_backend_is_rejected():
+    """Megatron SP is DistributedConfig.sequence_parallel (TP-SP), a different feature."""
+    with pytest.raises(ValueError, match="only applies to the transformers backend"):
+        _validate(
+            **{
+                "template_config.sequence_parallel_size": 2,
+                "distributed_config.backend": "megatron",
+                "distributed_config.nproc_per_node": 2,
+            }
+        )
+
+
+@pytest.mark.parametrize("rlhf_type", ["dpo", "grpo", "kto"])
+def test_sp_with_any_rlhf_type_is_rejected(rlhf_type):
+    """dev wires no RLHF SP mesh; legacy's grpo/dpo allowance would silently train without SP."""
+    with pytest.raises(ValueError, match="does not support sequence_parallel_size"):
+        _validate(rlhf_type=rlhf_type, **{"template_config.sequence_parallel_size": 2})
+
+
+def test_sp_in_ray_mode_is_rejected():
+    """Ray passes a pure data-parallel mesh (_apply_ray_placement); SP would silently not apply."""
+    with pytest.raises(NotImplementedError, match='mode="local"'):
+        _validate(
+            **{
+                "template_config.sequence_parallel_size": 2,
+                "distributed_config.mode": "ray",
+            }
+        )
+
+
+def test_sp_with_fsdp_is_rejected():
+    """The FSDP x ulysses composition in twinkle is unvalidated."""
+    with pytest.raises(NotImplementedError, match="fsdp"):
+        _validate(
+            **{
+                "template_config.sequence_parallel_size": 2,
+                "distributed_config.fsdp": "full_shard",
+            }
+        )
+
+
+def test_sp_with_left_padding_is_rejected():
+    """The SP collator's per-row position_ids assume right padding (legacy asserts at collate time)."""
+    with pytest.raises(ValueError, match="padding_side"):
+        _validate(
+            **{
+                "template_config.sequence_parallel_size": 2,
+                "template_config.padding_side": "left",
+            }
+        )
+
+
+def test_sp_padding_free_without_flash_attn_is_rejected():
+    """twinkle's SP strategy rejects the variable-length layout without FA2/3 at first forward."""
+    with pytest.raises(ValueError, match="flash attention"):
+        _validate(
+            **{
+                "template_config.sequence_parallel_size": 2,
+                "template_config.padding_free": True,
+                "model_config.attn_impl": "sdpa",
+            }
+        )
+
+
+def test_sp_padding_free_with_unset_attn_impl_is_rejected():
+    """attn_impl=None lands on the default (non-flash) kernel, so it is rejected too."""
+    with pytest.raises(ValueError, match="flash attention"):
+        _validate(
+            **{
+                "template_config.sequence_parallel_size": 2,
+                "template_config.padding_free": True,
+            }
+        )
+
+
+def test_sp_packing_inherits_the_flash_attn_requirement():
+    """_check_packing forces padding_free=True before this guard runs, so packing+SP+sdpa must fail."""
+    with pytest.raises(ValueError, match="flash attention"):
+        _validate(
+            **{
+                "template_config.sequence_parallel_size": 2,
+                "dataset_config.packing": True,
+                "model_config.attn_impl": "sdpa",
+            }
+        )
+
+
+def test_sp_without_torchrun_is_rejected():
+    """Single process: no ranks to split a sequence across (WORLD_SIZE is unset here)."""
+    with pytest.raises(ValueError, match="torchrun"):
+        _validate(**{"template_config.sequence_parallel_size": 2})
+
+
+def test_mesh_builder_returns_none_when_sp_is_off():
+    """sp=1 must reach TransformersModel with NO mesh -- the deliberate default-mesh local path."""
+    from swift.dev.builders import build_hf_device_mesh
+    from swift.dev.config import DistributedConfig
+
+    assert build_hf_device_mesh(DistributedConfig(), 1) is None
+    # Non-local mode never builds this mesh either (validate rejects ray+sp>1 before this runs).
+    assert build_hf_device_mesh(DistributedConfig(mode="ray"), 2) is None
+
+
+def test_mesh_builder_without_torchrun_raises():
+    """Plain pytest process: WORLD_SIZE unset -> world=1 -> the torchrun requirement fires."""
+    from swift.dev.builders import build_hf_device_mesh
+    from swift.dev.config import DistributedConfig
+
+    with pytest.raises(ValueError, match="torchrun"):
+        build_hf_device_mesh(DistributedConfig(), 2)
+
+
+@pytest.mark.slow
+def test_hf_sp_mesh_and_validate_over_gloo(tmp_path):
+    """2-proc gloo: sp=2 is ACCEPTED with all guards satisfied, and the mesh math holds.
+
+    The one combination the matrix above cannot cover: passing the divisibility guard needs a real
+    process group with world_size >= sp. gloo keeps it CPU-only. Asserts, per rank:
+      - validate_configs accepts sp=world with padding_free + flash_attention_2;
+      - the mesh reports ulysses_size=world and data_world_size=1 (world/ulysses);
+      - sp=world+1 raises on divisibility.
+    """
+    runner = Runners.path("hf_sp_mesh")
+    result_prefix = str(tmp_path / "gloo")
+    cmd = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--nproc_per_node=2",
+        f"--master_port={_master_port(10)}",
+        runner,
+        "--out",
+        result_prefix,
+    ]
+    out, err = _run_torchrun(cmd)
+
+    for rank in range(2):
+        path = f"{result_prefix}.rank{rank}.json"
+        if not os.path.exists(path):
+            raise AssertionError(
+                f"gloo runner produced no result for rank {rank}. stdout tail:\n{out[-2000:]}\n"
+                f"stderr tail:\n{err[-3000:]}"
+            )
+        with open(path) as f:
+            r = json.load(f)
+        assert r["world"] == 2
+        assert r["validate_ok"], f"rank {rank}: sp=world with all guards satisfied must validate"
+        assert r["ulysses_size"] == 2, f"rank {rank}: mesh ulysses_size={r['ulysses_size']}, not 2"
+        assert r["data_world_size"] == 1, f"rank {rank}: data_world_size={r['data_world_size']}, not world/ulysses=1"
+        assert r["divisibility_raised"], f"rank {rank}: sp=world+1 must raise on divisibility"

--- a/swift/dev/tests/feature/sft/test_e2e.py
+++ b/swift/dev/tests/feature/sft/test_e2e.py
@@ -1020,3 +1020,173 @@ def test_run_sft_hf_dp_loss_is_globally_token_weighted(tmp_path):
     assert rel < 0.02, (f'dp2 loss {got:.6f} is not the global token-weighted mean {ref:.6f} (rel={rel:.2e}, limit '
                         '2e-2): the two shapes trained on the same two samples, so this gap is an aggregation '
                         'convention difference, not noise')
+
+
+def _accel_device_count() -> int:
+    """Accelerator count, CUDA or NPU -- the cuda-only gates above all skip on an Ascend machine."""
+    if torch.cuda.is_available():
+        return torch.cuda.device_count()
+    try:
+        import torch_npu  # noqa: F401
+        return torch.npu.device_count() if torch.npu.is_available() else 0
+    except ImportError:
+        return 0
+
+
+def _flash_attn_available() -> bool:
+    """Flash attention per twinkle's SP gate (transformers' is_flash_attn_available, which counts
+    torch_npu/torch_xpu as flash-capable -- is_flash_attn_2_available alone would skip on Ascend)."""
+    try:
+        from transformers.modeling_flash_attention_utils import is_flash_attn_available
+        return is_flash_attn_available()
+    except Exception:
+        return False
+
+
+def _run_hf_sp_shape(shape, data_path, out_dir, result_prefix, padding_free, port_offset, nproc=None, sp_size=2):
+    """Launch the hf_sp runner for ONE shape; returns one result dict per rank. Sibling of
+    _run_hf_shape -- sp2 goes through torchrun (2 ranks, half a sequence each), single is a plain
+    process. nproc overrides the rank count (torchrun x4 + sp_size=2 is the hybrid dp+sp layout)."""
+    import sys
+
+    if nproc is None:
+        nproc = 2 if shape == 'sp2' else 1
+    runner = Runners.path('hf_sp')
+    cmd = [sys.executable]
+    if nproc > 1:
+        cmd += [
+            '-m', 'torch.distributed.run', f'--nproc_per_node={nproc}', f'--master_port={_master_port(port_offset)}'
+        ]
+    cmd += [runner, '--shape', shape, '--data', data_path, '--out', result_prefix, '--out_dir', out_dir]
+    if padding_free:
+        cmd += ['--padding_free']
+    if sp_size != 2:
+        cmd += ['--sp_size', str(sp_size)]
+    out, err = _run_torchrun(cmd)
+
+    results = []
+    for rank in range(nproc):
+        path = f'{result_prefix}.rank{rank}.json'
+        if not os.path.exists(path):
+            raise AssertionError(f'{shape} runner produced no result for rank {rank}. stdout tail:\n{out[-2000:]}\n'
+                                 f'stderr tail:\n{err[-3000:]}')
+        with open(path) as f:
+            results.append(json.load(f))
+    return results
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('padding_free', [False, True])
+def test_run_sft_hf_sp_matches_single(tmp_path, padding_free):
+    """sp=2 transformers SFT must report the SAME loss as a single-process run on the same batch.
+
+    Ulysses SP is a pure re-partition: both SP ranks receive identical samples (the loader slices by
+    data_world_size = world/ulysses) and each computes half of every sequence, then twinkle's
+    gather_loss_tensors reassembles the global token-weighted loss. So the sp2 loss must land on the
+    single-process loss within bf16 band, exactly like the dp2 aggregation test above.
+
+    padding_free=False runs the padded path (default sdpa kernel, portable); padding_free=True runs
+    the variable-length path, which twinkle's SP strategy gates on a flash attention kernel -- that
+    parametrization skips where flash-attn is unavailable.
+
+    Three assertion groups, mirroring the dp2 test:
+      - plumbing: mesh ulysses_size==2, data_world_size==1, sp_strategy constructed after training;
+      - cross-rank identity: both SP ranks report the same loss (the gather replicated it);
+      - value: sp2 loss ~= single-process loss (rel < 2e-2 band, same as dp2).
+    """
+    if _accel_device_count() < 2:
+        pytest.skip('needs >=2 accelerators')
+    if padding_free and not _flash_attn_available():
+        pytest.skip('padding_free + SP requires flash attention (flash_attn/torch_npu), not available')
+
+    data_path = str(tmp_path / 'toy_sft.jsonl')
+    _write_toy_dataset(data_path)
+    port_offset = 12 if padding_free else 11
+    tag = 'pf' if padding_free else 'pad'
+
+    sp2 = _run_hf_sp_shape('sp2', data_path, str(tmp_path / f'sp2_{tag}_out'), str(tmp_path / f'sp2_{tag}'),
+                           padding_free, port_offset)
+    single = _run_hf_sp_shape('single', data_path, str(tmp_path / f'single_{tag}_out'),
+                              str(tmp_path / f'single_{tag}'), padding_free, port_offset + 2)
+
+    print(f'\nHF sp (padding_free={padding_free}): sp2={[r["losses"] for r in sp2]} single={single[0]["losses"]}')
+    for r in sp2:
+        assert r['ulysses_size'] == 2, (
+            f'rank {r["rank"]}: mesh ulysses_size={r["ulysses_size"]}, not 2 -- the SP mesh did not '
+            'reach TransformersModel (build_hf_device_mesh / device_mesh kwarg broken)')
+        assert r['data_world_size'] == 1, (
+            f'rank {r["rank"]}: data_world_size={r["data_world_size"]}, not world/ulysses=1 -- the '
+            'loader would hand SP peers different samples')
+        assert r['enable_sp'], f'rank {r["rank"]}: model._enable_sp is False -- SP did not activate'
+        assert r['sp_strategy_present'], (
+            f'rank {r["rank"]}: sp_strategy never constructed -- the first-forward lazy init did not run')
+
+    assert sp2[0]['losses'] == sp2[1]['losses'], (
+        f'SP ranks disagree: rank0={sp2[0]["losses"]} rank1={sp2[1]["losses"]} -- gather_loss_tensors '
+        'did not replicate the loss across the SP group')
+
+    ref, got = single[0]['losses'][0], sp2[0]['losses'][0]
+    rel = abs(got - ref) / max(abs(ref), 1e-8)
+    assert rel < 0.02, (f'sp2 loss {got:.6f} != single-process loss {ref:.6f} (rel={rel:.2e}, limit 2e-2): SP is '
+                        'a pure re-partition over the same global batch, so this gap is a real split/gather '
+                        'bug, not noise')
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('padding_free', [False, True])
+def test_run_sft_hf_sp_hybrid_dp(tmp_path, padding_free):
+    """Hybrid layout: torchrun x4 with sp=2 -- world=4, ulysses=2, so data_world_size=2 and the two
+    SP groups train on DIFFERENT data slices (twinkle data_rank = dp_rank // ulysses_size: ranks
+    {0,1} -> data 0, ranks {2,3} -> data 1). Baseline: torchrun x2 with sp=1 (pure DP, world=2) --
+    with shuffle off the sampler hands data_rank d the same rows in both runs, so hybrid rank 2d
+    must report the baseline rank d loss (within bf16 band), and each SP pair must agree exactly.
+
+    Assertion groups:
+      - plumbing: ulysses_size==2, data_world_size==2, data_rank == rank//2, sp_strategy present;
+      - SP-pair identity: rank0==rank1 and rank2==rank3 losses (gather replicated within the group);
+      - value: hybrid rank0 ~= dp2 rank0, hybrid rank2 ~= dp2 rank1 (rel < 2e-2, same band as the
+        sp2-vs-single and dp2 aggregation tests).
+    """
+    if _accel_device_count() < 4:
+        pytest.skip('needs >=4 accelerators for the world=4 / sp=2 hybrid layout')
+    if padding_free and not _flash_attn_available():
+        pytest.skip('padding_free + SP requires flash attention (flash_attn/torch_npu), not available')
+
+    data_path = str(tmp_path / 'toy_sft.jsonl')
+    _write_toy_dataset(data_path)
+    port_offset = 14 if padding_free else 13
+    tag = 'pf' if padding_free else 'pad'
+
+    hybrid = _run_hf_sp_shape(
+        'sp2', data_path, str(tmp_path / f'hybrid_{tag}_out'), str(tmp_path / f'hybrid_{tag}'), padding_free,
+        port_offset, nproc=4)
+    dp2 = _run_hf_sp_shape(
+        'single', data_path, str(tmp_path / f'dp2_{tag}_out'), str(tmp_path / f'dp2_{tag}'), padding_free,
+        port_offset + 2, nproc=2)
+
+    print(f'\nHF sp hybrid (padding_free={padding_free}): '
+          f'hybrid={[r["losses"] for r in hybrid]} dp2={[r["losses"] for r in dp2]}')
+    for r in hybrid:
+        assert r['world_size'] == 4 and r['ulysses_size'] == 2, (
+            f'rank {r["rank"]}: world={r["world_size"]} ulysses={r["ulysses_size"]} -- expected the '
+            'world=4 / sp=2 hybrid mesh')
+        assert r['data_world_size'] == 2, (
+            f'rank {r["rank"]}: data_world_size={r["data_world_size"]}, not world/ulysses=2 -- the '
+            'loader layout did not switch to the hybrid mesh')
+        assert r['data_rank'] == r['rank'] // 2, (
+            f'rank {r["rank"]}: data_rank={r["data_rank"]}, expected rank//2={r["rank"] // 2} -- '
+            'data_rank = dp_rank // ulysses_size mapping broken; SP peers would see different samples')
+        assert r['enable_sp'] and r['sp_strategy_present'], (
+            f'rank {r["rank"]}: SP did not activate (enable_sp={r["enable_sp"]}, '
+            f'sp_strategy={r["sp_strategy_present"]})')
+
+    assert hybrid[0]['losses'] == hybrid[1]['losses'] and hybrid[2]['losses'] == hybrid[3]['losses'], (
+        f'SP pairs disagree: {[r["losses"] for r in hybrid]} -- gather_loss_tensors did not replicate '
+        'the loss within each SP group')
+
+    for h_rank, d_rank in ((0, 0), (2, 1)):
+        ref, got = dp2[d_rank]['losses'][0], hybrid[h_rank]['losses'][0]
+        rel = abs(got - ref) / max(abs(ref), 1e-8)
+        assert rel < 0.02, (
+            f'hybrid rank{h_rank} loss {got:.6f} != dp2 rank{d_rank} loss {ref:.6f} (rel={rel:.2e}, '
+            'limit 2e-2): same data slice, SP a pure re-partition -- a real gap is a split/gather bug')


### PR DESCRIPTION
## Summary

`TemplateConfig.sequence_parallel_size` existed on `dev-swift-v5` but had **no consumer** on the HF
transformers path: setting it to >1 silently trained with SP=1. This PR wires it end to end —
SFT + transformers backend + local (torchrun) mode — by feeding twinkle's built-in Ulysses SP the
one thing it needs: a `DeviceMesh` with `ulysses_size > 1`.

twinkle's `TransformersModel` already implements the full mechanism (mesh-driven activation, lazy
`SequenceParallelStrategy` init at first forward, sequence sharding hooks, loss gather across the SP
group). This PR is **wiring, not a new engine**: ~150 lines of glue plus validation and tests.

## Changes

- **`builders/model.py`** — new `build_hf_device_mesh()`: returns `None` for `sp<=1` or non-local
  mode (the deliberate no-mesh local path is preserved bit-for-bit), otherwise
  `DeviceMesh.from_sizes(world_size=W, dp_size=W, ulysses_size=sp)`. `build_model` /
  `_build_transformers_model` gain an optional `device_mesh` pass-through.
- **`builders/dataset.py`** — `build_dataset(..., device_mesh=None)`; `_twinkle_loader_layout` gains
  a first branch: `global_batch = per_device * mesh.data_world_size` and the mesh handed to the
  twinkle loader, so its DeviceMeshSampler slices by `data_rank = dp_rank // ulysses_size` and SP
  peers receive identical samples.
- **`recipe/assembly.py`** — new `plan_sp_mesh()` stage, called by `TrainAssembly.fit` right after
  `prepare()`; the mesh flows to `build_dataset(device_mesh=...)` and `build_model(device_mesh=...)`.
  Because all seven recipes share TrainAssembly, the wiring is recipe-agnostic (RLHF stays blocked
  by the validation gate below).
- **`config/validate.py`** — new `_check_hf_sequence_parallel`, six fail-fast gates (all raise,
  no silent downgrade):
  1. megatron backend (`sequence_parallel_size` is the HF Ulysses knob; Megatron's TP-SP is
     `DistributedConfig.sequence_parallel`, a different feature)
  2. any `rlhf_type` (dev's RLHF path has no mesh wiring; allowing grpo/dpo through today means
     silently training with SP=1 — exactly the failure mode validation exists to kill)
  3. `padding_free`/`packing` without a flash attention kernel (twinkle's SP strategy rejects the
     variable-length layout otherwise; we fail at validation with an actionable message instead of
     deep in the first forward)
  4. `padding_side != 'right'` (legacy asserts the same at collate time; dev refuses up front)
  5. FSDP (the FSDP × ulysses composition in twinkle is unvalidated)
  6. `world < 2` or `world % sp != 0`, read from `Platform.get_world_size()` — **not** `dist`:
     twinkle's local mode never calls `init_process_group`, so requiring dist here would reject
     every real SP run.

## Explicitly out of scope

- Megatron `DistributedConfig.sequence_parallel` (TP-SP) — untouched.
- RLHF / ray / FSDP × SP — blocked with actionable errors, not silently ignored.

## Test plan

- **Memory-benefit smoke** (manual, 1× Ascend 910B4 64 GB, Qwen3-0.6B LoRA, padding_free): at 16K max_length sp=1 OOMs while sp=2 fits — at the same
  per-card footprint as sp=1 at 8K. Double the sequence length at flat memory.

  | run                        | max_length | peak memory per rank | result |
  | -------------------------- | ---------- | -------------------- | ------ |
  | sp=1 (single process)      | 16384      | —                    | OOM    |
  | sp=2 (torchrun ×2)         | 16384      | 37234.2 MB           | OK     |
  | sp=1 (single process)      | 8192       | 37186.4 MB           | OK     |

- **End-to-end pass** (`feature/sft/test_e2e.py::test_run_sft_hf_sp_matches_single`,
  2× Ascend 910B4, Qwen3-0.6B LoRA, padding_free): torchrun ×2 sp=2 vs single-process sp=1
  on identical samples. Both SP ranks report the same loss, matching the single-process
  trajectory within the bf16 band — SP is a pure re-partition. 20-step loss curves
  (`local/run_sp_loss_curve.sh`):
<img width="956" height="662" alt="sp_loss_curve2" src="https://github.com/user-attachments/assets/d7bb9501-823b-43a5-82b9-590ced9582bf" />
