### PR TITLE
fix(megatron): gather InfoNCE labels across data-parallel ranks

### DIFF
--- a/swift/loss/embedding.py
+++ b/swift/loss/embedding.py
@@ -142,18 +142,21 @@ class InfonceLoss(BaseLoss):
             elif self.is_megatron:
                 from megatron.core import mpu
                 dp_group = mpu.get_data_parallel_group()
-                shapes = [sentences.new_empty((2, ), dtype=torch.long) for _ in range(world_size)]
+                shapes = [sentences.new_empty((3, ), dtype=torch.long) for _ in range(world_size)]
                 dist.all_gather(
                     shapes,
-                    sentences.new_tensor(sentences.shape, dtype=torch.long),
+                    sentences.new_tensor((*sentences.shape, labels.numel()), dtype=torch.long),
                     group=dp_group,
                 )
-                all_sentences = [sentences.new_empty(shape.tolist()) for shape in shapes]
+                all_sentences = [sentences.new_empty(shape[:2].tolist()) for shape in shapes]
                 dist.all_gather(
                     all_sentences,
                     sentences,
                     group=dp_group,
                 )
+                all_labels = [labels.new_empty((shape[2].item(), )) for shape in shapes]
+                dist.all_gather(all_labels, labels, group=dp_group)
+                labels = torch.cat(all_labels)
             else:
                 # gather all the sentences and labels across the gpus when calculate loss across all batches of all gpus
                 all_sentences = gather_object(sentences.unsqueeze(0))

--- a/tests/megatron/test_infonce_loss.py
+++ b/tests/megatron/test_infonce_loss.py
@@ -1,0 +1,79 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Compare distributed InfoNCE with the full-batch contrastive objective.
+
+Run from the repository root with at least two GPUs::
+
+    PYTHONPATH=. torchrun --standalone --nproc_per_node=4 -m pytest tests/megatron/test_infonce_loss.py -q
+"""
+import os
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+from swift.loss.embedding import InfonceLoss
+
+
+@pytest.fixture(scope='module')
+def distributed():
+    world_size = int(os.environ.get('WORLD_SIZE', '1'))
+    if not torch.cuda.is_available() or world_size < 2:
+        pytest.skip('requires torchrun with at least two GPUs')
+    torch.cuda.set_device(int(os.environ['LOCAL_RANK']))
+    dist.init_process_group('nccl')
+    yield world_size
+    dist.destroy_process_group()
+
+
+@pytest.fixture(scope='module', params=[1, 2])
+def parallel_groups(request, distributed):
+    world_size = distributed
+    tp_size = request.param
+    if not torch.cuda.is_available() or world_size < 2 * tp_size or world_size % tp_size:
+        pytest.skip('requires torchrun with at least two data-parallel ranks')
+    from megatron.core import mpu
+
+    mpu.initialize_model_parallel(tensor_model_parallel_size=tp_size)
+    try:
+        yield mpu.get_data_parallel_rank(), mpu.get_data_parallel_world_size()
+    finally:
+        dist.barrier()
+        mpu.destroy_model_parallel()
+
+
+@pytest.mark.parametrize('uneven_negatives', [False, True])
+def test_infonce_data_parallel_loss_and_gradients(parallel_groups, monkeypatch, uneven_negatives):
+    rank, world_size = parallel_groups
+    for name, value in {
+            'INFONCE_TEMPERATURE': '0.5',
+            'INFONCE_USE_BATCH': 'True',
+            'INFONCE_MASK_FAKE_NEGATIVE': 'False',
+            'INFONCE_INCLUDE_QQ': 'False',
+            'INFONCE_INCLUDE_DD': 'False',
+    }.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.delenv('INFONCE_HARD_NEGATIVES', raising=False)
+
+    groups = []
+    for dp_rank in range(world_size):
+        negatives = dp_rank + 1 if uneven_negatives else 1
+        generator = torch.Generator().manual_seed(42 + dp_rank)
+        groups.append(F.normalize(torch.randn(negatives + 2, 5, generator=generator), dim=-1).cuda())
+    local = groups[rank].detach().clone().requires_grad_()
+    labels = torch.tensor([1] + [0] * (len(local) - 2), device=local.device)
+    loss_func = InfonceLoss(None, None)
+    loss_func.is_megatron = True
+    actual = loss_func({'last_hidden_state': local}, labels)
+
+    # All queries classify their positive among every rank's documents.
+    reference = [group.detach().clone().requires_grad_() for group in groups]
+    queries = torch.stack([group[0] for group in reference])
+    documents = torch.cat([group[1:] for group in reference])
+    targets = torch.tensor([sum(len(group) - 1 for group in reference[:i]) for i in range(world_size)],
+                           device=local.device)
+    expected = F.cross_entropy(queries @ documents.T / 0.5, targets)
+
+    torch.testing.assert_close(actual, expected)
+    actual_grad, = torch.autograd.grad(actual, local)
+    expected_grad, = torch.autograd.grad(expected, reference[rank])
+    torch.testing.assert_close(actual_grad, expected_grad)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Megatron InfoNCE gathers embeddings across the data-parallel group but keeps rank-local labels. The loss consequently splits the global embeddings using an incomplete set of sample boundaries, omitting or misassigning other ranks' examples.

Gather label lengths with the existing shape exchange, gather the labels in the same DP group, and concatenate them in rank order before splitting the embeddings. This supports different numbers of negatives on different ranks without changing the loss formula or other training backends.

## Experiment results

Validation: four H800 GPUs with real Megatron process groups and NCCL, covering DP4 and TP2×DP2 with equal and unequal negative counts. All four regression cases fail on the original code and pass after the fix on each worker; repaired losses and local embedding gradients match an independent full-batch cross-entropy reference. Changed-file flake8, isort, YAPF and diff checks pass. These are distributed loss tests; a full pretrained-model training run was not performed.

The missing label gather was also identified in the unmerged refactor #9179. This PR isolates that correctness fix and adds distributed regression coverage.

```bash
PYTHONPATH=. OMP_NUM_THREADS=1 torchrun --standalone --nproc_per_node=4 \
  -m pytest tests/megatron/test_infonce_loss.py -q
```

Validated against `main` at `3f80ae012b80`. This is an explicitly launched
CUDA/NCCL regression; the existing unittest CI runner does not launch it.
