### PR TITLE
fix(embedding): exclude positives when resampling InfoNCE hard negatives

### DIFF
--- a/swift/loss/embedding.py
+++ b/swift/loss/embedding.py
@@ -104,7 +104,7 @@ def _parse_multi_negative_sentences(sentences, labels, hard_negatives=None):
                 split_part = split_part[:hard_negatives + 2]
             elif negatives < hard_negatives:
                 selected = np.random.choice(list(range(negatives)), size=hard_negatives - negatives, replace=True)
-                selected += 1  # skip positive
+                selected += 2  # skip anchor and positive
                 split_part = torch.cat((split_part, split_part[selected]), dim=0)
         split_tensors.append(split_part)
     return split_tensors

--- a/tests/train/test_embedding_loss.py
+++ b/tests/train/test_embedding_loss.py
@@ -1,0 +1,76 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import numpy as np
+import pytest
+import torch
+import torch.nn.functional as F
+
+from swift.loss.embedding import InfonceLoss, _parse_multi_negative_sentences
+
+
+@pytest.mark.parametrize('negative_count', [1, 2])
+def test_infonce_padding_samples_only_negatives(monkeypatch, negative_count):
+    # Cycle through the complete sampling population, including its last entry.
+    monkeypatch.setattr(np.random, 'choice', lambda a, size, replace: np.resize(a, size))
+    groups = torch.arange(2 * (negative_count + 2) * 3).reshape(2, negative_count + 2, 3)
+    labels = torch.tensor([1] + [0] * negative_count).repeat(2)
+
+    actual = _parse_multi_negative_sentences(groups.flatten(0, 1), labels, hard_negatives=3 * negative_count)
+
+    for original, padded in zip(groups, actual):
+        expected = torch.cat((original, original[2:].repeat(2, 1)))
+        torch.testing.assert_close(padded, expected)
+
+
+@pytest.mark.parametrize('hard_negatives', [None, 2, 3])
+def test_infonce_without_padding_preserves_samples(hard_negatives):
+    groups = torch.arange(30).reshape(2, 5, 3)
+    labels = torch.tensor([1, 0, 0, 0, 1, 0, 0, 0])
+
+    actual = _parse_multi_negative_sentences(groups.flatten(0, 1), labels, hard_negatives)
+
+    end = 5 if hard_negatives is None else hard_negatives + 2
+    for original, parsed in zip(groups, actual):
+        torch.testing.assert_close(parsed, original[:end])
+
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+@pytest.mark.parametrize('use_batch', [False, True])
+def test_infonce_padded_loss_and_gradients(monkeypatch, device, dtype, use_batch):
+    if device == 'cuda' and not torch.cuda.is_available():
+        pytest.skip('CUDA is not available')
+    for name, value in {
+            'RANK': '0',
+            'WORLD_SIZE': '1',
+            'INFONCE_TEMPERATURE': '0.5',
+            'INFONCE_HARD_NEGATIVES': '3',
+            'INFONCE_USE_BATCH': str(use_batch),
+            'INFONCE_MASK_FAKE_NEGATIVE': 'False',
+            'INFONCE_INCLUDE_QQ': 'False',
+            'INFONCE_INCLUDE_DD': 'False',
+    }.items():
+        monkeypatch.setenv(name, value)
+    embeddings = F.normalize(
+        torch.tensor([[1., 0., 0.], [1., 1., 0.], [-1., 0., 1.], [0., 1., 0.], [0., 1., 1.], [1., -1., 0.]],
+                     device=device,
+                     dtype=dtype),
+        dim=-1).requires_grad_()
+    labels = torch.tensor([1, 0, 1, 0], device=device)
+    actual = InfonceLoss(None, None)({'last_hidden_state': embeddings}, labels)
+
+    # Each example has one negative, so padding must repeat that negative twice.
+    reference = embeddings.detach().clone().requires_grad_()
+    queries = reference[[0, 3]]
+    documents = reference[[1, 2, 2, 2, 4, 5, 5, 5]]
+    if use_batch:
+        logits = queries @ documents.T / 0.5
+        targets = torch.tensor([0, 4], device=device)
+    else:
+        logits = (queries[:, None] * documents.reshape(2, 4, 3)).sum(-1) / 0.5
+        targets = torch.zeros(2, dtype=torch.long, device=device)
+    expected = F.cross_entropy(logits, targets)
+
+    torch.testing.assert_close(actual, expected)
+    actual_grad, = torch.autograd.grad(actual, embeddings)
+    expected_grad, = torch.autograd.grad(expected, reference)
+    torch.testing.assert_close(actual_grad, expected_grad)


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

When `INFONCE_HARD_NEGATIVES` exceeds an example's supplied negative count,
`_parse_multi_negative_sentences` resamples entries to fill the missing slots.
The group layout is `[anchor, positive, negatives...]`, but the sampled indices
are offset by one. This includes the positive in the sampling population and
excludes the last supplied negative.

For example, one supplied negative with `INFONCE_HARD_NEGATIVES=3` currently
produces `[anchor, positive, negative, positive, positive]`. Training continues,
but the positive is also treated as a negative in the InfoNCE denominator.

Offset by two to skip both the anchor and positive. Add regression tests for
the resampling population, unchanged non-padding/truncation behavior, and the
public `InfonceLoss` loss and embedding gradients against explicitly repeated
negatives, with in-batch negatives enabled and disabled.

Related to #5600, originally reported by @galabala and automatically closed for
inactivity. The issue remains reproducible on main at `3f80ae012b80`.

Minimal reproduction:

```python
import torch
from swift.loss.embedding import _parse_multi_negative_sentences

sentences = torch.tensor([[0.], [1.], [2.]])  # anchor, positive, negative
labels = torch.tensor([1., 0.])
result = _parse_multi_negative_sentences(sentences, labels, hard_negatives=3)[0]
print(result.flatten().tolist())
# Before: [0., 1., 2., 1., 1.]
# After:  [0., 1., 2., 2., 2.]
```

## Experiment results

`python -m pytest tests/train/test_embedding_loss.py -q`

- Before the fix, with CUDA hidden: 6 failed, 3 passed, 4 skipped.
- After the fix, with CUDA hidden: 9 passed, 4 skipped.
- After the fix, with one CUDA GPU visible: 13 passed, including CUDA loss
  and gradient comparisons in float32 and float64.
- Flake8 7.3.0, isort 8.0.1, YAPF 0.43.0, and `git diff --check` pass for the
  changed files.

These are focused correctness tests. Full model training, distributed training,
the complete upstream CI suite, and downstream retrieval benchmarks were not run.

The pytest regression is run explicitly with the command above; the existing
`tests/run.py` unittest runner does not automatically collect these functions.
