### PR TITLE
fix(megatron): reduce reranker evaluation metrics across DP ranks

### DIFF
--- a/swift/megatron/trainers/reranker_trainer.py
+++ b/swift/megatron/trainers/reranker_trainer.py
@@ -2,6 +2,7 @@
 import torch.nn
 from collections import namedtuple
 from functools import partial
+from megatron.core import mpu
 
 from swift.loss import loss_map
 from swift.metrics import eval_metrics_map
@@ -17,7 +18,7 @@ class MegatronRerankerTrainer(BaseMegatronTrainer):
     def __init__(self, args, template):
         super().__init__(args, template)
         self._loss_func = loss_map[args.loss_type](args, self)
-        self.eval_metrics = eval_metrics_map['reranker'](args, self)
+        self.eval_metrics = eval_metrics_map['reranker'](args, self, group=mpu.get_data_parallel_group())
 
     @staticmethod
     def _get_listwise_reranker_preds(logits, labels):

--- a/swift/metrics/reranker.py
+++ b/swift/metrics/reranker.py
@@ -5,16 +5,17 @@ from typing import Dict
 
 from swift.utils import get_logger
 from .base import EvalMetrics
-from .utils import Metric
+from .utils import MeanMetric, Metric
 
 logger = get_logger()
 
 
 class RerankerMetrics(EvalMetrics, Metric):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, group=None, **kwargs):
         super().__init__(*args, **kwargs)
         Metric.__init__(self)
+        self.group = group
         self.add_state('logits', default_factory=list)
         self.add_state('labels', default_factory=list)
 
@@ -23,20 +24,32 @@ class RerankerMetrics(EvalMetrics, Metric):
         self.labels.append(labels.cpu().numpy())
 
     def compute(self):
-        predictions = np.concatenate(self.logits)
-        labels = np.concatenate(self.labels)
-        return self._calculate_metrics(predictions, labels)
+        predictions = np.concatenate(self.logits) if self.logits else np.array([])
+        labels = np.concatenate(self.labels) if self.labels else np.array([])
+        if self.group is None:
+            return self._calculate_metrics(predictions, labels)
+        result = {}
+        for name, scores in self._calculate_query_metrics(predictions, labels).items():
+            # Weight by valid queries, not by ranks or document counts.
+            metric = MeanMetric(group=self.group)
+            metric.update(scores)
+            result[name] = metric.compute()['value']
+        return result
 
     def compute_metrics(self, eval_prediction: EvalPrediction) -> Dict[str, float]:
         return self._calculate_metrics(eval_prediction.predictions, eval_prediction.label_ids)
 
     def _calculate_metrics(self, logits, labels):
+        scores = self._calculate_query_metrics(logits, labels)
+        return {name: np.mean(values) if values else 0.0 for name, values in scores.items()}
+
+    def _calculate_query_metrics(self, logits, labels):
         """
         Calculate MRR and NDCG metrics for reranker.
 
         This function first groups the data based on query boundaries (identified by
         positive samples), then calculates MRR and NDCG for each group independently,
-        and finally returns the mean across all queries.
+        and returns the scores of all valid queries.
 
         Data format:
         - Each query group starts with a positive sample (label=1) followed by negatives (label=0)
@@ -47,7 +60,7 @@ class RerankerMetrics(EvalMetrics, Metric):
             labels: Binary labels (1 for positive, 0 for negative) [batch_size]
 
         Returns:
-            dict: Dictionary containing MRR and NDCG metrics averaged across all queries
+            dict: Dictionary containing per-query MRR and NDCG scores
         """
         # Convert to numpy if needed
         if hasattr(logits, 'numpy'):
@@ -62,7 +75,7 @@ class RerankerMetrics(EvalMetrics, Metric):
         positive_indices = np.where(labels == 1)[0]
 
         if len(positive_indices) == 0:
-            return {'mrr': 0.0, 'ndcg': 0.0}
+            return {'mrr': [], 'ndcg': []}
 
         # Step 2: Split into groups (queries)
         query_groups = []
@@ -132,15 +145,11 @@ class RerankerMetrics(EvalMetrics, Metric):
             ndcg = calculate_ndcg_single_query(relevance_scores, ranking)
             ndcg_scores.append(ndcg)
 
-        # Step 4: Calculate mean metrics across all valid queries
+        # Step 4: Return scores for averaging locally or across data-parallel ranks.
         if len(mrr_scores) == 0:
             logger.warning('No valid queries found for metric calculation')
-            return {'mrr': 0.0, 'ndcg': 0.0}
-
-        mean_mrr = np.mean(mrr_scores)
-        mean_ndcg = np.mean(ndcg_scores)
 
         return {
-            'mrr': mean_mrr,
-            'ndcg': mean_ndcg,
+            'mrr': mrr_scores,
+            'ndcg': ndcg_scores,
         }

--- a/tests/utils/test_reranker_metrics.py
+++ b/tests/utils/test_reranker_metrics.py
@@ -1,0 +1,106 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import math
+import os
+import tempfile
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import unittest
+from datetime import timedelta
+from transformers import EvalPrediction
+from unittest import mock
+
+from swift.metrics.reranker import RerankerMetrics
+
+
+def _update_ranks(metric, ranks):
+    for rank in ranks:
+        metric.update(torch.tensor([0.] + [1.] * (rank - 1)), torch.tensor([1] + [0] * (rank - 1)))
+
+
+def _distributed_worker(rank, rendezvous):
+    dist.init_process_group('gloo', init_method=rendezvous, rank=rank, world_size=4, timeout=timedelta(seconds=60))
+    try:
+        groups = [dist.new_group(ranks, timeout=timedelta(seconds=60)) for ranks in ([0, 1], [2, 3])]
+        singletons = [dist.new_group([r], timeout=timedelta(seconds=60)) for r in range(4)]
+        dist.barrier()
+        group = groups[rank // 2]
+        check = unittest.TestCase()
+        with mock.patch('swift.metrics.utils.get_current_device', return_value='cpu'):
+            metric = RerankerMetrics(None, None, group=group)
+            # Rank 0 has one valid query; rank 1 has two. Singleton queries are skipped.
+            query_ranks = [[2], [3, 3], [2], [4]][rank]
+            _update_ranks(metric, query_ranks)
+            _update_ranks(metric, [1])
+            expected_ranks = [2, 3, 3] if rank < 2 else [2, 4]
+            with mock.patch.object(dist, 'all_reduce', wraps=dist.all_reduce) as reduce:
+                result = metric.compute()
+            check.assertEqual(reduce.call_count, 2)
+            for call in reduce.call_args_list:
+                check.assertEqual(call.args[0].numel(), 2)
+                check.assertIs(call.kwargs['group'], group)
+            check.assertAlmostEqual(result['mrr'], sum(1 / r for r in expected_ranks) / len(expected_ranks), places=6)
+            check.assertAlmostEqual(
+                result['ndcg'], sum(1 / math.log2(r + 1) for r in expected_ranks) / len(expected_ranks), places=6)
+            # Computing again must not re-reduce already global state.
+            check.assertEqual(metric.compute(), result)
+
+            for empty_update in (False, True):
+                metric.reset()
+                if rank % 2:
+                    _update_ranks(metric, [2])
+                elif empty_update:
+                    _update_ranks(metric, [1])
+                result = metric.compute()
+                check.assertAlmostEqual(result['mrr'], 0.5)
+                check.assertAlmostEqual(result['ndcg'], 1 / math.log2(3), places=6)
+
+            metric.reset()
+            check.assertEqual(metric.compute(), {'mrr': 0., 'ndcg': 0.})
+            metric = RerankerMetrics(None, None, group=singletons[rank])
+            _update_ranks(metric, [rank + 2])
+            check.assertAlmostEqual(metric.compute()['mrr'], 1 / (rank + 2), places=6)
+
+            # The default/HF path must remain local even with a process group initialized.
+            local = RerankerMetrics(None, None)
+            _update_ranks(local, [2])
+            with mock.patch.object(dist, 'all_reduce', side_effect=AssertionError('unexpected collective')):
+                check.assertAlmostEqual(local.compute()['mrr'], 0.5)
+        # Keep the default group alive until all subgroups have finished.
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+class TestRerankerMetrics(unittest.TestCase):
+
+    def test_local_metrics_and_reset(self):
+        metric = RerankerMetrics(None, None)
+        _update_ranks(metric, [2, 3, 1])
+        result = metric.compute()
+        self.assertAlmostEqual(result['mrr'], (0.5 + 1 / 3) / 2)
+        self.assertAlmostEqual(result['ndcg'], (1 / math.log2(3) + 0.5) / 2)
+        metric.reset()
+        self.assertEqual(metric.compute(), {'mrr': 0., 'ndcg': 0.})
+
+    def test_query_split_across_updates(self):
+        metric = RerankerMetrics(None, None)
+        metric.update(torch.tensor([0.]), torch.tensor([1]))
+        metric.update(torch.tensor([1., 2.]), torch.tensor([0, 0]))
+        self.assertAlmostEqual(metric.compute()['mrr'], 1 / 3)
+
+    def test_hf_compute_metrics_stays_local(self):
+        metric = RerankerMetrics(None, None)
+        prediction = EvalPrediction(predictions=torch.tensor([0., 1.]), label_ids=torch.tensor([1, 0]))
+        with mock.patch.object(dist, 'all_reduce', side_effect=AssertionError('unexpected collective')):
+            self.assertAlmostEqual(metric.compute_metrics(prediction)['mrr'], 0.5)
+
+    @unittest.skipUnless(dist.is_available() and dist.is_gloo_available(), 'Gloo is required')
+    def test_data_parallel_groups(self):
+        with tempfile.TemporaryDirectory() as directory:
+            rendezvous = 'file://' + os.path.join(directory, 'rendezvous')
+            mp.spawn(_distributed_worker, args=(rendezvous, ), nprocs=4, join=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Megatron reranker validation computes MRR/NDCG from each data-parallel rank's local shard, so checkpoint selection can use a shard-dependent metric. Average the existing per-query scores across the DP group with the existing MeanMetric sum/count reduction. Weight only valid queries, including when some ranks have no valid queries.

Keep local/HF metric behavior and query-ranking calculations unchanged. Communicate two scalars per metric at evaluation completion; do not gather predictions or alter embedding/InfoNCE evaluation.

Validation: CPU unit tests and four-process Gloo tests covering unequal query counts, independent subgroups, empty/invalid shards, repeated compute/reset, DP=1 and the local/HF path. 300 comparisons match the upstream local implementation exactly, including tied logits and singleton queries. Pre-commit checks pass. Full Megatron/NCCL training was not run.
