### PR TITLE
Fix Arrow-aligned tool schemas leaking foreign parameters

### DIFF
--- a/swift/agent_template/base.py
+++ b/swift/agent_template/base.py
@@ -197,7 +197,40 @@ class BaseAgentTemplate(ReactCompatMixin, ABC):
         assert isinstance(tool, dict), f'tool: {tool}'
         if 'type' not in tool and 'function' not in tool:
             tool = {'type': 'function', 'function': tool}
+        function = tool.get('function')
+        if isinstance(function, dict) and isinstance(function.get('parameters'), dict):
+            parameters = BaseAgentTemplate._remove_null_properties(function['parameters'])
+            tool = {**tool, 'function': {**function, 'parameters': parameters}}
         return tool
+
+    @staticmethod
+    def _remove_null_properties(schema):
+        """Remove null property definitions introduced by Arrow struct alignment.
+
+        Property definitions must be schemas, so a null entry is padding rather
+        than a nullable parameter (which uses ``type: 'null'``). Only descend
+        through schema-valued keywords: defaults, constants, examples and custom
+        annotations may contain literal nulls or objects named ``properties``.
+        """
+        clean = BaseAgentTemplate._remove_null_properties
+        if isinstance(schema, list):
+            return [clean(child) for child in schema]
+        if not isinstance(schema, dict):
+            return schema
+        schema = schema.copy()
+        for key in ('properties', 'patternProperties', '$defs', 'definitions', 'dependentSchemas', 'dependencies'):
+            children = schema.get(key)
+            if isinstance(children, dict):
+                schema[key] = {
+                    name: clean(child)
+                    for name, child in children.items() if key != 'properties' or child is not None
+                }
+        for key in ('items', 'additionalItems', 'prefixItems', 'contains', 'additionalProperties', 'unevaluatedItems',
+                    'unevaluatedProperties', 'propertyNames', 'allOf', 'anyOf', 'oneOf', 'not', 'if', 'then', 'else',
+                    'contentSchema'):
+            if key in schema:
+                schema[key] = clean(schema[key])
+        return schema
 
     @staticmethod
     def _parse_tool(tool, lang: Literal['zh', 'en']) -> ToolDesc:

--- a/tests/general/test_agent_tool_schema.py
+++ b/tests/general/test_agent_tool_schema.py
@@ -1,0 +1,144 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import json
+import pyarrow as pa
+import unittest
+from copy import deepcopy
+
+from swift.agent_template.base import BaseAgentTemplate
+from swift.agent_template.hermes import HermesAgentTemplate
+from swift.agent_template.qwen3_coder import Qwen3CoderAgentTemplate
+
+
+def make_tool(name, properties):
+    return {
+        'type': 'function',
+        'function': {
+            'name': name,
+            'description': name,
+            'parameters': {
+                'type': 'object',
+                'properties': properties
+            },
+        },
+    }
+
+
+class TestAgentToolSchema(unittest.TestCase):
+
+    def test_arrow_aligned_tools_keep_their_own_parameters(self):
+        tools = [make_tool('first', {'a': {'type': 'string'}}), make_tool('second', {'b': {'type': 'integer'}})]
+        aligned = pa.Table.from_pylist([{'tools': tools}]).to_pylist()[0]['tools']
+        self.assertIsNone(aligned[0]['function']['parameters']['properties']['b'])
+        self.assertIsNone(aligned[1]['function']['parameters']['properties']['a'])
+
+        self.assertEqual([BaseAgentTemplate.wrap_tool(tool) for tool in aligned], tools)
+
+    def test_nested_properties_are_cleaned_without_mutating_input(self):
+        tool = make_tool(
+            'nested', {
+                'object': {
+                    'type': 'object',
+                    'properties': {
+                        'keep': {
+                            'type': 'string'
+                        },
+                        'foreign': None
+                    }
+                },
+                'array': {
+                    'type': 'array',
+                    'items': {
+                        'properties': {
+                            'keep': {},
+                            'foreign': None
+                        }
+                    }
+                },
+                'foreign': None,
+            })
+        original = deepcopy(tool)
+
+        result = BaseAgentTemplate.wrap_tool(tool)
+
+        properties = result['function']['parameters']['properties']
+        self.assertNotIn('foreign', properties)
+        self.assertEqual(properties['object']['properties'], {'keep': {'type': 'string'}})
+        self.assertEqual(properties['array']['items']['properties'], {'keep': {}})
+        self.assertEqual(tool, original)
+
+    def test_schema_branches_and_definitions_are_cleaned(self):
+        child = {'properties': {'keep': {}, 'foreign': None}}
+        parameters = {
+            '$defs': {
+                'entry': deepcopy(child)
+            },
+            'anyOf': [deepcopy(child), {
+                'type': 'null'
+            }],
+            'additionalProperties': deepcopy(child),
+        }
+        tool = make_tool('branches', {})
+        tool['function']['parameters'] = parameters
+
+        result = BaseAgentTemplate.wrap_tool(tool)['function']['parameters']
+
+        expected_child = {'properties': {'keep': {}}}
+        self.assertEqual(result['$defs']['entry'], expected_child)
+        self.assertEqual(result['anyOf'], [expected_child, {'type': 'null'}])
+        self.assertEqual(result['additionalProperties'], expected_child)
+
+    def test_semantic_nulls_boolean_schemas_and_literal_objects_are_preserved(self):
+        literal = {'properties': {'literal_null': None}}
+        properties = {
+            'nullable': {
+                'type': ['string', 'null'],
+                'default': None,
+                'const': None,
+                'enum': [None, 'value']
+            },
+            'any': True,
+            'never': False,
+            'unconstrained': {},
+            'literal': {
+                'default': literal,
+                'examples': [literal],
+                'const': literal,
+                'x-extra': literal
+            },
+        }
+        tool = make_tool('valid', properties)
+
+        self.assertEqual(BaseAgentTemplate.wrap_tool(tool), tool)
+
+    def test_unwrapped_tools_and_non_schema_parameters(self):
+        tool = make_tool('raw', {'keep': {}, 'foreign': None})['function']
+        result = BaseAgentTemplate.wrap_tool(tool)
+        self.assertEqual(result, make_tool('raw', {'keep': {}}))
+
+        for parameters in [None, 'a JSON string', [{'name': 'argument', 'description': None}]]:
+            with self.subTest(parameters=parameters):
+                tool = {'name': 'legacy', 'parameters': parameters}
+                self.assertEqual(BaseAgentTemplate.wrap_tool(tool), {'type': 'function', 'function': tool})
+
+    def test_hermes_prompt_does_not_include_foreign_parameters(self):
+        tool = make_tool('first', {'a': {'type': 'string'}, 'foreign': None})
+
+        prompt = HermesAgentTemplate()._format_tools([tool])
+        rendered_tool = json.loads(prompt.split('<tools>\n', 1)[1].split('\n</tools>', 1)[0])
+
+        self.assertEqual(rendered_tool, make_tool('first', {'a': {'type': 'string'}}))
+
+    def test_qwen3_coder_prompt_accepts_arrow_aligned_tools(self):
+        tools = [make_tool('first', {'a': {'type': 'string'}}), make_tool('second', {'b': {'type': 'integer'}})]
+        aligned = pa.Table.from_pylist([{'tools': tools}]).to_pylist()[0]['tools']
+        # Template preprocessing wraps each tool before formatting the system prompt.
+        wrapped = [BaseAgentTemplate.wrap_tool(tool) for tool in aligned]
+
+        prompt = Qwen3CoderAgentTemplate()._format_tools(wrapped)
+
+        self.assertEqual(prompt.count('<name>a</name>'), 1)
+        self.assertEqual(prompt.count('<name>b</name>'), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixes #6467.

When tools with different parameter names are stored as Arrow structs, their `properties` maps are aligned to a shared set of fields. A tool defining only `a` can therefore arrive as `{"a": {"type": "string"}, "b": null}`. The extra fields are emitted into Hermes-style tool descriptions, and Qwen3-Coder's formatter raises a `TypeError` when it reads a null property definition.

`BaseAgentTemplate.wrap_tool()` now removes null **property definitions** before they reach the prompt. It follows schema-valued keywords to handle nested objects, array items, definitions and schema branches. It preserves nullable schemas, `default: null`, `const: null`, null enum members, boolean schemas, and literal objects inside examples/defaults/custom annotations. The input tool dictionary is left unchanged; legacy non-dictionary parameters keep their existing behavior.

The regression uses a real in-memory `pyarrow.Table` to reproduce the alignment and exercises both the Hermes and Qwen3-Coder prompt paths. No production dependency is added.

## Experiment results

- New regression suite: **6 failed / 1 passed before**, **7 passed after** (plus 3 parameter subtests).
- `pre-commit run --all-files`: passed (flake8, isort, YAPF and repository file checks).
- `git diff --check`: passed.

Local tests used a lightweight import harness that loads the actual `base.py`, `hermes.py` and `qwen3_coder.py` modules while isolating unused inference/type imports. PyArrow and the production schema/prompt methods ran normally. The committed tests use regular project imports in `tests/general/test_agent_tool_schema.py`. Full Torch/Transformers integration and training were not run; no models or datasets were downloaded.

Developed and tested with OpenAI Codex assistance. Manually reviewed by myself and another independent coding agent.
