### PR TITLE
fix(megatron): correct rollout weight reload, resume offsets and sampler seed

### DIFF
--- a/swift/megatron/trainers/base.py
+++ b/swift/megatron/trainers/base.py
@@ -1044,16 +1044,24 @@ class BaseMegatronTrainer(ABC):
             if val_dataset is not None:
                 val_dataloader = build_streaming_dataloader(args, val_dataset, self.data_collator)
             return train_dataloader, val_dataloader
+        consumed_samples = self.state.consumed_train_samples
+        if args.rlhf_type in {'grpo', 'gkd'}:
+            if consumed_samples % args.num_generations:
+                raise RuntimeError(f'consumed_train_samples ({consumed_samples}) must be divisible by '
+                                   f'num_generations ({args.num_generations})')
+            # Checkpoints count generated samples; the dataloader indexes unrepeated prompts.
+            consumed_samples //= args.num_generations
         train_batch_sampler = MegatronPretrainingRandomSampler(
             train_dataset,
             total_samples=len(train_dataset),
-            consumed_samples=self.state.consumed_train_samples,
+            consumed_samples=consumed_samples,
             micro_batch_size=args.micro_batch_size,
             data_parallel_rank=mpu.get_data_parallel_rank(),
             data_parallel_size=mpu.get_data_parallel_world_size(),
             data_sharding=args.data_sharding,
             shuffle=args.train_dataloader_shuffle,
             group_by_length=args.group_by_length,
+            seed=args.data_seed,
         )
         train_dataloader = self._create_dataloader(train_dataset, train_batch_sampler)
         if val_dataset is not None:

--- a/swift/megatron/trainers/batch_sampler.py
+++ b/swift/megatron/trainers/batch_sampler.py
@@ -75,6 +75,7 @@ class MegatronPretrainingRandomSampler:
         data_sharding,
         shuffle: bool = True,
         group_by_length: bool = False,
+        seed: int = 0,
     ):
         # Keep a copy of input params for later use.
         self.dataset = dataset
@@ -93,6 +94,7 @@ class MegatronPretrainingRandomSampler:
         self.data_sharding = data_sharding
         self.shuffle = shuffle
         self.group_by_length = group_by_length
+        self.seed = seed
         self.lengths = self.dataset['lengths'] if group_by_length else None
         if self.lengths is not None:
             self.lengths = [max(length) if isinstance(length, list) else length for length in self.lengths]
@@ -124,14 +126,14 @@ class MegatronPretrainingRandomSampler:
                 start_idx = self.data_parallel_rank * bucket_size
 
                 g = torch.Generator()
-                g.manual_seed(self.epoch)
+                g.manual_seed(self.seed + self.epoch)
                 random_idx = torch.randperm(bucket_size, generator=g).tolist()
                 idx_range = [start_idx + x for x in random_idx[bucket_offset:]]
             else:
                 full_bucket_size = (self.total_samples // self.micro_batch_size) * self.micro_batch_size
                 full_bucket_offset = current_epoch_samples
                 g = torch.Generator()
-                g.manual_seed(self.epoch)
+                g.manual_seed(self.seed + self.epoch)
                 if self.group_by_length:
                     from transformers.trainer_pt_utils import get_length_grouped_indices
                     idx_range_total = get_length_grouped_indices(

--- a/swift/megatron/trainers/rollout_mixin.py
+++ b/swift/megatron/trainers/rollout_mixin.py
@@ -634,7 +634,7 @@ class MegatronRolloutMixin(BaseRolloutTrainerMixin):
                 patch_vllm_moe_model_weight_loader(llm_model)
                 llm_model.load_weights(weight_iterator)
                 _model_config = self.engine.engine.model_config
-                finish_vllm_weight_reload(llm_model, model_config=_model_config, target_device=self.device)
+                finish_vllm_weight_reload(llm_model, model_config=_model_config, target_device=self.device, strict=True)
         elif self.vllm_mode == 'server':
             self._load_weights_to_server_in_buckets(weight_iterator)
             if self.is_main_process:

--- a/swift/rlhf_trainers/utils.py
+++ b/swift/rlhf_trainers/utils.py
@@ -1097,14 +1097,21 @@ def patch_vllm_moe_model_weight_loader(model, *, load_preprocessed_weight: bool 
     original_model._swift_moe_weight_loader_patched = True
 
 
-def finish_vllm_weight_reload(vllm_model, model_config, target_device):
+def finish_vllm_weight_reload(vllm_model, model_config, target_device, *, strict: bool = False):
     if vllm_model is None or model_config is None or target_device is None:
         return
     try:
-        from vllm.model_executor.model_loader.utils import process_weights_after_loading
+        from vllm.model_executor.model_loader import utils as model_loader_utils
+
+        # Older vLLM releases do not expose the post-load helper.
+        process_weights_after_loading = getattr(model_loader_utils, 'process_weights_after_loading', None)
+        if process_weights_after_loading is None:
+            return
+        target_device = torch.device(target_device)
         process_weights_after_loading(vllm_model, model_config, target_device)
     except Exception:
-        return
+        if strict:
+            raise
 
 
 _cached_reverse_renamings = None


### PR DESCRIPTION
# PR type

- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fixes #10098 and #10099 with changes to four production files.

Megatron colocated weight reload passes an integer device ordinal into vLLM's post-load processing, which expects a `torch.device`. The existing exception handler hides this failure. Normalize the device and enable strict error propagation for the Megatron caller. Older vLLM releases without the helper retain the compatibility skip; errors inside an existing helper propagate in strict mode. Other callers retain non-strict behavior.

The on-policy checkpoint counts generated training samples, while the dataloader indexes unrepeated prompts. Convert the offset at dataloader construction for GRPO/GKD, without modifying the persisted counter, and reject offsets not divisible by `num_generations`. For example, 32 consumed rollout rows with four generations correspond to eight prompt rows. GKD currently forces `num_generations=1`, so its conversion is a no-op.

Pass `data_seed` into the random sampler and use `seed + epoch` in both sharding branches, including length grouping. The optional sampler argument defaults to zero for existing direct callers.

Compatibility note: honoring `data_seed` changes the shuffle order used by old checkpoints, including non-on-policy callers of this sampler. Seed zero reproduces the old sampler permutation only if dataset ordering is identical; changing `data_seed` can also affect upstream dataset preparation. This patch does not restore rollout buffers or guarantee identical generation/RNG state after a resume.

## Experiment results

Validation scripts were kept local; the PR contains production code only.

- **56 local regression cases passed**: real PyTorch samplers and DataLoaders, two simulated DP ranks, both sharding branches, shuffled/unshuffled resume, cross-epoch resume, incomplete dataset tails, length grouping, seed behavior, validation/streaming preservation, device conversion, legacy helper absence, and strict/non-strict error propagation. The harness loads the actual production functions/classes in isolation; it does not launch a distributed Megatron trainer.
- **Real vLLM/GPU integration passed** on an NVIDIA RTX A1000 Laptop GPU: a small probe module's CPU parameter moves to CUDA for post-load processing and returns to CPU with the expected value; an intentional processing error propagates. PyTorch 2.13.0+cu130; installed vLLM development build `0.1.dev564+ga3561ef8e.d20260823`.
- The initial 33-case suite against the original code produced **22 failures, 8 passes, and 3 GPU skips** in the sandbox.
- `pre-commit run --files swift/rlhf_trainers/utils.py swift/megatron/trainers/rollout_mixin.py swift/megatron/trainers/base.py swift/megatron/trainers/batch_sampler.py`: passed.
- `git diff --check`: passed.

No full distributed Megatron training run or NPU hardware validation was performed.
