### PR TITLE
fix(infer): propagate Transformers worker errors to callers

### DIFF
--- a/swift/infer_engine/transformers_engine.py
+++ b/swift/infer_engine/transformers_engine.py
@@ -172,20 +172,24 @@ class TransformersEngine(InferEngine):
             if item is not None:
                 kwargs, queue_list = item
                 request_config = kwargs['request_config']
-                res_list_or_gen = self._infer(**kwargs)
-                if request_config.stream:
-                    finished = False
-                    while not finished:
-                        try:
-                            res_list = next(res_list_or_gen)
-                        except StopIteration:
-                            finished = True
-                            res_list = [None] * len(queue_list)
-                        for (queue, loop), res in zip(queue_list, res_list):
+                try:
+                    res_list_or_gen = self._infer(**kwargs)
+                    if request_config.stream:
+                        finished = False
+                        while not finished:
+                            try:
+                                res_list = next(res_list_or_gen)
+                            except StopIteration:
+                                finished = True
+                                res_list = [None] * len(queue_list)
+                            for (queue, loop), res in zip(queue_list, res_list):
+                                asyncio.run_coroutine_threadsafe(queue.put(res), loop)
+                    else:
+                        for (queue, loop), res in zip(queue_list, res_list_or_gen):
                             asyncio.run_coroutine_threadsafe(queue.put(res), loop)
-                else:
-                    for (queue, loop), res in zip(queue_list, res_list_or_gen):
-                        asyncio.run_coroutine_threadsafe(queue.put(res), loop)
+                except Exception as e:
+                    for queue, loop in queue_list:
+                        asyncio.run_coroutine_threadsafe(queue.put(e), loop)
 
     def _add_adapter(self, adapter_path: str, adapter_name: Optional[str] = None) -> None:
         self.model = Swift.from_pretrained(self.model, adapter_path, adapter_name)
@@ -501,11 +505,16 @@ class TransformersEngine(InferEngine):
                     await asyncio.sleep(0)
                     if item is None:
                         break
+                    if isinstance(item, Exception):
+                        raise item
                     yield item
 
             return _gen_wrapper()
         else:
-            return await queue.get()
+            item = await queue.get()
+            if isinstance(item, Exception):
+                raise item
+            return item
 
     # Ensure `template._post_encode` has no gradient.
     @torch.inference_mode()

--- a/tests/infer/test_transformers_worker.py
+++ b/tests/infer/test_transformers_worker.py
@@ -1,0 +1,127 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import asyncio
+import unittest
+from queue import Queue
+from threading import Event
+from transformers import GenerationConfig
+
+from swift.infer_engine import RequestConfig, TransformersEngine
+
+
+class _WorkerEngine(TransformersEngine):
+
+    def __init__(self):
+        self._queue = Queue()
+        self._task_pool = {}
+        self._task_thread = None
+        self.max_batch_size = 0
+        self.stopped = Event()
+        self.batches = []
+
+    def _fetch_infer_requests(self):
+        if self.stopped.is_set():
+            raise SystemExit
+        return super()._fetch_infer_requests()
+
+    def _infer(self, infer_requests, request_config, **kwargs):
+        self.batches.append(infer_requests)
+        if request_config.stream and request_config.num_beams == 2:
+            # Exercise the real backend rejection before model generation starts.
+            return self._infer_stream({},
+                                      generation_config=GenerationConfig(num_beams=2),
+                                      adapter_request=None,
+                                      request_config=request_config,
+                                      template_inputs=[])
+        if infer_requests[0] == 'bad':
+            raise ValueError('encoding failed')
+        if request_config.stream:
+
+            def stream():
+                yield ['partial'] * len(infer_requests)
+                if infer_requests[0] == 'partial_failure':
+                    raise RuntimeError('stream iteration failed')
+
+            return stream()
+        return infer_requests
+
+
+class TestTransformersWorker(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = _WorkerEngine()
+
+    async def asyncTearDown(self):
+        self.engine.stopped.set()
+        if self.engine._task_thread is not None:
+            self.engine._task_thread.join(timeout=2)
+            self.assertFalse(self.engine._task_thread.is_alive())
+
+    async def request(self, text, **kwargs):
+        return await asyncio.wait_for(self.engine.infer_async(text, RequestConfig(**kwargs)), timeout=2)
+
+    async def assert_recovery(self):
+        self.assertEqual(await self.request('healthy'), 'healthy')
+        self.assertTrue(self.engine._task_thread.is_alive())
+
+    async def test_nonstream_batch_failure_reaches_every_caller(self):
+        results = await asyncio.gather(self.request('bad'), self.request('also_bad'), return_exceptions=True)
+        self.assertEqual(self.engine.batches[0], ['bad', 'also_bad'])
+        for error in results:
+            self.assertIsInstance(error, ValueError)
+            self.assertEqual(str(error), 'encoding failed')
+        await self.assert_recovery()
+
+    async def test_stream_beam_search_error_reaches_caller(self):
+        streams = await asyncio.gather(
+            self.request('query', stream=True, num_beams=2), self.request('another_query', stream=True, num_beams=2))
+        for stream in streams:
+            with self.assertRaisesRegex(ValueError, 'does not support beam search'):
+                await asyncio.wait_for(anext(stream), timeout=2)
+        await self.assert_recovery()
+
+    async def test_error_after_partial_stream_and_normal_completion(self):
+        stream = await self.request('partial_failure', stream=True)
+        self.assertEqual(await asyncio.wait_for(anext(stream), timeout=2), 'partial')
+        with self.assertRaisesRegex(RuntimeError, 'stream iteration failed'):
+            await asyncio.wait_for(anext(stream), timeout=2)
+        await self.assert_recovery()
+        stream = await self.request('healthy', stream=True)
+        self.assertEqual(await asyncio.wait_for(anext(stream), timeout=2), 'partial')
+        with self.assertRaises(StopAsyncIteration):
+            await asyncio.wait_for(anext(stream), timeout=2)
+
+
+class TestTransformersWorkerStrictMode(unittest.TestCase):
+
+    def test_outer_infer_preserves_strict_policy(self):
+        for strict in (True, False):
+            for stream in (True, False):
+                with self.subTest(strict=strict, stream=stream):
+                    engine = _WorkerEngine()
+                    engine.strict = strict
+                    config = RequestConfig(stream=stream)
+
+                    def request():
+                        results = engine.infer(['bad'], config, use_tqdm=False)
+                        return list(results[0]) if stream else results
+
+                    try:
+                        # Non-streaming infer bypasses the worker and raises directly.
+                        if strict or not stream:
+                            with self.assertRaisesRegex(ValueError, 'encoding failed'):
+                                request()
+                        else:
+                            self.assertEqual(request(), [])
+                        self.assertEqual(engine.infer(['healthy'], RequestConfig(), use_tqdm=False), ['healthy'])
+                    finally:
+                        engine.stopped.set()
+                        if engine._task_thread is not None:
+                            engine._task_thread.join(timeout=2)
+                            self.assertFalse(engine._task_thread.is_alive())
+                        loop = getattr(engine, '_event_loop', None)
+                        if loop is not None:
+                            loop.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
An exception while processing an asynchronous TransformersEngine request can terminate its background inference worker without putting a result on the caller's queue. For example, requesting streaming with beam search reaches the backend's existing ValueError, but the caller waits indefinitely and later requests are left waiting too.

Catch exceptions from batch inference and stream iteration, deliver them through each affected request's existing result queue, and raise them in infer_async. The worker remains available for subsequent requests. Normal response and end-of-stream handling are unchanged.

Validation: four new CPU regression tests cover non-streaming batch error delivery, the real streaming/beam-search rejection, errors after partial streaming, normal completion, subsequent request recovery, and the existing synchronous strict policy. The two existing strict/non-strict stream-adapter tests also pass. A separate randomly initialized one-layer Qwen2 probe exercises the full TransformersEngine encoding and generation path: upstream times out and loses its worker; the fix reports the ValueError and completes the next generation on the same worker. Applicable pre-commit hooks pass.

This addresses errors raised in the request worker. Exceptions confined to the separate model.generate thread, cancellation, and recovery from fatal device errors are outside this change. No pretrained-model quality or production incident claim is made.

Follow-up verification uses 30 unchanged public texts from SQuAD, CMRC 2018 and HumanEval with a local byte-level tokenizer and tiny random Qwen2. After each rejected request, non-streaming tokens/text and streaming text match upstream direct generation. A separate original CMRC context exceeding the test model limit reproduces the same upstream worker failure; the fix delivers MaxLengthError and the next generation succeeds. Synchronous non-streaming infer bypasses this worker and is outside the failure scope.
