### PR TITLE
fix(infer): exclude padding from Transformers prompt usage

### DIFF
--- a/swift/infer_engine/infer_engine.py
+++ b/swift/infer_engine/infer_engine.py
@@ -201,7 +201,11 @@ class InferEngine(BaseInferEngine, ProcessorMixin):
             return [ChatCompletionMessageToolCall(function=function) for function in functions]
 
     @staticmethod
-    def _get_num_tokens(inputs: Dict[str, Any]) -> int:
+    def _get_num_tokens(inputs: Dict[str, Any], batch_idx: Optional[int] = None) -> int:
+        # Generation slicing needs the padded width; usage counts only real prompt tokens.
+        attention_mask = inputs.get('attention_mask')
+        if batch_idx is not None and attention_mask is not None and attention_mask.ndim == 2:
+            return int(attention_mask[batch_idx].sum().item())
         if 'input_ids' in inputs:  # 1d or 2d
             input_ids = inputs['input_ids']
             if isinstance(input_ids, list):

--- a/swift/infer_engine/transformers_engine.py
+++ b/swift/infer_engine/transformers_engine.py
@@ -265,8 +265,9 @@ class TransformersEngine(InferEngine):
 
         generate_kwargs = self.template.prepare_generate_kwargs(generate_kwargs, model=self.model)
         thread = Thread(target=_model_generate, kwargs=generate_kwargs)
-        thread.start()
         batch_size = inputs['attention_mask'].shape[0]
+        prompt_token_counts = [self._get_num_tokens(inputs, batch_idx=i) for i in range(batch_size)]
+        thread.start()
         all_is_finished = False
         is_finished = [False] * batch_size
         infer_streamers = [InferStreamer(self.template, template_inputs=template_inputs[i]) for i in range(batch_size)]
@@ -316,7 +317,7 @@ class TransformersEngine(InferEngine):
                 logprobs = self._get_logprobs(logprobs_list, generate_ids[token_idxs[i]:], request_config.top_logprobs)
                 token_idxs[i] = len(generate_ids)
 
-                usage_info = self._get_usage_info(num_prompt_tokens, len(generate_ids))
+                usage_info = self._get_usage_info(prompt_token_counts[i], len(generate_ids))
                 toolcall = None
                 if is_finished[i]:
                     toolcall = self._get_toolcall(
@@ -355,7 +356,6 @@ class TransformersEngine(InferEngine):
         adapter_names = self._get_adapter_names(adapter_request)
         if adapter_names is not None:
             call_kwargs['adapter_names'] = adapter_names
-        num_prompt_tokens = self._get_num_tokens(inputs)
         inputs.pop('labels', None)
         output = self.model(**inputs, **call_kwargs)
         if hasattr(output, 'logits'):
@@ -390,7 +390,7 @@ class TransformersEngine(InferEngine):
 
         res = []
         for i, pred in enumerate(preds):
-            usage_info = self._get_usage_info(num_prompt_tokens, 1)
+            usage_info = self._get_usage_info(self._get_num_tokens(inputs, batch_idx=i), 1)
             if task_type == 'embedding':
                 res.append(
                     EmbeddingResponse(
@@ -428,7 +428,7 @@ class TransformersEngine(InferEngine):
         num_return_sequences = generation_config.num_return_sequences
         for i in range(inputs['attention_mask'].shape[0]):
             choices = []
-            usage_info = self._get_usage_info(num_prompt_tokens, 0)
+            usage_info = self._get_usage_info(self._get_num_tokens(inputs, batch_idx=i), 0)
             for j in range(num_return_sequences):
                 batched_index = i * num_return_sequences + j
                 generate_ids = batched_generate_ids[batched_index]

--- a/tests/infer/test_prompt_usage.py
+++ b/tests/infer/test_prompt_usage.py
@@ -1,0 +1,116 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import torch
+import unittest
+from transformers import GenerationConfig
+from types import SimpleNamespace
+
+from swift.infer_engine import RequestConfig, TransformersEngine
+from swift.infer_engine.infer_engine import InferEngine
+
+
+def _generate(model, input_ids, generation_config, streamer=None, **kwargs):
+    input_ids = input_ids.repeat_interleave(generation_config.num_return_sequences, dim=0)
+    generated = torch.full((input_ids.shape[0], 2), 9)
+    if streamer is not None:
+        streamer.put(input_ids)
+        for token in generated.T:
+            streamer.put(token)
+        streamer.end()
+    return {'sequences': torch.cat([input_ids, generated], dim=1)}
+
+
+class TestPromptUsage(unittest.TestCase):
+
+    def setUp(self):
+        self.inputs = {
+            'input_ids': torch.tensor([[0, 0, 4, 5], [4, 5, 6, 7]]),
+            'attention_mask': torch.tensor([[0, 0, 1, 1], [1, 1, 1, 1]])
+        }
+        self.engine = object.__new__(TransformersEngine)
+        self.engine.model = lambda **kw: SimpleNamespace(logits=torch.tensor([[1., 0.], [0., 1.]]))
+        self.engine.model_name = 'test-model'
+        self.engine.processor = SimpleNamespace(pad_token_id=0)
+        self.engine._adapters_pool = {}
+        self.engine.template = SimpleNamespace(
+            tokenizer=self.engine.tokenizer,
+            prepare_generate_kwargs=lambda kwargs, **kw: kwargs,
+            generate=_generate,
+            get_generate_ids=lambda ids, length: ids[:, length:],
+            decode_generate_ids=lambda ids, **kw: '好' * len(ids),
+            debug_logger=lambda data: None,
+            task_type='seq_cls',
+            decode_seq_cls=lambda logits, top: (logits.argmax(-1).tolist(), [None, None]))
+
+    def test_prompt_count_keeps_padded_width_for_generation(self):
+        masks = [
+            torch.tensor([[0, 0, 1, 1], [1, 1, 1, 1]]),
+            torch.tensor([[1, 1, 0, 0], [1, 1, 1, 1]], dtype=torch.bool),
+        ]
+        for mask in masks:
+            inputs = {**self.inputs, 'attention_mask': mask}
+            self.assertEqual(InferEngine._get_num_tokens(inputs), 4)
+            self.assertEqual(InferEngine._get_num_tokens(inputs, batch_idx=0), 2)
+            self.assertEqual(InferEngine._get_num_tokens(inputs, batch_idx=1), 4)
+        embeddings = {'inputs_embeds': torch.zeros(2, 4, 8), 'attention_mask': self.inputs['attention_mask']}
+        self.assertEqual(InferEngine._get_num_tokens(embeddings), 4)
+        self.assertEqual(InferEngine._get_num_tokens(embeddings, batch_idx=0), 2)
+        for mask in (None, torch.ones(2, 1, 4, 4)):
+            inputs = {'input_ids': self.inputs['input_ids'], 'attention_mask': mask}
+            self.assertEqual(InferEngine._get_num_tokens(inputs, batch_idx=0), 4)
+
+    def test_real_pad_token_ids_and_generation_budget(self):
+        # A token equal to pad_token_id is still part of the prompt when its mask is 1.
+        inputs = {
+            'input_ids': torch.tensor([[0, 0, 0, 5], [4, 5, 6, 7]]),
+            'attention_mask': torch.tensor([[0, 1, 1, 1], [1, 1, 1, 1]])
+        }
+        self.assertEqual(InferEngine._get_num_tokens(inputs, batch_idx=0), 3)
+        self.engine.max_model_len = 10
+        self.engine.max_tokens_offset = 0
+        for requested in (None, 9):
+            config = RequestConfig(max_tokens=requested)
+            self.engine.set_default_max_tokens(config, inputs)
+            self.assertEqual(config.max_tokens, 6)
+
+    def test_full_generation_usage_and_choices(self):
+        for n in (1, 2):
+            config = GenerationConfig(max_new_tokens=2, num_return_sequences=n, do_sample=True)
+            responses = self.engine._infer_full(
+                self.inputs,
+                generation_config=config,
+                adapter_request=None,
+                request_config=RequestConfig(),
+                template_inputs=[None, None])
+            self.assertEqual([r.usage.prompt_tokens for r in responses], [2, 4])
+            self.assertEqual([r.usage.completion_tokens for r in responses], [2 * n, 2 * n])
+            self.assertEqual([r.usage.total_tokens for r in responses], [2 + 2 * n, 4 + 2 * n])
+            for response in responses:
+                self.assertEqual(len(response.choices), n)
+                self.assertTrue(all(c.message.content == '好好' for c in response.choices))
+
+    def test_stream_usage_and_generation_slicing(self):
+        chunks = list(
+            self.engine._infer_stream(
+                self.inputs,
+                generation_config=GenerationConfig(
+                    max_new_tokens=2, output_logits=False, num_beams=1, num_return_sequences=1),
+                adapter_request=None,
+                request_config=RequestConfig(stream=True),
+                template_inputs=[None, None]))
+        for chunk in chunks:
+            for i, response in enumerate(chunk):
+                if response is not None:
+                    self.assertEqual(response.usage.prompt_tokens, [2, 4][i])
+        self.assertEqual([r.usage.total_tokens for r in chunks[-1]], [4, 6])
+        for i in range(2):
+            text = ''.join(chunk[i].choices[0].delta.content for chunk in chunks if chunk[i] is not None)
+            self.assertEqual(text, '好好')
+
+    def test_forward_only_usage(self):
+        responses = self.engine._infer_forward(self.inputs, adapter_request=None, request_config=RequestConfig())
+        self.assertEqual([r.usage.prompt_tokens for r in responses], [2, 4])
+        self.assertEqual([r.usage.total_tokens for r in responses], [3, 5])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
TransformersEngine uses the padded batch width as prompt_tokens for every response. When differently sized prompts are batched together, shorter requests report padding as input tokens in both streaming and non-streaming responses. Forward-only tasks share the same accounting issue.

Allow the existing token-count helper to count one batch row using its standard 2D attention mask, and use that count when constructing response usage. Calls without a batch index keep returning the padded width for generation slicing and maximum-token calculations. Streaming counts are computed once before generation starts. Missing or higher-dimensional masks retain the existing fallback behavior.

Validation: five CPU regression tests cover left/right padding, inputs_embeds, missing/4D-mask fallback, generation slicing/budgets, valid tokens sharing the pad ID, multiple returned sequences, streaming usage and forward-only usage. A separate actual tiny-Qwen2 probe uses 30 unchanged SQuAD, CMRC 2018 and HumanEval prompts: 27 requests were overcounted upstream (4,100 reported prompt tokens versus 3,349 when run individually). After the fix, batched and streamed counts match individual requests, and generated token IDs and streamed text match upstream. Applicable pre-commit checks pass. This uses a local tokenizer and random tiny model, not pretrained quality evaluation or a GPU benchmark.

The same 30 public prompts were also interleaved across datasets and rerun in batches of 7 (including a two-request tail) and 30. Upstream reported 6,855 and 7,500 prompt tokens respectively; both fixed runs report the single-request total of 3,349, with unchanged generation outputs.
