### PR TITLE
fix(megatron): normalize GKD loss by global valid-token count

### DIFF
--- a/docs/source/Megatron-SWIFT/Command-line-parameters.md
+++ b/docs/source/Megatron-SWIFT/Command-line-parameters.md
@@ -332,7 +332,7 @@ Megatron训练参数继承自Megatron参数和基本参数（**与ms-swift共用
 除了继承训练参数外，还支持以下参数：
 - 🔥rlhf_type: 默认为'dpo'。目前可选择为'dpo'、'grpo'、'kto'、'rm'和'gkd'。
 - loss_scale: 覆盖[基本参数](../Instruction/Command-line-parameters.md)中的loss_scale。默认为'last_round'。
-- calculate_per_token_loss: 覆盖Megatron参数，默认为False。
+- calculate_per_token_loss: 覆盖Megatron参数。非Ray的GKD默认为True，按全局批次中有效蒸馏token的总数归一化损失与梯度。当前该路径要求`context_parallel_size=1`；设置为False可保留旧版microbatch均值聚合（变长回答的token权重不同）。Ray GKD及其他RLHF类型仍默认为False。启用SFT混合损失时，Teacher必须覆盖所有有效回答token，否则无法共用全局归一化分母。
 
 
 ### DPO参数

--- a/docs/source_en/Megatron-SWIFT/Command-line-parameters.md
+++ b/docs/source_en/Megatron-SWIFT/Command-line-parameters.md
@@ -351,7 +351,7 @@ In addition to inheriting the training parameters, the following parameters are 
 
 - 🔥rlhf_type: Default is 'dpo'. Currently, 'dpo', 'grpo', 'kto', 'rm', and 'gkd' are available.
 - loss_scale: Overrides the `loss_scale` in [basic parameters](../Instruction/Command-line-parameters.md). Default is 'last_round'.
-- calculate_per_token_loss: Overrides the Megatron parameter. Default is False.
+- calculate_per_token_loss: Overrides the Megatron parameter. Defaults to True for non-Ray GKD, normalizing loss and gradients by the global count of valid distillation tokens. This path currently requires `context_parallel_size=1`; setting False retains legacy microbatch averaging, which weights tokens differently for variable-length responses. Ray GKD and other RLHF types still default to False. Mixing SFT loss requires teacher scores for every valid response token so both objectives share the global denominator.
 
 
 ### DPO Parameters

--- a/swift/megatron/arguments/rlhf_args.py
+++ b/swift/megatron/arguments/rlhf_args.py
@@ -11,9 +11,16 @@ class MegatronRLHFArguments(MegatronSftArguments):
     loss_scale: str = 'last_round'
     truncation_strategy: Optional[Literal['delete', 'left', 'right', 'split', None]] = None
 
-    calculate_per_token_loss: bool = False
+    calculate_per_token_loss: Optional[bool] = None
 
     def __post_init__(self):
+        if self.calculate_per_token_loss is None:
+            # Ray uses a separate loss interface; retain its existing default.
+            self.calculate_per_token_loss = self.rlhf_type == 'gkd' and not self.use_ray
+        if (self.rlhf_type == 'gkd' and not self.use_ray and self.calculate_per_token_loss
+                and self.context_parallel_size > 1):
+            raise NotImplementedError('Token-normalized Megatron GKD currently requires context_parallel_size=1. '
+                                      'Set calculate_per_token_loss=False to retain legacy microbatch averaging.')
         if self.rlhf_type == 'rm':
             self.task_type = 'seq_cls'
             self.num_labels = 1

--- a/swift/megatron/trainers/gkd_trainer.py
+++ b/swift/megatron/trainers/gkd_trainer.py
@@ -359,9 +359,17 @@ class MegatronGKDTrainer(MegatronRolloutMixin, MegatronRLHFTrainer):
             gather_fn=tp_gather_topk,
             log_softmax_fn=vocab_parallel_log_softmax,
             kl_div_fn=vocab_parallel_kl_div)
-        jsd_loss_val = cp_reduce(jsd_total, jsd_num_valid, cp_size=self.args.context_parallel_size)
-
-        loss = jsd_loss_val
+        token_normalized = self.args.calculate_per_token_loss
+        if token_normalized:
+            # The scheduler accumulates token sums; finalize_model_grads divides
+            # the summed gradients by the DP-global valid-token count once.
+            # Keep an autograd edge even when this microbatch has no scored tokens.
+            if not jsd_total.requires_grad:
+                jsd_total = jsd_total + student_logits[..., :0].sum()
+            loss = jsd_total
+        else:
+            jsd_loss_val = cp_reduce(jsd_total, jsd_num_valid, cp_size=self.args.context_parallel_size)
+            loss = jsd_loss_val
 
         # Add SFT loss if enabled (skip for student-generated responses)
         sft_loss = None
@@ -376,29 +384,48 @@ class MegatronGKDTrainer(MegatronRolloutMixin, MegatronRLHFTrainer):
             sft_loss_sum = (per_token_loss * loss_mask).sum()
             sft_loss_count = loss_mask.sum().float()
 
-            # All-reduce across CP group for correct averaging
-            if args.context_parallel_size > 1:
-                sft_stats = torch.stack([sft_loss_sum, sft_loss_count])
+            if token_normalized:
+                # API top-k can omit positions that still contribute to SFT.
+                # Two different global denominators require a separate contract.
+                mismatched_count = (sft_loss_count != jsd_num_valid).to(torch.int)
                 torch.distributed.all_reduce(
-                    sft_stats, op=torch.distributed.ReduceOp.SUM, group=mpu.get_context_parallel_group())
-                sft_loss_sum, sft_loss_count = sft_stats[0], sft_stats[1]
-
-            sft_loss = sft_loss_sum / sft_loss_count
-
+                    mismatched_count, op=torch.distributed.ReduceOp.MAX, group=mpu.get_data_parallel_group())
+                if mismatched_count:
+                    raise ValueError('Token-normalized GKD with sft_alpha>0 requires teacher scores for every '
+                                     'valid response token. Use sft_alpha=0 for partial teacher coverage.')
+                sft_loss = sft_loss_sum
+            else:
+                if args.context_parallel_size > 1:
+                    sft_stats = torch.stack([sft_loss_sum, sft_loss_count])
+                    torch.distributed.all_reduce(
+                        sft_stats, op=torch.distributed.ReduceOp.SUM, group=mpu.get_context_parallel_group())
+                    sft_loss_sum, sft_loss_count = sft_stats[0], sft_stats[1]
+                sft_loss = sft_loss_sum / sft_loss_count
             loss = loss + self.sft_alpha * sft_loss
 
         metric = {'loss': loss.detach().clone()}
         if sft_loss is not None:
-            metric['jsd_loss'] = jsd_loss_val.detach().clone()
+            metric['jsd_loss'] = (jsd_total if token_normalized else jsd_loss_val).detach().clone()
             metric['sft_loss'] = sft_loss.detach().clone()
-        metric = self._all_reduce_metric(metric)
-
-        loss = loss / mpu.get_context_parallel_world_size()
+        if token_normalized:
+            # BaseMegatronTrainer sums [numerator, denominator] across microbatches
+            # and logging steps before division. Counts must never be DP-averaged.
+            metric_dtype = torch.promote_types(loss.dtype, torch.float32)
+            metric = {
+                key: torch.stack([value.to(metric_dtype), jsd_num_valid.to(metric_dtype)])
+                for key, value in metric.items()
+            }
+            metric = self._all_reduce_metric(metric, reduction=torch.distributed.ReduceOp.SUM)
+        else:
+            metric = self._all_reduce_metric(metric)
+            loss = loss / mpu.get_context_parallel_world_size()
 
         # Flush completion logs at generation cycle boundaries.
         if (self._step - 1) % self.steps_per_generation == 0:
             self._flush_log_completions()
 
+        if token_normalized:
+            return loss, jsd_num_valid.detach().clone().to(torch.int), metric
         return loss, metric
 
     def forward_step(self, data_iterator, model):

--- a/tests/megatron/test_gkd_global_token_mean.py
+++ b/tests/megatron/test_gkd_global_token_mean.py
@@ -1,0 +1,333 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""CPU contracts for native Megatron GKD token normalization.
+
+Load the actual argument class and loss methods through AST to avoid importing
+CUDA, vLLM and model-loading infrastructure. The loss math is the real shared
+gkd_loss module. Collectives are mocked; these are not distributed scheduler tests.
+
+Run: python -m pytest tests/megatron/test_gkd_global_token_mean.py -q
+"""
+import ast
+import importlib.util
+import sys
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Dict, Literal, Optional
+from unittest import mock
+
+try:
+    import torch
+    TORCH_UNAVAILABLE = None
+except (ImportError, OSError) as error:
+    torch = None
+    TORCH_UNAVAILABLE = str(error)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_node(relative_path, name, namespace, owner=None):
+    path = ROOT / relative_path
+    tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+    nodes = tree.body
+    if owner is not None:
+        nodes = next(node for node in nodes if isinstance(node, ast.ClassDef) and node.name == owner).body
+    node = next(node for node in nodes if isinstance(node, (ast.ClassDef, ast.FunctionDef)) and node.name == name)
+    exec(compile(ast.Module(body=[node], type_ignores=[]), str(path), 'exec'), namespace)
+    return namespace[name]
+
+
+@dataclass
+class _SftArguments:
+    use_ray: bool = False
+    context_parallel_size: int = 1
+
+    def __post_init__(self):
+        self.parent_post_init_called = True
+
+
+class TestGKDTokenArguments(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.args_cls = _load_node(
+            'swift/megatron/arguments/rlhf_args.py', 'MegatronRLHFArguments', {
+                '__name__': __name__,
+                'dataclass': dataclass,
+                'Literal': Literal,
+                'Optional': Optional,
+                'MegatronSftArguments': _SftArguments,
+            })
+
+    def test_native_gkd_default(self):
+        args = self.args_cls(rlhf_type='gkd')
+        self.assertIs(args.calculate_per_token_loss, True)
+        self.assertTrue(args.parent_post_init_called)
+
+    def test_other_objective_defaults_unchanged(self):
+        for objective in ('dpo', 'kto', 'grpo', 'rm'):
+            with self.subTest(objective=objective):
+                args = self.args_cls(rlhf_type=objective)
+                self.assertIs(args.calculate_per_token_loss, False)
+
+    def test_ray_default_unchanged(self):
+        args = self.args_cls(rlhf_type='gkd', use_ray=True, context_parallel_size=2)
+        self.assertIs(args.calculate_per_token_loss, False)
+
+    def test_explicit_legacy_opt_out(self):
+        args = self.args_cls(rlhf_type='gkd', calculate_per_token_loss=False, context_parallel_size=2)
+        self.assertIs(args.calculate_per_token_loss, False)
+
+    def test_explicit_values_preserved_for_other_backends(self):
+        for kwargs in ({'rlhf_type': 'grpo'}, {'rlhf_type': 'gkd', 'use_ray': True}):
+            for value in (False, True):
+                with self.subTest(kwargs=kwargs, value=value):
+                    self.assertIs(
+                        self.args_cls(**kwargs, calculate_per_token_loss=value).calculate_per_token_loss, value)
+
+    def test_cp_requires_explicit_scope_decision(self):
+        for value in (None, True):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(NotImplementedError, 'context_parallel_size=1'):
+                    self.args_cls(rlhf_type='gkd', context_parallel_size=2, calculate_per_token_loss=value)
+
+
+@unittest.skipIf(TORCH_UNAVAILABLE is not None, TORCH_UNAVAILABLE or '')
+class TestGKDGlobalTokenMean(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        path = ROOT / 'swift/rlhf_trainers/gkd_loss.py'
+        spec = importlib.util.spec_from_file_location('_gkd_token_test_math', path)
+        cls.math = importlib.util.module_from_spec(spec)
+        with mock.patch.dict(sys.modules, {spec.name: cls.math}):
+            spec.loader.exec_module(cls.math)
+        cls.mpu = SimpleNamespace(get_context_parallel_world_size=lambda: 1, get_data_parallel_group=lambda: 'dp')
+        namespace = {'torch': torch, 'mpu': cls.mpu, 'Dict': Dict}
+        cp_reduce = _load_node('swift/megatron/trainers/gkd_utils.py', 'cp_reduce', namespace)
+        cls.reduce_metric = staticmethod(
+            _load_node('swift/megatron/trainers/base.py', '_all_reduce_metric', namespace, 'BaseMegatronTrainer'))
+        cls.namespace = {
+            'torch': torch,
+            'mpu': cls.mpu,
+            'DataSource': cls.math.DataSource,
+            'TeacherOutput': cls.math.TeacherOutput,
+            'gkd_loss': cls.math.gkd_loss,
+            'cp_reduce': cp_reduce,
+            'tp_gather_topk': cls.math.default_gather,
+            'vocab_parallel_log_softmax': cls.math.default_log_softmax,
+            'vocab_parallel_kl_div': cls.math.default_kl_div,
+        }
+        cls.loss_func = staticmethod(
+            _load_node('swift/megatron/trainers/gkd_trainer.py', 'loss_func', cls.namespace, 'MegatronGKDTrainer'))
+
+    def _trainer(self, beta=1.0, alpha=0.0, per_token=True):
+
+        def language_model_loss(labels, logits_sbv):
+            logits = logits_sbv.transpose(0, 1)
+            return torch.nn.functional.cross_entropy(
+                logits.reshape(-1, logits.shape[-1]), labels.reshape(-1), reduction='none',
+                ignore_index=-100).reshape_as(labels)
+
+        trainer = SimpleNamespace(
+            args=SimpleNamespace(calculate_per_token_loss=per_token, context_parallel_size=1),
+            beta=beta,
+            temperature=1.0,
+            sft_alpha=alpha,
+            unwrapped_models=[SimpleNamespace(compute_language_model_loss=language_model_loss)],
+            _step=1,
+            steps_per_generation=2,
+            _flush_log_completions=mock.Mock(),
+        )
+        trainer._all_reduce_metric = lambda metric, **kwargs: self.reduce_metric(trainer, metric, **kwargs)
+        return trainer
+
+    def _teacher(self, logits, labels, mode):
+        if mode == 'full':
+            return self.math.TeacherOutput(full_logits=logits, labels=labels)
+        values, indices = logits.topk(3, dim=-1)
+        if mode == 'partial':
+            values = values.clone()
+            values[:, -1] = -torch.inf
+        return self.math.TeacherOutput(topk_logprobs=values, topk_indices=indices, labels=labels)
+
+    def _reference(self, logits, labels, teacher, beta, alpha=0.0):
+        mask = labels != -100
+        selected = logits[mask]
+        if teacher.is_topk_mode:
+            teacher_logits = teacher.topk_logprobs[mask]
+            covered = ~torch.isinf(teacher_logits).all(-1)
+            selected = selected.gather(-1, teacher.topk_indices[mask])[covered]
+            teacher_logits = teacher_logits[covered]
+        else:
+            teacher_logits = teacher.full_logits[mask]
+        student_log = selected.log_softmax(-1)
+        teacher_log = teacher_logits.log_softmax(-1)
+        if beta == 0:
+            tokens = (teacher_log.exp() * (teacher_log - student_log)).sum(-1)
+        elif beta == 1:
+            tokens = (student_log.exp() * (student_log - teacher_log)).sum(-1)
+        else:
+            mixed = torch.logaddexp(student_log + student_log.new_tensor(1 - beta).log(),
+                                    teacher_log + teacher_log.new_tensor(beta).log())
+            tokens = (
+                beta * (teacher_log.exp() * (teacher_log - mixed)).sum(-1) + (1 - beta) *
+                (student_log.exp() * (student_log - mixed)).sum(-1))
+        result = tokens.sum() / tokens.numel()
+        if alpha:
+            result = result + alpha * torch.nn.functional.cross_entropy(logits[mask], labels[mask])
+        return result
+
+    def _check_partition(self, mode, beta, alpha=0.0, source=None):
+        generator = torch.Generator().manual_seed(19)
+        inputs = torch.randn(4, 4, 7, generator=generator, dtype=torch.float64)
+        teacher_logits = torch.randn(4, 4, 7, generator=generator, dtype=torch.float64)
+        labels = torch.tensor([[1, -100, -100, -100], [0, 2, 1, 4], [3, 5, -100, -100], [-100] * 4])
+        reference_weight = torch.zeros(7, dtype=torch.float64, requires_grad=True)
+        teacher = self._teacher(teacher_logits, labels, mode)
+        active_alpha = alpha if source != self.math.DataSource.STUDENT else 0.0
+        expected = self._reference(inputs + reference_weight, labels, teacher, beta, active_alpha)
+        expected.backward()
+        for groups in (([0], [1], [2], [3]), ([0, 1], [2, 3]), ([0, 1, 2, 3], )):
+            with self.subTest(groups=groups):
+                weight = torch.zeros(7, dtype=torch.float64, requires_grad=True)
+                trainer = self._trainer(beta, alpha)
+                numerator = torch.zeros((), dtype=torch.float64)
+                denominator = torch.zeros((), dtype=torch.int)
+                stats = torch.zeros(2, dtype=torch.float64)
+                with mock.patch.object(torch.distributed, 'all_reduce') as reduce:
+                    for group in groups:
+                        batch_labels = labels[group]
+                        result = self.loss_func(
+                            trainer,
+                            inputs[group] + weight,
+                            labels=batch_labels,
+                            teacher_output=self._teacher(teacher_logits[group], batch_labels, mode),
+                            data_source=source or self.math.DataSource.DATASET)
+                        self.assertEqual(len(result), 3)
+                        loss_sum, count, metric = result
+                        self.assertEqual(count.dtype, torch.int)
+                        self.assertTrue(loss_sum.requires_grad)
+                        loss_sum.backward()
+                        numerator += loss_sum.detach()
+                        denominator += count
+                        stats += metric['loss']
+                    for call in reduce.call_args_list:
+                        operation = call.kwargs.get('op', call.args[1] if len(call.args) > 1 else None)
+                        self.assertIn(operation, (torch.distributed.ReduceOp.SUM, torch.distributed.ReduceOp.MAX))
+                torch.testing.assert_close(numerator / denominator, expected.detach(), rtol=1e-12, atol=1e-12)
+                torch.testing.assert_close(weight.grad / denominator, reference_weight.grad, rtol=1e-11, atol=1e-12)
+                torch.testing.assert_close(stats[0] / stats[1], expected.detach(), rtol=1e-12, atol=1e-12)
+
+    def test_full_vocab_loss_and_gradients(self):
+        for beta in (0.0, 0.5, 1.0):
+            with self.subTest(beta=beta):
+                self._check_partition('full', beta)
+
+    def test_topk_loss_and_gradients(self):
+        for beta in (0.0, 0.5, 1.0):
+            with self.subTest(beta=beta):
+                self._check_partition('topk', beta)
+
+    def test_partial_teacher_coverage_uses_scored_token_count(self):
+        self._check_partition('partial', 1.0)
+
+    def test_sft_mixture_uses_token_sums(self):
+        for mode in ('full', 'topk'):
+            with self.subTest(mode=mode):
+                self._check_partition(mode, 1.0, alpha=0.3)
+
+    def test_student_rollouts_skip_sft(self):
+        self._check_partition('partial', 1.0, alpha=0.3, source=self.math.DataSource.STUDENT)
+
+    def test_partial_teacher_coverage_rejects_sft_mixture(self):
+        labels = torch.tensor([[0, 1]])
+        logits = torch.zeros(1, 2, 7, dtype=torch.float64, requires_grad=True)
+        teacher = self._teacher(logits.detach(), labels, 'partial')
+        with mock.patch.object(torch.distributed, 'all_reduce'):
+            with self.assertRaisesRegex(ValueError, 'teacher scores for every'):
+                self.loss_func(self._trainer(alpha=0.3), logits, labels=labels, teacher_output=teacher)
+
+    def test_coverage_error_is_shared_with_other_dp_ranks(self):
+        labels = torch.tensor([[0, 1]])
+        logits = torch.zeros(1, 2, 7, dtype=torch.float64, requires_grad=True)
+
+        def remote_mismatch(value, op, group):
+            self.assertEqual(op, torch.distributed.ReduceOp.MAX)
+            self.assertEqual(group, 'dp')
+            value.fill_(1)
+
+        with mock.patch.object(torch.distributed, 'all_reduce', side_effect=remote_mismatch):
+            with self.assertRaisesRegex(ValueError, 'teacher scores for every'):
+                self.loss_func(
+                    self._trainer(alpha=0.3),
+                    logits,
+                    labels=labels,
+                    teacher_output=self._teacher(logits.detach(), labels, 'full'))
+
+    def test_dp_metric_sum_keeps_local_gradient_normalizer(self):
+        trainer = self._trainer()
+        logits = torch.tensor([[[1.0]]], requires_grad=True)
+        labels = torch.tensor([[0]])
+
+        def token_values(student, *_args, **_kwargs):
+            return student.sum(), labels.new_tensor(1)
+
+        def sum_remote(value, op, group):
+            self.assertEqual(op, torch.distributed.ReduceOp.SUM)
+            self.assertEqual(group, 'dp')
+            value.add_(value.new_tensor([[9.0, 3.0]]))
+
+        with mock.patch.dict(self.namespace, {'gkd_loss': token_values}):
+            with mock.patch.object(torch.distributed, 'all_reduce', side_effect=sum_remote):
+                loss, count, metric = self.loss_func(trainer, logits, labels=labels, teacher_output=None)
+        self.assertEqual(count.item(), 1)
+        self.assertEqual(loss.item(), 1)
+        torch.testing.assert_close(metric['loss'], torch.tensor([10.0, 4.0]))
+        self.assertEqual((metric['loss'][0] / metric['loss'][1]).item(), 2.5)
+        loss.backward()
+        torch.testing.assert_close(logits.grad, torch.ones_like(logits))
+
+    def test_empty_mask_keeps_zero_gradient_and_zero_count(self):
+        logits = torch.randn(1, 2, 7, dtype=torch.float64, requires_grad=True)
+        labels = torch.full((1, 2), -100)
+        with mock.patch.object(torch.distributed, 'all_reduce'):
+            loss, count, metric = self.loss_func(
+                self._trainer(), logits, labels=labels, teacher_output=self._teacher(logits.detach(), labels, 'full'))
+        self.assertEqual(count.item(), 0)
+        self.assertEqual(loss.item(), 0)
+        self.assertTrue(loss.requires_grad)
+        loss.backward()
+        torch.testing.assert_close(logits.grad, torch.zeros_like(logits))
+        torch.testing.assert_close(metric['loss'], torch.zeros(2, dtype=torch.float64))
+
+    def test_low_precision_logits_do_not_round_metric_counts(self):
+        logits = torch.zeros(1, 1, 1, dtype=torch.bfloat16, requires_grad=True)
+        labels = torch.tensor([[0]])
+
+        def token_values(student, *_args, **_kwargs):
+            return student.sum(), labels.new_tensor(257)
+
+        with mock.patch.dict(self.namespace, {'gkd_loss': token_values}):
+            with mock.patch.object(torch.distributed, 'all_reduce'):
+                _, count, metric = self.loss_func(self._trainer(), logits, labels=labels, teacher_output=None)
+        self.assertEqual(count.item(), 257)
+        self.assertEqual(metric['loss'].dtype, torch.float32)
+        self.assertEqual(metric['loss'][1].item(), 257)
+
+    def test_legacy_mode_retains_two_value_interface(self):
+        trainer = self._trainer(per_token=False)
+        labels = torch.tensor([[0, 1]])
+        logits = torch.tensor([[[2., 1., 0.], [0., 1., 3.]]], dtype=torch.float64, requires_grad=True)
+        teacher = self._teacher(torch.zeros_like(logits), labels, 'full')
+        with mock.patch.object(torch.distributed, 'all_reduce') as reduce:
+            loss, metric = self.loss_func(trainer, logits, labels=labels, teacher_output=teacher)
+        expected = self._reference(logits, labels, teacher, 1.0)
+        torch.testing.assert_close(loss, expected)
+        self.assertEqual(metric['loss'].numel(), 1)
+        self.assertEqual(reduce.call_args.args[1], torch.distributed.ReduceOp.AVG)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Related to #10076

## Status

Draft for implementation and API review. The CPU regression suite and repository
pre-commit checks pass, but an actual Megatron distributed run is still required
before this is ready to merge.

Prepared against modelscope/ms-swift commit
`ddd16cb15ec90d2b122fbf1e57d7fd2a259427fc`.

## Problem

Native Megatron GKD currently returns a normalized microbatch loss through the
two-value loss interface. When microbatches or DP ranks contain different numbers
of scored response tokens, averaging those means does not equal the global token
mean. The intended objective is:

```text
sum(loss over all scored response tokens) / number of scored response tokens
```

For example, a microbatch with loss sum 1 over 1 token and another with loss sum 9
over 3 tokens should give 10/4 = 2.5, not (1/1 + 9/3)/2 = 2.0.

## Proposed Changes

- Default `calculate_per_token_loss` to true for native, non-Ray GKD only.
  Preserve explicit settings and the defaults for other RLHF objectives and Ray.
- Return `(loss_sum, local_num_tokens, metrics)` on the token-normalized path so
  the existing Megatron scheduler/finalization contract performs normalization.
- Report detached `[loss_sum, token_count]` pairs using DP SUM, preserving the
  denominator through microbatch and logging-step aggregation.
- Keep a zero-valued autograd connection for an empty scored-token microbatch.
- Accumulate optional SFT as a sum using the same denominator. Reject partial
  teacher coverage when SFT is active; synchronize that check across DP ranks.
- Require CP=1 on the new path. Explicit false keeps legacy behavior.
- Add isolated CPU contract tests and update Chinese and English parameter docs.

## Scope Decisions For Review

1. Is enabling this by default for native GKD acceptable, or should the first PR
   be opt-in? CP>1 now requires explicit legacy opt-out and is not fixed here.
2. Is rejecting partial teacher coverage with SFT acceptable? Supporting distinct
   GKD and SFT global denominators would require a different normalization contract.
3. Are AST-isolated unit tests acceptable here? They execute the actual argument
   class and loss methods plus the real shared loss math, but mock collectives and
   infrastructure. They do not replace imported-trainer or distributed tests.

## Validation

- [x] `python -m py_compile` for all three changed Python files.
- [x] `pre-commit run --files` for the five changed files.
- [x] `pre-commit run --all-files` for the complete repository.
- [x] CPU numerical/gradient contract suite: 17 passed, 0 skipped, 0 failures.
- [x] Full-vocabulary/top-k KL and JSD, partition-invariant loss and gradients,
  teacher coverage, SFT, simulated DP metrics, empty masks, low-precision counts,
  argument defaults, and the legacy interface are covered.
- [x] Actual trainer import/CLI parsing with the supported dependency stack.
- [ ] Megatron DP=1/2 with unequal response lengths and gradient accumulation.
- [ ] TP=1/2, optional SFT, mixed empty microbatches, and an all-empty step.
- [ ] CP compatibility review and PP/VPP smoke tests as applicable.
- [ ] Repository CI.

The CPU suite ran in the target Linux Docker environment. Its mocked collectives
validate the local contracts and metric reduction inputs, not NCCL or the Megatron
distributed scheduler itself.

## Deliberately Excluded

No changes to vocabulary-parallel autograd primitives, shared GKD math, Ray GKD,
teacher-logit memory scheduling, rollout weight synchronization, checkpoint/resume,
or training batch sizing.
