### PR TITLE
fix(loss): preserve token weights in custom cross entropy

### DIFF
--- a/swift/loss/causal_lm.py
+++ b/swift/loss/causal_lm.py
@@ -7,6 +7,8 @@ class CustomCrossEntropyLoss(BaseLoss):
     def __call__(self, outputs, labels, *, num_items_in_batch=None, loss_scale=None, **kwargs):
         from swift.trainers import per_token_loss_func
         token_loss = per_token_loss_func(outputs, labels)
+        if loss_scale is not None:
+            token_loss = token_loss * loss_scale
         if num_items_in_batch is None:
             num_items_in_batch = (labels[:, 1:] != -100).sum()
         return token_loss.sum() / num_items_in_batch

--- a/tests/train/test_cross_entropy_loss.py
+++ b/tests/train/test_cross_entropy_loss.py
@@ -1,0 +1,40 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import torch
+import torch.nn.functional as F
+import unittest
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+from swift.loss.causal_lm import CustomCrossEntropyLoss
+
+
+class TestCustomCrossEntropyLoss(unittest.TestCase):
+
+    def test_token_weights_and_normalization(self):
+        for scale_mode in ['none', 'ones', 'weighted', 'zero']:
+            for num_items_in_batch in [None, 20]:
+                with self.subTest(scale_mode=scale_mode, num_items_in_batch=num_items_in_batch):
+                    torch.manual_seed(42)
+                    logits = torch.randn(2, 5, 7, requires_grad=True)
+                    reference_logits = logits.detach().clone().requires_grad_()
+                    labels = torch.tensor([[-100, 1, 2, 3, 4], [-100, 2, -100, 4, 5]])
+                    weights = torch.ones(2, 5)
+                    if scale_mode == 'weighted':
+                        weights = torch.tensor([[0., 0.25, 2., 0., 1.], [0., 3., 0., 0.5, 2.]])
+                    elif scale_mode == 'zero':
+                        weights.zero_()
+                    # Seq2SeqTrainer has already shifted and flattened loss_scale at the loss callback boundary.
+                    loss_scale = None if scale_mode == 'none' else weights.roll(-1, dims=-1).reshape(-1)
+                    actual = CustomCrossEntropyLoss(None, None)(
+                        CausalLMOutputWithPast(logits=logits),
+                        labels,
+                        num_items_in_batch=num_items_in_batch,
+                        loss_scale=loss_scale)
+                    token_loss = F.cross_entropy(
+                        reference_logits[:, :-1].reshape(-1, 7), labels[:, 1:].reshape(-1),
+                        reduction='none').reshape(2, 4)
+                    denominator = (labels[:, 1:] != -100).sum() if num_items_in_batch is None else num_items_in_batch
+                    expected = (token_loss * weights[:, 1:]).sum() / denominator
+                    torch.testing.assert_close(actual, expected)
+                    actual.backward()
+                    expected.backward()
+                    torch.testing.assert_close(logits.grad, reference_logits.grad)


### PR DESCRIPTION
# PR type
- [x] Bug Fix

# PR information

With `--loss_type cross_entropy`, `Seq2SeqTrainer` passes the aligned token weights to `CustomCrossEntropyLoss`, but the callback discards them when recomputing cross entropy. Nonuniform weights therefore change the objective in the default trainer path but have no effect when this loss is selected explicitly; even zero-weight tokens contribute to the loss.

Apply `loss_scale` to the per-token loss before reducing it. Keep the existing valid-token or `num_items_in_batch` denominator.

## Experiment results

The unittest covers eight combinations of absent/unit/nonuniform/zero weights and local/explicit normalization. Four weighted cases fail before the fix, and all eight pass after it, including gradient comparisons against independently shifted PyTorch cross entropy.

An offline tiny Qwen3 check through `Seq2SeqTrainer._prepare_inputs` and `compute_loss` also matches reference loss, all parameter gradients and one SGD update on CPU FP32 and H800 FP32/BF16. This is a direct trainer-method integration check; full SFT runs, sequence parallelism and packing were not tested.

```bash
python -m unittest discover -s tests/train -p test_cross_entropy_loss.py -v
```

Changed-file pre-commit checks pass.
