### PR TITLE
fix(rlhf): propagate async rollout failures across ranks

### DIFF
--- a/swift/rlhf_trainers/grpo_trainer.py
+++ b/swift/rlhf_trainers/grpo_trainer.py
@@ -20,7 +20,6 @@ except ImportError:
 import concurrent.futures
 import inspect
 import os
-import time
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -144,7 +143,7 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
 
         if self.args.dynamic_sample or self.template.truncation_strategy == 'raise':
             self._prepare_resample_data_iterator()
-        # flag indicating whether the evaluation has started
+        # Whether training still needs to wait for the last evaluation rollout.
         self.eval_flag = False
 
         if self.template.sequence_parallel_size > 1:
@@ -1799,8 +1798,7 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
     def evaluation_loop(self, dataloader, *args, **kwargs):
         # Wait for the training rollout to complete
         if self.args.async_generate:
-            while not self.is_async_generate_train_rollout_done():
-                time.sleep(0.1)
+            self._wait_queue(self.train_queue)
         if self._queue.empty() and self.args.async_generate:
             self._prefetch(dataloader)
         output = super().evaluation_loop(dataloader, *args, **kwargs)
@@ -1808,10 +1806,10 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
         return output
 
     def training_step(self, model: nn.Module, inputs: DataType, num_items_in_batch=None) -> torch.Tensor:
-        if self.args.async_generate:
+        if self.args.async_generate and self.eval_flag:
             # Wait for the eval rollout to complete
-            while not self.is_async_generate_eval_rollout_done():
-                time.sleep(0.1)
+            self._wait_queue(self.eval_queue)
+            self.eval_flag = False
         return super().training_step(model, inputs, num_items_in_batch)
 
     def old_policy(self):

--- a/swift/rlhf_trainers/rollout_mixin.py
+++ b/swift/rlhf_trainers/rollout_mixin.py
@@ -58,8 +58,9 @@ logger = get_logger()
 
 @dataclass
 class DataCache:
-    """Cache container for rollout results"""
-    results: List['OnPolicySample']
+    """A terminal rollout result, including failures raised by the worker."""
+    results: Optional[List['OnPolicySample']] = None
+    error: Optional[BaseException] = None
 
 
 class AsyncGenerateCallback(TrainerCallback):
@@ -1183,6 +1184,10 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
         args = self.args
         assert isinstance(args, RolloutTrainerArgumentsMixin)
 
+        if args.async_generate:
+            # Check every rank before updating weights or starting another rollout.
+            self._wait_queue()
+
         if self.vllm_mode == 'colocate' and args.sleep_level > 0:
             if self.engine.inner_model_executor.is_sleeping:
                 wake_up_params = inspect.signature(self.engine.engine.wake_up).parameters
@@ -1191,7 +1196,7 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
                 self.engine.engine.wake_up(**kwargs)
 
         if self.state.global_step != self._last_loaded_step or args.sleep_level == 2:
-            self._move_model_to_vllm()
+            self._move_model_to_vllm(skip_async_check=True)
             self._last_loaded_step = self.state.global_step
 
         context = self.offload_context if self.enable_offload else nullcontext
@@ -1204,11 +1209,11 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
                     set_expandable_segments(False)
                     self.engine.engine.wake_up(tags=['kv_cache'])
 
-                if hasattr(self, 'async_generate') and self.async_generate:
+                if args.async_generate:
+                    data_cache = self._queue.get_nowait()
                     all_inputs = gather_object(samples)
                     self.async_generate_rollout(all_inputs)
 
-                    data_cache = self._queue.get()
                     all_outputs = gather_object(data_cache.results)
 
                     per_device_datasize = len(all_outputs) // self.accelerator.num_processes
@@ -1627,21 +1632,29 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
                 logger.error('Inference task failed: %s', str(e))
                 raise
 
-        future: Future = self.executor.submit(infer_task)
-
         def done(future):
             try:
-                result = future.result()
-                current_queue.put(DataCache(result))
-            except Exception as e:
-                logger.error('Error in async_generate_rollout callback: %s', str(e))
+                data_cache = DataCache(results=future.result())
+            except BaseException as e:
+                data_cache = DataCache(error=e)
+            current_queue.put(data_cache)
 
+        try:
+            future: Future = self.executor.submit(infer_task)
+        except BaseException as e:
+            # Submission failures must obey the same protocol on every rank.
+            future = Future()
+            future.set_exception(e)
+        # Keep the latest Future for each mode, including its exception, until replaced.
+        self._async_futures[current_queue] = future
         future.add_done_callback(done)
+        return future
 
     def _prepare_async_generate(self):
         """Initialize async generation queues and callback"""
         self.train_queue = Queue()
         self.eval_queue = Queue()
+        self._async_futures = {}
         args = self.args
 
         if args.async_generate:
@@ -1655,9 +1668,25 @@ class RolloutTrainerMixin(BaseRolloutTrainerMixin, RLHFTrainerMixin):
         else:
             return self.train_queue
 
-    def _wait_queue(self):
-        """Wait for queue to have items"""
-        while self._queue.empty():
+    def _wait_queue(self, current_queue=None):
+        """Wait for results on every rank, propagating failures before further collectives."""
+        if current_queue is None:
+            current_queue = self._queue
+        while True:
+            # Peek without consuming: weight updates and train/eval transitions also wait here.
+            with current_queue.mutex:
+                data_cache = current_queue.queue[0] if current_queue.queue else None
+            error = data_cache.error if data_cache is not None else None
+            error_message = f'{type(error).__name__}: {error}' if error is not None else None
+            # Exchange only serializable status; the original exception stays on its owning rank.
+            statuses = gather_object([(data_cache is not None, error_message)])
+            for rank, (_, message) in enumerate(statuses):
+                if message is not None:
+                    if error is not None:
+                        raise error
+                    raise RuntimeError(f'Async rollout failed on rank {rank}: {message}')
+            if all(ready for ready, _ in statuses):
+                return
             time.sleep(0.01)
 
     def _sort_by_request_id(self, all_outputs: List[RolloutOutput]) -> List[RolloutOutput]:


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

When an async rollout Future raises, the completion callback currently logs the exception without placing an outcome in the queue. Training can then wait indefinitely for a result that will never arrive. Raising only on the failing rank can also leave peers waiting in result collectives.

Queue both successful results and failures, retain the latest training/evaluation Futures, and exchange readiness/error status at rollout wait boundaries. The failing rank re-raises its original exception; peers raise an error identifying that rank. Check before weight updates, offload, or another rollout, and apply the same handling to training/evaluation transitions.

Reuse the check across weight updates and result consumption, and check each evaluation rollout only once when training resumes, to avoid duplicate status collectives.

This handles failures from completed async tasks, including cancellation and submission errors. It does not add HTTP or NCCL timeouts.

## Experiment results

Local regression tests were run on this PR branch; test files are not included in the commit.

- 18 single-process tests passed: real ThreadPoolExecutor failures, original exception/traceback preservation, cancellation, submission failure, queue ownership across mode changes, successful prefetch, failure checks before weight movement/offload, and avoiding repeated status checks. Includes the existing offload cleanup regression tests.
- Two-process CPU/Gloo validation passed with both a ready peer and a peer whose result queue was still empty. Both ranks reported failure before entering result gathering.
- All pre-commit checks and git diff --check passed.

Full GPU training was not run.