### PR TITLE
embedding model bug fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,8 @@ if __name__ == '__main__':
         install_requires=install_requires,
         extras_require=extra_requires,
         entry_points={
-            'console_scripts': ['swift=swift.cli.main:cli_main', 'megatron=swift.cli._megatron.main:cli_main']
+            'console_scripts': ['swift=swift.cli.main:cli_main', 'megatron=swift.cli._megatron.main:cli_main'],
+            'vllm.general_plugins': ['swift_uembed=swift.model.models.qwen:register_uembed_model'],
         },
         dependency_links=deps_link,
         zip_safe=False)

--- a/swift/infer_engine/vllm_engine.py
+++ b/swift/infer_engine/vllm_engine.py
@@ -485,8 +485,10 @@ class VllmEngine(InferEngine):
             if mm_processor_kwargs:
                 llm_inputs['mm_processor_kwargs'] = mm_processor_kwargs
 
-            has_task_arg = 'task' in inspect.signature(PoolingParams).parameters
-            has_activation_arg = 'activation' in inspect.signature(PoolingParams).parameters
+            pooling_params_signature = inspect.signature(PoolingParams)
+            has_task_arg = 'task' in pooling_params_signature.parameters
+            has_activation_arg = 'activation' in pooling_params_signature.parameters
+            has_use_activation_arg = 'use_activation' in pooling_params_signature.parameters
             task_mapping = {
                 'embedding': 'embed',
                 'seq_cls': 'classify',
@@ -497,9 +499,11 @@ class VllmEngine(InferEngine):
                 pooling_kwargs = {}
                 if has_task_arg:
                     pooling_kwargs['task'] = task_mapping[self.task_type]
-                if self.task_type in ('reranker', 'generative_reranker') and \
-                        has_activation_arg and self.reranker_use_activation:
-                    pooling_kwargs['activation'] = True
+                if self.task_type in ('reranker', 'generative_reranker') and self.reranker_use_activation:
+                    if has_use_activation_arg:
+                        pooling_kwargs['use_activation'] = True
+                    elif has_activation_arg:
+                        pooling_kwargs['activation'] = True
                 pooling_kwargs = self.template.prepare_pooling_params(pooling_kwargs)
                 pooling_params = PoolingParams(**pooling_kwargs)
                 if self.use_async_engine:

--- a/swift/infer_engine/vllm_engine.py
+++ b/swift/infer_engine/vllm_engine.py
@@ -500,8 +500,11 @@ class VllmEngine(InferEngine):
                 if self.task_type in ('reranker', 'generative_reranker') and \
                         has_activation_arg and self.reranker_use_activation:
                     pooling_kwargs['activation'] = True
+                pooling_kwargs = self.template.prepare_pooling_params(pooling_kwargs)
                 pooling_params = PoolingParams(**pooling_kwargs)
-                return self.engine.encode(llm_inputs, pooling_params, request_id)
+                if self.use_async_engine:
+                    return self.engine.encode(llm_inputs, pooling_params, request_id, **kwargs)
+                return self.engine.add_request(request_id, llm_inputs, pooling_params, **kwargs)
             elif self.use_async_engine:
                 return self.engine.generate(llm_inputs, generation_config, request_id, **kwargs)
             else:
@@ -696,7 +699,7 @@ class VllmEngine(InferEngine):
 
     def _create_embedding_response(self, result, generation_config, request_id) -> EmbeddingResponse:
         assert result is not None
-        embedding = result.outputs.data.cpu().numpy().tolist()
+        embedding = self.template.extract_embedding(result)
         usage_info = self._get_usage_info(len(result.prompt_token_ids), 0)
         return EmbeddingResponse(
             model=self.model_name, data=[EmbeddingResponseData(embedding=embedding)], usage=usage_info, id=request_id)
@@ -709,6 +712,8 @@ class VllmEngine(InferEngine):
         request_id,
     ) -> ChatCompletionResponse:
         assert result is not None
+        if self.task_type == 'embedding':
+            return self._create_embedding_response(result, None, request_id)
         num_generated_tokens = sum(len(output.token_ids) for output in result.outputs)
         usage_info = self._get_usage_info(len(result.prompt_token_ids), num_generated_tokens)
         choices = []

--- a/swift/model/models/qwen.py
+++ b/swift/model/models/qwen.py
@@ -1823,6 +1823,25 @@ class Qwen3_5EmbLoader(Qwen3_5Loader):
         return model
 
 
+def register_uembed_model():
+    from vllm import ModelRegistry
+
+    arch = 'UEmbedForConditionalGeneration'
+    if arch in ModelRegistry.get_supported_archs():
+        return
+
+    from vllm.model_executor.models.qwen3_5 import Qwen3_5ForConditionalGeneration
+    from vllm.model_executor.models.utils import WeightsMapper
+
+    class UEmbedForConditionalGeneration(Qwen3_5ForConditionalGeneration):
+        hf_to_vllm_mapper = WeightsMapper(orig_to_new_prefix={
+            'language_model.': 'model.language_model.',
+            'visual.': 'model.visual.',
+        }) | Qwen3_5ForConditionalGeneration.hf_to_vllm_mapper
+
+    ModelRegistry.register_model(arch, UEmbedForConditionalGeneration)
+
+
 register_model(
     ModelMeta(
         MLLMModelType.qwen3_5_emb, [

--- a/swift/template/base.py
+++ b/swift/template/base.py
@@ -412,6 +412,12 @@ class Template(ProcessorMixin):
     def prepare_engine_kwargs(self) -> Dict[str, Any]:
         return {}
 
+    def prepare_pooling_params(self, pooling_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        return pooling_kwargs
+
+    def extract_embedding(self, result) -> Any:
+        return result.outputs.data.cpu().numpy().tolist()
+
     def _get_max_pixels(self, inputs=None):
         max_pixels = None if inputs is None else inputs.chat_template_kwargs.get('max_pixels')
         if max_pixels is None:

--- a/swift/template/templates/qwen.py
+++ b/swift/template/templates/qwen.py
@@ -760,6 +760,30 @@ class Qwen3_5EmbTemplate(Qwen3_5Template):
             if last_msg['role'] != 'assistant':
                 inputs.messages.append({'role': 'assistant', 'content': ''})
 
+    def prepare_engine_kwargs(self) -> Dict[str, Any]:
+        if self.mode == 'vllm' and self.template_meta.template_type == MLLMTemplateType.qwen3_5_emb:
+            from vllm.config import PoolerConfig
+            return {
+                'hf_overrides': {
+                    'architectures': ['UEmbedForConditionalGeneration'],
+                },
+                'pooler_config': PoolerConfig(task='token_embed', pooling_type='ALL'),
+            }
+        return {}
+
+    def prepare_pooling_params(self, pooling_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        if self.mode == 'vllm' and self.template_meta.template_type == MLLMTemplateType.qwen3_5_emb:
+            pooling_kwargs.update(task='token_embed', use_activation=False)
+        return pooling_kwargs
+
+    def extract_embedding(self, result) -> Any:
+        if self.template_meta.template_type == MLLMTemplateType.qwen3_5_emb:
+            data = result.outputs.data
+            num_eos = self.num_eos_tokens
+            embedding = torch.nn.functional.normalize(data[-(num_eos + 1)].float(), p=2, dim=-1)
+            return embedding.cpu().tolist()
+        return super().extract_embedding(result)
+
 
 register_template(
     QwenTemplateMeta(


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
Bug 1: UEmbed-2B model fails inference on vLLM

(1) The weight architecture of UEmbed-2B is `Qwen3_5ForConditionalGeneration`; loading it directly using vLLM's built-in Qwen3.5 model class fails because UEmbed's weight prefixes (`language_model.`, `visual.`) do not match the prefixes expected by vLLM (`model.language_model.`, `model.visual.`). A custom model class, `UEmbedForConditionalGeneration`, must be registered with a weight prefix mapping.
(2) Additionally, UEmbed's embedding extraction method differs from standard embedding models: instead of pooling the entire sequence, it takes the vector of the token at the `-(num_eos_tokens + 1)` position and applies L2 normalization. The `num_eos_tokens` value is read from the model's `sparse_info.json`. This requires custom pooling parameters and result extraction logic.

This change registers the custom model class via vLLM's `general_plugins` entry point and injects UEmbed-specific configuration and extraction logic through template extension points (`prepare_engine_kwargs`, `prepare_pooling_params`, `extract_embedding`). All logic is encapsulated within the model's own code to avoid polluting public classes.

Bug 2: All embedding/reranker/seq_cls tasks crash when using the synchronous engine (`use_async_engine=False`)

The synchronous engine (`LLMEngine`) lacks a method present in the asynchronous engine (`AsyncLLMEngine`). Running any pooling task with the synchronous engine triggers an `AttributeError`.

This change calls either `encode` (asynchronous) or `add_request` (synchronous) based on the `use_async_engine` flag and passes `**kwargs` (such as LoRA adapter parameters).

Bug 3: Embedding task results are incorrectly decoded when using the synchronous engine

`_create_chat_completion_response` does not check if `task_type == 'embedding'`; consequently, the embedding vector is treated as token IDs and passed to `decode_generate_ids`, resulting in nonsensical output or errors. An early return path calling `_create_embedding_response` has been added to handle this case.