### PR TITLE
fix(loss): compensate InfoNCE gradients for DDP averaging

### DIFF
--- a/swift/loss/embedding.py
+++ b/swift/loss/embedding.py
@@ -133,6 +133,7 @@ class InfonceLoss(BaseLoss):
             rank, _, world_size, _ = get_dist_setting()
         # repeat of anchor(1)+positive(1)+negatives(n)
         sentences = outputs['last_hidden_state']
+        gradient_scale = 1
 
         if world_size > 1 and use_batch:
             if getattr(sequence_parallel, 'dp_group', None) is not None:
@@ -163,6 +164,8 @@ class InfonceLoss(BaseLoss):
                 labels = gather_object(labels)
             # override the gathered one
             all_sentences[rank] = sentences
+            if not self.is_megatron:
+                gradient_scale = len(all_sentences)
             for idx in range(len(all_sentences)):
                 if idx == rank:
                     continue
@@ -321,4 +324,7 @@ class InfonceLoss(BaseLoss):
                     # next positive is neg+1
                     length += tensor.size(0) - 1
                 loss /= len(split_tensors)
+        if gradient_scale > 1:
+            # DDP averages the local contributions to the global loss graph; preserve the reported loss.
+            loss = loss.detach() + gradient_scale * (loss - loss.detach())
         return loss


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

With `INFONCE_USE_BATCH=True`, each HF/DDP rank computes the same global mean InfoNCE loss after gathering embeddings, but retains the computation graph only for its own embeddings. DDP then averages these local gradient contributions, making the parameter gradient smaller than the full-batch reference by the data-parallel size even though the loss values match.

Compensate the backward gradient by the number of gathered DP embedding shards while preserving the reported loss through a detached value. The scale remains one without cross-rank batch negatives. Using the gathered shard count avoids including SP/TP ranks in the compensation. This change is limited to the HF path; Megatron behavior is unchanged.

Only six production-code lines are added in `swift/loss/embedding.py`.

## Experiment results

Real two-process CPU DDP with a linear encoder and the production InfoNCE implementation:

| Measurement | Before | After |
| --- | --- | --- |
| Distributed loss | 0.8853394985 | 0.8853394985 |
| Full-batch reference loss | 0.8853394985 | 0.8853394985 |
| DDP / reference gradient ratio | 0.5 | 1.0 |

All 21 local comparison cases passed: seven configurations across world/DP sizes 2/2, 4/2 and 2/1. Coverage includes equal and variable negative counts, QQ/DD with fake-negative masking, disabled batch negatives, and gradient accumulation. The subgroup cases validate DP group selection without running a sequence-parallel model. Maximum gradient error against the reference was below `6.71e-8`.

All applicable pre-commit checks passed. Validation scripts remain outside the repository.
