### PR TITLE
fix(megatron): gather embedding evaluation metrics across DP ranks

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,4 +4,5 @@ isort>=4.3.21
 modelscope
 pre-commit
 pytest
+scikit-learn
 yapf==0.30.0 # use fix version to ensure consistent auto-styling

--- a/swift/megatron/trainers/embedding_trainer.py
+++ b/swift/megatron/trainers/embedding_trainer.py
@@ -2,6 +2,7 @@
 import torch.nn
 import torch.nn.functional as F
 from functools import partial
+from megatron.core import mpu
 
 from swift.loss import loss_map
 from swift.metrics import eval_metrics_map
@@ -18,6 +19,7 @@ class MegatronEmbeddingTrainer(BaseMegatronTrainer):
         self._loss_func = loss_map[args.loss_type](args, self)
         eval_metric = 'infonce' if args.loss_type == 'infonce' else 'paired'
         self.eval_metrics = eval_metrics_map[eval_metric](args, self)
+        self.eval_metrics.group = mpu.get_data_parallel_group()
 
     def loss_func(self,
                   output_tensor: torch.Tensor,

--- a/swift/metrics/embedding.py
+++ b/swift/metrics/embedding.py
@@ -2,6 +2,7 @@
 import numpy as np
 import os
 import torch
+import torch.distributed as dist
 from transformers import EvalPrediction
 from transformers.utils import strtobool
 from typing import Dict
@@ -17,14 +18,21 @@ class EmbedddingMetricMixin(Metric):
         super().__init__()
         self.add_state('last_hidden_state', default_factory=list)
         self.add_state('labels', default_factory=list)
+        self.group = None
 
     def update(self, last_hidden_state, labels):
         self.last_hidden_state.append(last_hidden_state.cpu().numpy())
         self.labels.append(labels.cpu().numpy())
 
     def compute(self):
-        predictions = np.concatenate(self.last_hidden_state)
-        labels = np.concatenate(self.labels)
+        predictions, labels = self.last_hidden_state, self.labels
+        if self.group is not None and dist.get_world_size(self.group) > 1:
+            states = [None] * dist.get_world_size(self.group)
+            dist.all_gather_object(states, (predictions, labels), group=self.group)
+            predictions = [batch for rank_predictions, _ in states for batch in rank_predictions]
+            labels = [batch for _, rank_labels in states for batch in rank_labels]
+        predictions = np.concatenate(predictions)
+        labels = np.concatenate(labels)
         return self._calculate_metrics(predictions, labels)
 
 

--- a/tests/utils/test_embedding_metrics_dp.py
+++ b/tests/utils/test_embedding_metrics_dp.py
@@ -1,0 +1,94 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import numpy as np
+import os
+import tempfile
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import unittest
+from datetime import timedelta
+from unittest import mock
+
+from swift.metrics.embedding import InfonceMetrics, PairedMetrics
+
+
+def _shard(kind, rank):
+    generator = torch.Generator().manual_seed(42 + rank)
+    count = rank + 2
+    if kind == 'paired':
+        return torch.randn(count * 2, 8, generator=generator), torch.arange(count).float() + rank
+    predictions, labels = [], []
+    for i in range(count):
+        negatives = 1 + (i + rank) % 3
+        predictions.append(torch.randn(negatives + 2, 8, generator=generator))
+        labels.extend([1] + [0] * negatives)
+    return torch.cat(predictions), torch.tensor(labels)
+
+
+def _metric_worker(rank, init_file):
+    dist.init_process_group(
+        'gloo', init_method=f'file://{init_file}', rank=rank, world_size=4, timeout=timedelta(seconds=90))
+    groups = [dist.new_group([0, 2]), dist.new_group([1, 3])]
+    singletons = [dist.new_group([r]) for r in range(4)]
+    peers = [0, 2] if rank % 2 == 0 else [1, 3]
+    group = groups[rank % 2]
+    failures = []
+    try:
+        for kind, cls in [('paired', PairedMetrics), ('infonce', InfonceMetrics)]:
+            local = cls(None, None)
+            local.update(*_shard(kind, rank))
+            expected_local = local.compute()
+            local.group = singletons[rank]
+            assert local.compute() == expected_local
+            for empty_peer in [False, True]:
+                metric = cls(None, None)
+                metric.group = group
+                included = peers[1:] if empty_peer else peers
+                if rank in included:
+                    metric.update(*_shard(kind, rank))
+                shards = [_shard(kind, p) for p in included]
+                reference = cls(None, None)
+                reference.update(torch.cat([s[0] for s in shards]), torch.cat([s[1] for s in shards]))
+                expected = reference.compute()
+                original_count = len(metric.labels)
+                for repeat in range(2):
+                    try:
+                        actual = metric.compute()
+                        for key in expected:
+                            np.testing.assert_allclose(actual[key], expected[key], rtol=1e-6, atol=1e-6)
+                        assert len(metric.labels) == original_count
+                    except (AssertionError, ValueError) as error:
+                        failures.append(f'{kind} empty_peer={empty_peer} repeat={repeat}: {error}')
+                metric.reset()
+                assert not metric.labels and not metric.last_hidden_state
+        assert not failures, '\n'.join(failures)
+    finally:
+        dist.destroy_process_group()
+
+
+class TestEmbeddingMetricsDataParallel(unittest.TestCase):
+
+    def setUp(self):
+        environment = mock.patch.dict(os.environ)
+        environment.start()
+        self.addCleanup(environment.stop)
+        for name in ['INFONCE_USE_BATCH', 'INFONCE_HARD_NEGATIVES']:
+            os.environ.pop(name, None)
+
+    def test_local_compute_matches_hf_entry(self):
+        from transformers import EvalPrediction
+        for kind, cls in [('paired', PairedMetrics), ('infonce', InfonceMetrics)]:
+            predictions, labels = _shard(kind, 0)
+            metric = cls(None, None)
+            metric.update(predictions, labels)
+            expected = metric.compute_metrics(EvalPrediction(predictions.numpy(), labels.numpy()))
+            self.assertEqual(metric.compute(), expected)
+
+    @unittest.skipUnless(dist.is_available() and dist.is_gloo_available(), 'Gloo is required')
+    def test_independent_data_parallel_groups(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mp.spawn(_metric_worker, args=(os.path.join(directory, 'init'), ), nprocs=4, join=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Megatron embedding evaluation accumulates predictions and labels locally, so each data-parallel rank computes different metrics over its own shard. Pearson/Spearman correlations cannot be recovered by averaging these local correlations. InfoNCE evaluation also misses other DP ranks' in-batch candidates.

Give the embedding metric the trainer's data-parallel group and gather predictions together with their labels before computing the existing metrics. Gathering the accumulated lists supports unequal shard sizes and a rank with no local updates. The accumulated state stays local, so repeated computation does not duplicate samples. The default/Hugging Face entry remains local.

This complements #10088, which handles reranker query metrics. Embedding correlations and cross-query InfoNCE candidates require the complete predictions rather than a reduction of per-query scores. This change does not modify the reranker implementation.

## Experiment results

- The new CPU regression fails on the original implementation and passes after the fix. Both tests pass, including four Gloo workers in independent groups, unequal sample counts, an empty peer, repeated computation, reset, singleton groups, and the local/HF entry.
- Four H800 GPUs with real Megatron-Core 0.16.0 process groups and NCCL: DP4, TP2×DP2 and CP2×DP2. Paired and InfoNCE metrics match a complete-data reference with and without an empty first DP rank, on every worker.
- Changed-file pre-commit checks pass.

The GPU check exercises metric collection and process groups, not a full pretrained-model evaluation. Gathering embeddings adds communication and per-rank memory proportional to the evaluation data; full-model performance, pipeline parallel evaluation, and multi-node execution were not tested.
