### PR TITLE
fix(loss): preserve gradients for skipped listwise reranker batches

### DIFF
--- a/swift/loss/reranker.py
+++ b/swift/loss/reranker.py
@@ -58,7 +58,7 @@ class ListwiseRerankerLoss(BaseLoss):
 
         if len(positive_indices) == 0:
             # No positive samples in this batch, return zero loss
-            return torch.tensor(0.0, device=logits.device, requires_grad=True)
+            return logits[:0].sum()
 
         # Ensure positive_indices is 1D
         if positive_indices.dim() == 0:
@@ -103,7 +103,8 @@ class ListwiseRerankerLoss(BaseLoss):
             num_groups += 1
 
         if num_groups == 0:
-            return torch.tensor(0.0, device=logits.device, requires_grad=True)
+            # Keep skipped batches in the autograd graph without reading their scores.
+            return logits[:0].sum()
 
         # Return average loss across all groups
         return total_loss / num_groups

--- a/tests/utils/test_reranker_loss.py
+++ b/tests/utils/test_reranker_loss.py
@@ -1,0 +1,104 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import os
+import tempfile
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+import unittest
+from datetime import timedelta
+from torch.nn.parallel import DistributedDataParallel
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from swift.loss.reranker import ListwiseRerankerLoss
+
+
+def _ddp_worker(rank, rendezvous):
+    dist.init_process_group('gloo', init_method=rendezvous, rank=rank, world_size=2, timeout=timedelta(seconds=20))
+    try:
+        torch.manual_seed(42)
+        model = DistributedDataParallel(torch.nn.Linear(2, 1, bias=False))
+        loss_func = ListwiseRerankerLoss(None, None)
+        inputs = torch.tensor([[1., 2.], [3., 1.], [-1., 0.]])
+        with patch.dict(os.environ, {'LISTWISE_RERANKER_MIN_GROUP_SIZE': '3', 'LISTWISE_RERANKER_TEMPERATURE': '1.0'}):
+            # Include all-skipped, retained and uneven steps in the same DDP model.
+            for counts in [(2, 2), (3, 3), (2, 3)]:
+                model.zero_grad(set_to_none=True)
+                count = counts[rank]
+                logits = model(inputs[:count])
+                loss = loss_func(SimpleNamespace(logits=logits), torch.tensor([1] + [0] * (count - 1)))
+                loss.backward()
+                if max(counts) == 2:
+                    torch.testing.assert_close(model.module.weight.grad, torch.zeros_like(model.module.weight))
+                    continue
+                expected = model.module.weight.detach().clone().requires_grad_()
+                scores = F.linear(inputs, expected).squeeze(-1)
+                reference_loss = F.cross_entropy(scores.unsqueeze(0), torch.tensor([0]))
+                reference_loss.backward()
+                reference_grad = expected.grad * (sum(c == 3 for c in counts) / 2)
+                torch.testing.assert_close(model.module.weight.grad, reference_grad)
+            # Flush accumulated gradients even when the final local microbatch is skipped.
+            for first_counts in [(2, 3), (3, 2)]:
+                model.zero_grad(set_to_none=True)
+                with model.no_sync():
+                    count = first_counts[rank]
+                    logits = model(inputs[:count])
+                    loss = loss_func(SimpleNamespace(logits=logits), torch.tensor([1] + [0] * (count - 1)))
+                    (loss / 2).backward()
+                count = 5 - first_counts[rank]
+                logits = model(inputs[:count])
+                loss = loss_func(SimpleNamespace(logits=logits), torch.tensor([1] + [0] * (count - 1)))
+                (loss / 2).backward()
+                expected = model.module.weight.detach().clone().requires_grad_()
+                F.cross_entropy(F.linear(inputs, expected).T, torch.tensor([0])).backward()
+                torch.testing.assert_close(model.module.weight.grad, expected.grad / 2)
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+class TestListwiseRerankerLoss(unittest.TestCase):
+
+    def setUp(self):
+        self.loss_func = ListwiseRerankerLoss(None, None)
+
+    def test_skipped_groups_have_zero_gradients(self):
+        for dtype in (torch.float32, torch.float64, torch.bfloat16):
+            for labels in ([0, 0], [1, 0]):
+                with self.subTest(
+                        dtype=dtype, labels=labels), patch.dict(os.environ, {'LISTWISE_RERANKER_MIN_GROUP_SIZE': '3'}):
+                    logits = torch.tensor([[1.], [2.]], dtype=dtype, requires_grad=True)
+                    loss = self.loss_func(SimpleNamespace(logits=logits), torch.tensor(labels))
+                    self.assertEqual(loss.item(), 0.)
+                    loss.backward()
+                    self.assertIsNotNone(logits.grad)
+                    torch.testing.assert_close(logits.grad, torch.zeros_like(logits))
+
+    def test_skipped_nonfinite_scores_do_not_contaminate_zero(self):
+        logits = torch.tensor([[float('nan')], [float('inf')]], requires_grad=True)
+        loss = self.loss_func(SimpleNamespace(logits=logits), torch.tensor([0, 0]))
+        self.assertEqual(loss.item(), 0.)
+        loss.backward()
+        self.assertIsNotNone(logits.grad)
+        torch.testing.assert_close(logits.grad, torch.zeros_like(logits))
+
+    def test_mixed_groups_preserve_retained_loss_and_gradients(self):
+        with patch.dict(os.environ, {'LISTWISE_RERANKER_MIN_GROUP_SIZE': '3', 'LISTWISE_RERANKER_TEMPERATURE': '0.7'}):
+            logits = torch.tensor([[4.], [2.], [1.], [3.], [2.]], dtype=torch.float64, requires_grad=True)
+            loss = self.loss_func(SimpleNamespace(logits=logits), torch.tensor([1, 0, 1, 0, 0]))
+            reference_logits = logits.detach().clone().requires_grad_()
+            reference = F.cross_entropy(reference_logits[2:].T / 0.7, torch.tensor([0]))
+            torch.testing.assert_close(loss, reference)
+            loss.backward()
+            reference.backward()
+            torch.testing.assert_close(logits.grad, reference_logits.grad)
+
+    @unittest.skipUnless(dist.is_available() and dist.is_gloo_available(), 'Gloo is required')
+    def test_skipped_steps_and_uneven_ranks_under_ddp(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mp.spawn(_ddp_worker, args=('file://' + os.path.join(directory, 'store'), ), nprocs=2, join=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Listwise reranker loss returns a new, unrelated zero tensor when no query group is retained. With the documented LISTWISE_RERANKER_MIN_GROUP_SIZE filter, one DDP rank can skip its groups while another still contributes a loss. The skipped rank produces no model gradients, leaving its peer waiting in backward.

Return a sum over an empty logits slice in both zero-loss branches. This preserves the autograd connection and supplies zero gradients without reading skipped scores. Retained query losses and averaging are unchanged.

Validation: four CPU tests pass, covering both zero branches, three floating dtypes, skipped nonfinite scores, retained loss/gradient equivalence and real two-process DDP with skipped and unequal-rank steps plus no_sync gradient accumulation. A separate time-bounded Gloo probe reproduces the upstream backward timeout and verifies identical gradients after the fix. Applicable pre-commit checks pass. No full pretrained-model or Megatron/NCCL training run was performed.

Additional verification uses 600 unchanged public ranking records from SciDocs, StackOverflow and AskUbuntu through the existing preprocessor and reranker grouping/collation methods, with a tiny deterministic text-feature scorer. Across three minimum-size settings, 1,762 retained cases match upstream loss and gradients exactly; 38 skipped cases now supply zero gradients. Original AskUbuntu records reproduce the asymmetric-rank backward timeout at the default threshold of 2; the fix completes successfully. These are grouping/autograd checks, not pretrained-model quality tests.

When an entire optimizer step has zero gradients, existing optimizer momentum or weight decay can still update parameters. This change restores connected-zero semantics; it does not add globally empty-step skipping. AdamW and momentum SGD match an explicit connected-zero reference.

A random one-layer BERT smoke test also reproduces the upstream timeout with find_unused_parameters both enabled and disabled. The fix passes both configurations and non-reentrant gradient checkpointing; all 25 parameter gradients match a cross-entropy reference. This is a CPU/Gloo model-structure check, not full Trainer.train or pretrained training.
