### PR TITLE
fix(trainer): normalize partial gradient accumulation windows

### DIFF
--- a/swift/trainers/reranker_trainer.py
+++ b/swift/trainers/reranker_trainer.py
@@ -35,7 +35,9 @@ class RerankerTrainer(Trainer):
                 loss = outputs.loss
 
             if num_items_in_batch is not None and self.model_accepts_loss_kwargs:
-                loss = loss / self.args.gradient_accumulation_steps
+                accumulation_steps = getattr(self, 'current_gradient_accumulation_steps',
+                                             self.args.gradient_accumulation_steps)
+                loss = loss / accumulation_steps
 
             if labels is not None:
                 self._compute_acc(outputs, labels)

--- a/swift/trainers/trainer.py
+++ b/swift/trainers/trainer.py
@@ -68,5 +68,7 @@ class Trainer(SwiftMixin, DataLoaderMixin, HfTrainer):
         if inputs.get('labels') is not None:
             self._compute_acc(outputs, inputs['labels'])
         if num_items_in_batch is not None and self.model_accepts_loss_kwargs:
-            loss = loss / self.args.gradient_accumulation_steps
+            accumulation_steps = getattr(self, 'current_gradient_accumulation_steps',
+                                         self.args.gradient_accumulation_steps)
+            loss = loss / accumulation_steps
         return (loss, outputs) if return_outputs else loss

--- a/tests/train/test_trainer_partial_accumulation.py
+++ b/tests/train/test_trainer_partial_accumulation.py
@@ -1,0 +1,68 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import collections
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import Trainer as HfTrainer
+from transformers import TrainingArguments
+from transformers.modeling_outputs import SequenceClassifierOutput
+from types import SimpleNamespace
+
+from swift.loss.reranker import PointwiseRerankerLoss
+from swift.metrics import MeanMetric
+from swift.trainers import RerankerTrainer, Trainer
+
+
+class TinyRegressor(nn.Module):
+
+    def __init__(self, accepts_loss_kwargs=True):
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor([[0.5]]))
+        self.config = SimpleNamespace(problem_type='regression')
+        self.accepts_loss_kwargs = accepts_loss_kwargs
+
+    def forward(self, input_ids, labels=None, **kwargs):
+        logits = input_ids @ self.weight
+        loss = None if labels is None else F.mse_loss(logits[:, 0], labels)
+        return SequenceClassifierOutput(loss=loss, logits=logits)
+
+
+@pytest.mark.parametrize('kind', ['trainer', 'trainer_no_loss_kwargs', 'reranker'])
+@pytest.mark.parametrize('window_size', [1, 2, 4])
+def test_partial_accumulation_matches_full_batch(tmp_path, kind, window_size):
+    model = TinyRegressor(accepts_loss_kwargs=kind != 'trainer_no_loss_kwargs')
+    trainer_cls = RerankerTrainer if kind == 'reranker' else Trainer
+    # Initialize the real HF training/backward machinery without model downloads
+    # or Swift's unrelated tokenizer, checkpoint and callback setup.
+    trainer = trainer_cls.__new__(trainer_cls)
+    args = TrainingArguments(
+        output_dir=str(tmp_path), use_cpu=True, gradient_accumulation_steps=4, report_to=[], disable_tqdm=True)
+    HfTrainer.__init__(trainer, model=model, args=args)
+    trainer.task_type = 'reranker' if kind == 'reranker' else 'seq_cls'
+    trainer.problem_type = 'regression'
+    trainer.template = SimpleNamespace(sequence_parallel_size=1)
+    trainer.custom_metrics = {'train': collections.defaultdict(lambda: MeanMetric(nan_value=None, device='cpu'))}
+    args.loss_type = 'pointwise_reranker' if kind == 'reranker' else None
+    if kind == 'reranker':
+        trainer.compute_loss_func = PointwiseRerankerLoss(args, trainer)
+    # SwiftMixin sets Accelerate's num_steps=1; Trainer owns loss normalization.
+    trainer.accelerator.gradient_state.plugin_kwargs['num_steps'] = 1
+    # HF's epoch loop sets this from the number of prefetched micro-batches.
+    trainer.current_gradient_accumulation_steps = window_size
+    batches = [{
+        'input_ids': torch.tensor([[float(i + 1)], [float(i + 2)]]),
+        'labels': torch.tensor([0., 1.])
+    } for i in range(window_size)]
+    num_items = sum(batch['labels'].numel() for batch in batches)
+    accumulated_loss = sum(trainer.training_step(model, dict(batch), num_items_in_batch=num_items) for batch in batches)
+
+    reference = TinyRegressor()
+    inputs = torch.cat([batch['input_ids'] for batch in batches])
+    labels = torch.cat([batch['labels'] for batch in batches])
+    output = reference(input_ids=inputs, labels=labels)
+    reference_loss = F.binary_cross_entropy_with_logits(output.logits[:,
+                                                                      0], labels) if kind == 'reranker' else output.loss
+    reference_loss.backward()
+    torch.testing.assert_close(model.weight.grad, reference.weight.grad)
+    torch.testing.assert_close(accumulated_loss, reference_loss.detach())


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

When the last accumulation window of an epoch has fewer micro-batches than
`gradient_accumulation_steps`, `Trainer.compute_loss` and
`RerankerTrainer.compute_loss` still divide their mean loss by the configured
window size. For models accepting loss kwargs, HF's `training_step` does not
divide that loss again. With a configured window of four and an actual window
of two, this produces half the full-batch reference gradient.

Use HF Trainer's `current_gradient_accumulation_steps` for that division, with
the configured value as a fallback for versions/callers without this attribute.
Full windows and the existing normalization branch conditions are unchanged.

The regression runs the actual HF `training_step`/Accelerate backward path
with Swift's Trainer and RerankerTrainer loss implementations, then compares
parameter gradients and accumulated loss with an independent concatenated-batch
reference. It uses a tiny CPU model, no model downloads. The test initializes
HF's training machinery directly and supplies Swift's required loss context;
it does not run the complete Swift initialization or epoch loop.

## Experiment results

```bash
CUDA_VISIBLE_DEVICES='' PYTHONPATH=. python -m pytest -q \
  tests/train/test_trainer_partial_accumulation.py
```

- Original code: 4 failed, 5 passed. Failures are partial windows of one/two
  micro-batches in Trainer and RerankerTrainer.
- Fixed code: 9 passed with Transformers 5.3.0 / Accelerate 1.14.0;
  9 passed with Transformers 4.57.1 / Accelerate 1.11.0.
- Controls cover full windows and Trainer's model-without-loss-kwargs path.
- Changed-file pre-commit, flake8/isort/YAPF and `git diff --check` pass.

These are CPU backward tests with equal-size micro-batches, not distributed,
AMP, full fine-tuning or variable-batch weighting tests. The new pytest module
must be invoked explicitly; the repository's existing unittest CI does not
automatically collect it.

Related: #9510 refactors the training loop but retains the configured-size
loss division in these implementations; this fix is independent of that work.
