### PR TITLE
fix(model): rewrite seq_cls architectures to *ForSequenceClassification

### DIFF
--- a/swift/model/patcher.py
+++ b/swift/model/patcher.py
@@ -249,6 +249,29 @@ def transformers_seq_cls_forward(self, *args, origin_forward, padding_side=None,
     )
 
 
+def _seq_cls_architectures(arch_list):
+    """Rewrite architectures to the matching ``*ForSequenceClassification`` class.
+
+    Used by :func:`_patch_sequence_classification` so that the on-disk
+    ``config.json`` produced by ``PreTrainedModel.save_pretrained`` references
+    the seq_cls architecture (e.g. ``Qwen3VLForSequenceClassification``) instead
+    of the generation architecture that the model class is actually an instance
+    of. Without this, downstream vLLM deployment fails because the checkpoint
+    advertises ``Qwen3VLForConditionalGeneration`` while shipping a
+    ``score`` head and ``num_labels`` / ``problem_type`` fields — see #9704.
+    """
+    if not arch_list:
+        return arch_list
+    res = []
+    for arch in arch_list:
+        if arch.endswith('ForConditionalGeneration'):
+            arch = arch[:-len('ForConditionalGeneration')] + 'ForSequenceClassification'
+        elif arch.endswith('ForCausalLM'):
+            arch = arch[:-len('ForCausalLM')] + 'ForSequenceClassification'
+        res.append(arch)
+    return res
+
+
 def _patch_sequence_classification(model, model_meta):
     hidden_size = HfConfigFactory.get_config_attr(model.config, 'hidden_size')
     initializer_range = HfConfigFactory.get_config_attr(model.config, 'initializer_range')
@@ -273,6 +296,12 @@ def _patch_sequence_classification(model, model_meta):
         return transformers_seq_cls_forward(self, *args, origin_forward=origin_forward, **kwargs)
 
     lm_head_model.forward = MethodType(new_forward, lm_head_model)
+
+    # Align the on-disk `architectures` with the task. PreTrainedModel.save_pretrained
+    # writes `model.__class__.__name__` for `architectures`, but the seq_cls patcher
+    # monkey-patches a `score` head onto the generation class without swapping it,
+    # so the saved checkpoint would otherwise advertise the wrong class (see #9704).
+    model.config.architectures = _seq_cls_architectures(getattr(model.config, 'architectures', None))
 
 
 @contextmanager

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -48,6 +48,53 @@ class TestMolmo2Registration(unittest.TestCase):
         self.assertIn(TemplateType.molmo2, TEMPLATE_MAPPING)
 
 
+class TestSeqClsArchitecturesRewrite(unittest.TestCase):
+    """Regression coverage for #9704.
+
+    The seq_cls / reranker patcher monkey-patches a ``score`` head onto the
+    generation model class without swapping the class itself, so
+    ``PreTrainedModel.save_pretrained`` would otherwise write the wrong
+    ``architectures`` to ``config.json`` and break downstream vLLM deployment.
+    """
+
+    def test_seq_cls_architectures_rewrite(self):
+        from swift.model.patcher import _seq_cls_architectures
+
+        # Generation -> SequenceClassification
+        self.assertEqual(_seq_cls_architectures(['Qwen2ForCausalLM']), ['Qwen2ForSequenceClassification'])
+        self.assertEqual(
+            _seq_cls_architectures(['Qwen3VLForConditionalGeneration']),
+            ['Qwen3VLForSequenceClassification'])
+        self.assertEqual(_seq_cls_architectures(['LlamaForCausalLM']), ['LlamaForSequenceClassification'])
+        self.assertEqual(
+            _seq_cls_architectures(['Qwen2VLForConditionalGeneration']),
+            ['Qwen2VLForSequenceClassification'])
+
+        # Already-seq_cls class is preserved (idempotent).
+        self.assertEqual(
+            _seq_cls_architectures(['BertForSequenceClassification']),
+            ['BertForSequenceClassification'])
+
+        # Multi-arch list: only the matching suffix is rewritten.
+        self.assertEqual(
+            _seq_cls_architectures(['FooForCausalLM', 'BarForConditionalGeneration']),
+            ['FooForSequenceClassification', 'BarForSequenceClassification'])
+
+        # Empty / None inputs are returned unchanged.
+        self.assertEqual(_seq_cls_architectures([]), [])
+        self.assertIsNone(_seq_cls_architectures(None))
+
+    def test_seq_cls_architectures_unknown_suffix(self):
+        """Unknown suffixes (custom architectures) are left alone — we don't
+        silently invent a class name that may not exist in transformers."""
+        from swift.model.patcher import _seq_cls_architectures
+
+        self.assertEqual(_seq_cls_architectures(['MyCustomLMHeadModel']), ['MyCustomLMHeadModel'])
+        self.assertEqual(
+            _seq_cls_architectures(['MyCustomLMHeadModel', 'LlamaForCausalLM']),
+            ['MyCustomLMHeadModel', 'LlamaForSequenceClassification'])
+
+
 if __name__ == '__main__':
     test_qwen2()
     # test_modelscope_hub()


### PR DESCRIPTION
## Summary

Fixes #9704.

When fine-tuning a VLM or LM with `task_type=seq_cls` (or `reranker`), the seq_cls patcher in `_patch_sequence_classification` monkey-patches a `score` head onto the **generation** model class without swapping the class itself. `transformers.PreTrainedModel.save_pretrained` then writes `model.__class__.__name__` into `config.json['architectures']`, so the on-disk checkpoint advertises e.g. `Qwen3VLForConditionalGeneration` while shipping a `score` head, `num_labels`, `id2label`, and `problem_type=multi_label_classification`.

Downstream vLLM deployment reads `architectures` to pick the model class, finds the generation class, and rejects the checkpoint — even though `PtEngine` inference works correctly. The reporter in #9704 confirmed all four of `score.weight: [20, 4096]`, `id2label`, `label2id`, and `problem_type` are written correctly; only `architectures` is wrong.

## Fix

Rewrite `model.config.architectures` in-place to the matching `*ForSequenceClassification` class at the same place the `score` head is attached, so every save path (trainer `_save_model`, `save_checkpoint`, export-quant, peft merge-and-unload) writes the right value automatically. The existing `vllm_engine.py:347-353` `arch_mapping` override is left in place — it remains useful for users who already have bad checkpoints on disk.

The new helper `_seq_cls_architectures` handles the suffix rewrite idempotently and leaves unknown / custom architectures untouched (so we never advertise a class that does not exist in transformers).

## Mapping coverage

| Source class | Rewritten to |
| --- | --- |
| `*ForConditionalGeneration` (Qwen3-VL, Qwen2-VL, InternVL, LLaVA, GLM4V, …) | `*ForSequenceClassification` |
| `*ForCausalLM` (Qwen2, Llama, Mistral, Mixtral, Yi, …) | `*ForSequenceClassification` |
| Already `*ForSequenceClassification` | unchanged (idempotent) |
| Custom / unknown suffix | unchanged |
| `[]` / `None` | unchanged |

## Tests

Added `TestSeqClsArchitecturesRewrite` in `tests/general/test_model.py` covering:
- generation → seq_cls rewrite for both `ForCausalLM` and `ForConditionalGeneration` suffixes
- idempotence on already-seq_cls classes
- multi-arch lists
- empty / `None` inputs
- unknown / custom architectures left untouched

Local sanity checks (10/10 PASS) and syntax checks on both files PASS. Full ms-swift unit / smoke CI is needed to validate end-to-end on real seq_cls training runs; that will run on the upstream CI after this PR is opened.

## Out of scope

- Megatron seq_cls `architectures` rewrite — Megatron has its own seq_cls head code path (`swift/megatron/utils/convert_utils.py:283`, `swift/megatron/model/utils.py:47`); happy to follow up with a separate PR if maintainers want it.
- `vllm_engine.py:347-353` `arch_mapping` cleanup — kept for backward-compat with existing bad checkpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)