### PR TITLE
[DPO] Fix padding-free LD completion weighting

### DIFF
--- a/swift/rlhf_trainers/dpo_trainer.py
+++ b/swift/rlhf_trainers/dpo_trainer.py
@@ -137,13 +137,13 @@ class DPOTrainer(RLHFTrainerMixin, SwiftMixin, DataLoaderMixin, HFDPOTrainer):
             completion_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
             completion_token_counts = self._packed_sequence_sum(loss_mask.flatten().long(), completion_lengths)
             if self.args.ld_alpha is not None and not is_ref_model:
-                chosen_lengths = completion_lengths[:num_examples]
-                rejected_lengths = completion_lengths[num_examples:]
+                chosen_lengths = completion_token_counts[:num_examples]
+                rejected_lengths = completion_token_counts[num_examples:]
                 public_lengths = torch.min(chosen_lengths, rejected_lengths)  # l_p in the paper
                 public_lengths = torch.cat((public_lengths, public_lengths))
-                front_lengths = torch.min(completion_lengths, public_lengths)
-                split_lengths = torch.stack((front_lengths, completion_lengths - front_lengths), dim=-1).flatten()
-                split_logps = self._packed_sequence_sum(per_token_logps.flatten(), split_lengths).view(-1, 2)
+                split_lengths = torch.stack((public_lengths, completion_token_counts - public_lengths),
+                                            dim=-1).flatten()
+                split_logps = self._packed_sequence_sum(per_token_logps[loss_mask], split_lengths).view(-1, 2)
                 all_logps = split_logps[:, 0] + self.args.ld_alpha * split_logps[:, 1]
             else:
                 all_logps = self._packed_sequence_sum(per_token_logps.flatten(), completion_lengths)

--- a/tests/test_align/test_rlhf_loss.py
+++ b/tests/test_align/test_rlhf_loss.py
@@ -129,6 +129,8 @@ class _LogitsToKeepModel:
         logits = self.logits
         if isinstance(logits_to_keep, torch.Tensor):
             logits = logits[:, logits_to_keep]
+        elif isinstance(logits_to_keep, int):
+            logits = logits[:, -logits_to_keep:]
         return SimpleNamespace(logits=logits)
 
 
@@ -143,12 +145,38 @@ class _PaddingFreeDPOStub:
         self.loss_type = ['sigmoid']
 
     def get_use_logits_to_keep(self, default_value=True):
-        return True
+        return self.args.use_logits_to_keep
 
     prepare_logits_to_keep = SwiftMixin.prepare_logits_to_keep
     get_cu_seqlens = SwiftMixin.get_cu_seqlens
     get_per_token_logps = RLHFTrainerMixin.get_per_token_logps
     _packed_sequence_sum = staticmethod(RLHFTrainerMixin._packed_sequence_sum)
+
+
+@pytest.mark.parametrize('use_logits_to_keep', [False, True])
+def test_padding_free_dpo_matches_padded(use_logits_to_keep):
+    rows = [torch.tensor([-100, -100, 0, 0, 0, 0]), torch.tensor([-100, -100, 0, 0])]
+    scores, grads = [], []
+    for padding_free in [False, True]:
+        labels = (
+            torch.cat(rows).unsqueeze(0) if padding_free else torch.nn.utils.rnn.pad_sequence(
+                rows, batch_first=True, padding_value=-100))
+        logits = torch.zeros(*labels.shape, 2, requires_grad=True)
+        trainer = _PaddingFreeDPOStub(ld_alpha=0.0)
+        trainer.template.padding_free = padding_free
+        trainer.args.use_logits_to_keep = use_logits_to_keep
+        batch = {'labels': labels}
+        if padding_free:
+            batch['position_ids'] = torch.cat([torch.arange(len(row)) for row in rows]).unsqueeze(0)
+        with patch.dict(os.environ, {'SWIFT_SINGLE_DEVICE_MODE': '1'}):
+            output = DPOTrainer.concatenated_forward(trainer, _LogitsToKeepModel(logits), batch)
+        score = torch.cat((output['chosen_logps'], output['rejected_logps']))
+        score.sum().backward()
+        scores.append(score)
+        grads.append(
+            logits.grad[0] if padding_free else torch.cat([logits.grad[i, :len(row)] for i, row in enumerate(rows)]))
+    torch.testing.assert_close(scores[0], scores[1])
+    torch.testing.assert_close(grads[0], grads[1])
 
 
 class TestPackedRLHFReduction(unittest.TestCase):
@@ -195,8 +223,9 @@ class TestPackedRLHFReduction(unittest.TestCase):
                                                                 expected_batch['logits_to_keep'])
                 expected_lengths = expected_cu_seqlens[1:] - expected_cu_seqlens[:-1]
                 self.assertEqual(expected_lengths.cpu().tolist(), [3, 2, 4, 1])
+                expected_counts = _reference_segment_sum(expected_loss_mask.flatten(), expected_lengths)
                 expected_all_logps = _reference_dpo_sum(
-                    expected_logps.flatten(), expected_lengths, num_examples=2, ld_alpha=0.5)
+                    expected_logps[expected_loss_mask], expected_counts, num_examples=2, ld_alpha=0.5)
                 num_tokens = int(expected_cu_seqlens[2].item())
                 expected_nll_loss = -expected_logps[:, :num_tokens][expected_loss_mask[:, :num_tokens]].mean()
                 expected_chosen_logits = expected_mean_logits[:, :num_tokens][expected_loss_mask[:, :num_tokens]].mean()


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Padding-free LD-DPO used physical packed segment lengths to determine the shared completion prefix. Prompt/masked positions could therefore receive a place in that prefix and change the weights of valid response tokens. With four chosen and two rejected response tokens, `logits_to_keep` produces segment lengths `[4, 3]`; at `ld_alpha=0`, the chosen score includes three response tokens instead of two. The mismatch also occurs without `logits_to_keep`.

Use the existing effective completion token counts for the shared length and filter logprobs by `loss_mask` before reducing the prefix and suffix. This aligns padding-free LD weighting with the padded path.

Correct the existing integration test's reference inputs to use effective counts and valid logprobs. Add one parameterized regression comparing padded/padding-free scores and gradients with `logits_to_keep` enabled and disabled.

## Experiment results

- Both new regression variants and the corrected integration test fail against the original `concatenated_forward` implementation.
- After the fix, `pytest tests/test_align/test_rlhf_loss.py -q`: **12 passed, 32 subtests passed** on CPU.
- All applicable pre-commit hooks on the two changed files and `git diff --check` passed.

Full model training and GPU validation were not run.
