### PR TITLE
[megatron] Fix contiguous CP token reconstruction

### DIFF
--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -1120,7 +1120,8 @@ class BaseMegatronTrainer(ABC):
 
     def get_last_tokens(self, output_tensor, packed_seq_params=None, attention_mask=None):
         if self.args.context_parallel_size > 1:
-            output_tensor = reconstruct_tensor_cp(output_tensor, packed_seq_params, dim=1)
+            output_tensor = reconstruct_tensor_cp(
+                output_tensor, packed_seq_params, dim=1, cp_partition_mode=self.args.cp_partition_mode)
         if packed_seq_params is None:
             # Compatible with attention_mask_2d
             if attention_mask.dim() > 2:

--- a/swift/megatron/trainers/grpo_trainer.py
+++ b/swift/megatron/trainers/grpo_trainer.py
@@ -909,10 +909,11 @@ class MegatronGRPOTrainer(MegatronRolloutMixin, MegatronRLHFTrainer):
                 num_samples = packed_seq_params.seq_lens.shape[0] if args.padding_free else micro_batch_size
                 cp_size = args.context_parallel_size
                 per_token_logps_packed = reconstruct_tensor_cp(cp_size, per_token_logps_packed, packed_seq_params,
-                                                               num_samples)
+                                                               num_samples, args.cp_partition_mode)
                 if per_token_entropy_packed is not None:
                     per_token_entropy_packed = reconstruct_tensor_cp(cp_size, per_token_entropy_packed,
-                                                                     packed_seq_params, num_samples)
+                                                                     packed_seq_params, num_samples,
+                                                                     args.cp_partition_mode)
 
             if args.padding_free:
                 # Pad from rmpad [1, total_tokens] to batch format [batch_size, max_seq_len]

--- a/swift/megatron/trainers/rlhf_mixin.py
+++ b/swift/megatron/trainers/rlhf_mixin.py
@@ -79,7 +79,7 @@ class MegatronRLHFTrainer(BaseMegatronTrainer):
         if per_token:
             if args.context_parallel_size > 1:
                 per_token_logps = reconstruct_tensor_cp(args.context_parallel_size, per_token_logps, packed_seq_params,
-                                                        num_samples)
+                                                        num_samples, args.cp_partition_mode)
             return per_token_logps
 
         if args.padding_free:

--- a/swift/megatron/trainers/utils.py
+++ b/swift/megatron/trainers/utils.py
@@ -465,11 +465,11 @@ def compute_per_token_logps_fn(model, args, data_iterator, temperature=1.0, no_g
 
     if args.context_parallel_size > 1:
         per_token_logps = reconstruct_tensor_cp(args.context_parallel_size, per_token_logps, packed_seq_params,
-                                                num_samples)
+                                                num_samples, args.cp_partition_mode)
     return per_token_logps, routing_topk_idx
 
 
-def reconstruct_tensor_cp(cp_size, tensor, packed_seq_params, num_samples):
+def reconstruct_tensor_cp(cp_size, tensor, packed_seq_params, num_samples, cp_partition_mode='zigzag'):
     """In CP mode, all_gather and reconstruct full tensor sequences."""
     cp_rank = mpu.get_context_parallel_rank()
 
@@ -477,6 +477,13 @@ def reconstruct_tensor_cp(cp_size, tensor, packed_seq_params, num_samples):
     output_list = [torch.empty_like(tensor) for _ in range(cp_size)]
     torch.distributed.all_gather(output_list, tensor.contiguous(), group=mpu.get_context_parallel_group())
     output_list[cp_rank] = tensor
+
+    if cp_partition_mode == 'contiguous':
+        # Contiguous CP splits the entire flattened packed sequence across ranks.
+        output_full = torch.cat(output_list, dim=1)
+        if packed_seq_params is not None:
+            output_full = output_full[:, :packed_seq_params.cu_seqlens_q[num_samples].item()]
+        return output_full
 
     if packed_seq_params is not None:
         cu_seqlens_full = packed_seq_params.cu_seqlens_q

--- a/swift/megatron/utils/utils.py
+++ b/swift/megatron/utils/utils.py
@@ -261,8 +261,8 @@ def get_packed_seq_params(args, position_ids: torch.Tensor) -> PackedSeqParams:
     return packed
 
 
-def reconstruct_tensor_cp(tensor, packed_seq_params, dim=1) -> torch.Tensor:
-    """In CP mode, all-gather and undo the load-balanced (zigzag) chunking
+def reconstruct_tensor_cp(tensor, packed_seq_params, dim=1, cp_partition_mode='zigzag') -> torch.Tensor:
+    """In CP mode, all-gather and undo the configured partitioning
     produced by ``split_cp_inputs``, restoring the full sequence in original
     token order along ``dim``.
 
@@ -271,6 +271,7 @@ def reconstruct_tensor_cp(tensor, packed_seq_params, dim=1) -> torch.Tensor:
         packed_seq_params: ``PackedSeqParams`` for THD inputs, or ``None`` for
             regular ``[B, S, ...]`` inputs.
         dim: Sequence dimension index of ``tensor`` (default: 1).
+        cp_partition_mode: CP partition layout, either ``zigzag`` or ``contiguous``.
 
     Returns:
         torch.Tensor: Full-sequence tensor with the same shape as ``tensor``
@@ -289,6 +290,8 @@ def reconstruct_tensor_cp(tensor, packed_seq_params, dim=1) -> torch.Tensor:
     torch.distributed.all_gather(output_list, tensor.contiguous(), group=cp_group)
     output_list[cp_rank] = tensor
     gathered = torch.cat(output_list, dim=dim)
+    if cp_partition_mode == 'contiguous':
+        return gathered
 
     # `_undo_attention_load_balancing` assumes sequence dim is 0; transpose if needed.
     if dim != 0:


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

With `context_parallel_size > 1` and `cp_partition_mode='contiguous'`, reconstruction still applied zigzag ordering. For CP=2, contiguous shards `[0,1,2,3]` and `[4,5,6,7]` therefore produced `[0,1,4,5,6,7,2,3]`, silently misaligning per-token logprobs and entropy with completion masks and rollout data.

Pass the configured partition mode through the shared logprob, RLHF, GRPO, and last-token reconstruction paths. Contiguous reconstruction concatenates shards in rank order; the per-token packed path crops trailing padding at `cu_seqlens_q[num_samples]`. This matches mcore-bridge's contiguous slicing of the entire flattened packed tensor. The hidden-state helper also skips zigzag reordering for contiguous shards.
