### PR TITLE
fix(embedding): select UEmbed dense token with vLLM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,8 @@ if __name__ == '__main__':
         install_requires=install_requires,
         extras_require=extra_requires,
         entry_points={
-            'console_scripts': ['swift=swift.cli.main:cli_main', 'megatron=swift.cli._megatron.main:cli_main']
+            'console_scripts': ['swift=swift.cli.main:cli_main', 'megatron=swift.cli._megatron.main:cli_main'],
+            'vllm.general_plugins': ['swift_uembed=swift.infer_engine.patch:register_uembed_model'],
         },
         dependency_links=deps_link,
         zip_safe=False)

--- a/swift/infer_engine/patch.py
+++ b/swift/infer_engine/patch.py
@@ -4,6 +4,13 @@ from functools import wraps
 from transformers import AutoConfig, AutoTokenizer, PretrainedConfig, PreTrainedTokenizerBase
 
 
+def register_uembed_model():
+    from vllm import ModelRegistry
+    if 'UEmbedForConditionalGeneration' not in ModelRegistry.get_supported_archs():
+        ModelRegistry.register_model('UEmbedForConditionalGeneration',
+                                     'swift.infer_engine.vllm_uembed:UEmbedForConditionalGeneration')
+
+
 @contextmanager
 def patch_auto_tokenizer(tokenizer: PreTrainedTokenizerBase):
     _old_from_pretrained = AutoTokenizer.from_pretrained

--- a/swift/infer_engine/vllm_engine.py
+++ b/swift/infer_engine/vllm_engine.py
@@ -221,6 +221,9 @@ class VllmEngine(InferEngine):
                 ignore_patterns=getattr(template.model_meta, 'ignore_patterns', None),
                 hub_token=hub_token)
         super().__init__(template)
+        self._uembed_num_eos_tokens = (
+            getattr(template, 'num_eos_tokens', 0)
+            if self.task_type == 'embedding' and self.model_meta.model_type == 'qwen3_5_emb' else None)
         if max_model_len is not None:
             self.max_model_len = max_model_len
             logger.info(f'Setting max_model_len: {max_model_len}')
@@ -348,6 +351,13 @@ class VllmEngine(InferEngine):
         arch_mapping = {'deepseek_vl2': ['DeepseekVLV2ForCausalLM'], 'chatglm4v': ['GLM4VForCausalLM']}
         if self.model_meta.model_type in arch_mapping:
             hf_overrides['architectures'] = arch_mapping[self.model_meta.model_type]
+        if self._uembed_num_eos_tokens is not None:
+            from vllm.config import PoolerConfig
+
+            from .patch import register_uembed_model
+            register_uembed_model()
+            hf_overrides['architectures'] = ['UEmbedForConditionalGeneration']
+            engine_kwargs['pooler_config'] = PoolerConfig(task='token_embed', pooling_type='ALL')
         hf_overrides.update(self._get_hf_config_overrides())
         if hf_overrides:
             engine_kwargs['hf_overrides'] = hf_overrides
@@ -497,11 +507,15 @@ class VllmEngine(InferEngine):
                 pooling_kwargs = {}
                 if has_task_arg:
                     pooling_kwargs['task'] = task_mapping[self.task_type]
+                if self._uembed_num_eos_tokens is not None:
+                    pooling_kwargs.update(task='token_embed', use_activation=False)
                 if self.task_type in ('reranker', 'generative_reranker') and \
                         has_activation_arg and self.reranker_use_activation:
                     pooling_kwargs['activation'] = True
                 pooling_params = PoolingParams(**pooling_kwargs)
-                return self.engine.encode(llm_inputs, pooling_params, request_id)
+                if self.use_async_engine:
+                    return self.engine.encode(llm_inputs, pooling_params, request_id, **kwargs)
+                return self.engine.add_request(request_id, llm_inputs, pooling_params, **kwargs)
             elif self.use_async_engine:
                 return self.engine.generate(llm_inputs, generation_config, request_id, **kwargs)
             else:
@@ -696,7 +710,11 @@ class VllmEngine(InferEngine):
 
     def _create_embedding_response(self, result, generation_config, request_id) -> EmbeddingResponse:
         assert result is not None
-        embedding = result.outputs.data.cpu().numpy().tolist()
+        embedding = result.outputs.data
+        if self._uembed_num_eos_tokens is not None:
+            embedding = torch.nn.functional.normalize(
+                embedding[-(self._uembed_num_eos_tokens + 1)].float(), p=2, dim=-1)
+        embedding = embedding.cpu().tolist()
         usage_info = self._get_usage_info(len(result.prompt_token_ids), 0)
         return EmbeddingResponse(
             model=self.model_name, data=[EmbeddingResponseData(embedding=embedding)], usage=usage_info, id=request_id)
@@ -709,6 +727,8 @@ class VllmEngine(InferEngine):
         request_id,
     ) -> ChatCompletionResponse:
         assert result is not None
+        if self.task_type == 'embedding':
+            return self._create_embedding_response(result, None, request_id)
         num_generated_tokens = sum(len(output.token_ids) for output in result.outputs)
         usage_info = self._get_usage_info(len(result.prompt_token_ids), num_generated_tokens)
         choices = []

--- a/swift/infer_engine/vllm_uembed.py
+++ b/swift/infer_engine/vllm_uembed.py
@@ -1,0 +1,11 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+from vllm.model_executor.models.qwen3_5 import Qwen3_5ForConditionalGeneration
+from vllm.model_executor.models.utils import WeightsMapper
+
+
+class UEmbedForConditionalGeneration(Qwen3_5ForConditionalGeneration):
+    # Accept both the original AutoModel checkpoint and exported CausalLM weights.
+    hf_to_vllm_mapper = WeightsMapper(orig_to_new_prefix={
+        'language_model.': 'model.language_model.',
+        'visual.': 'model.visual.',
+    }) | Qwen3_5ForConditionalGeneration.hf_to_vllm_mapper


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

UEmbed's vLLM embedding path uses sequence pooling (`embed` / LAST), returning the final appended sparse EOS state instead of the dense state at `-(num_eos_tokens + 1)`. Its original checkpoint also stores `language_model.*` / `visual.*` keys without the CausalLM `model.` prefix.

Configure UEmbed for `token_embed` / ALL with activation disabled, then select the configured dense position and L2-normalize the single-vector response. A small, lazily registered Qwen3.5 subclass accepts both original and already-prefixed checkpoints without rewriting weight files. Registration uses `vllm.general_plugins` so it also works in spawned workers. Editable installations need reinstalling to pick up the new entry point.

The synchronous embedding path also needs `add_request` and embedding response conversion; it previously called the asynchronous `encode` API and attempted to format a chat completion. Other embedding models retain their sequence-pooling configuration and returned vectors.

Reference: [official UEmbed vLLM example](https://github.com/Alibaba-NLP/UEmbed/blob/main/examples/vllm_example.py). The existing 16-token template suffix is preserved.

## Experiment results

- Local regression checks (test scripts retained outside this PR): **9 passed, 2 skipped**. Covers offsets 0/3/16, unequal sequence lengths, synchronous/asynchronous responses, unchanged non-UEmbed vectors, and loading original/exported keys through the real vLLM pooling adapter and weight loader with a tiny CPU parameter tree. The two full-checkpoint GPU alignment checks were skipped; cosine similarity > 0.999 remains unverified.
- Additional checks passed: architecture resolution and key mapping in a real spawned process; the public `infer()` path for UEmbed and ordinary embedding models in both modes with a simulated backend, including reversed completion order.
- `uvx pre-commit run --from-ref upstream/main --to-ref HEAD`: all applicable hooks passed. `git diff --check` passed.
