### PR TITLE
fix(rlhf): undo gradient-accumulation scaling for DAPO/CISPO/FIPO losses

### DIFF
--- a/swift/rlhf_trainers/grpo_trainer.py
+++ b/swift/rlhf_trainers/grpo_trainer.py
@@ -77,6 +77,10 @@ if is_wandb_available():
 if is_swanlab_available():
     import swanlab
 
+# Losses normalized by the completion tokens of the whole gradient-accumulation window instead of the tokens of
+# the current micro-batch. See `GRPOTrainer._undo_gradient_accumulation_scaling`.
+WINDOW_NORMALIZED_LOSS_TYPES = ['cispo', 'dapo', 'fipo']
+
 
 class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
@@ -1128,7 +1132,7 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
             if self.beta != 0.0:
                 kl_loss = (per_token_kl * completion_mask).sum() / completion_mask.sum().clamp(min=1.0)
                 loss = loss + kl_loss * self.beta
-        elif self.loss_type in ['cispo', 'dapo', 'fipo']:
+        elif self.loss_type in WINDOW_NORMALIZED_LOSS_TYPES:
             # CISPO, DAPO, and FIPO: Normalize by total completion tokens across all processes
             normalizer = grpo_batch.num_items_in_batch / self.accelerator.num_processes
             loss = (per_token_loss * completion_mask).sum() / normalizer
@@ -1218,8 +1222,23 @@ class GRPOTrainer(RolloutTrainerMixin, SwiftMixin, HFGRPOTrainer):
             }
         if mode == 'train' and self.chord_sft_iterator is not None:
             loss = compute_chord_loss(self, grpo_loss=loss)
+        loss = self._undo_gradient_accumulation_scaling(loss)
 
         return loss, metrics_data
+
+    def _undo_gradient_accumulation_scaling(self, loss: torch.Tensor) -> torch.Tensor:
+        """Undo the gradient-accumulation scaling of `Trainer` for window-normalized losses."""
+        # `Trainer.training_step` divides the loss by `current_gradient_accumulation_steps` before backward
+        # (`Accelerator` is created with `num_steps=1`, so the loss is not scaled a second time there). That is
+        # correct for a loss averaged over the current micro-batch, but `WINDOW_NORMALIZED_LOSS_TYPES` are
+        # normalized by the completion tokens of the whole accumulation window, so dividing them would shrink
+        # the loss and its gradient by that factor.
+        if (self.loss_type in WINDOW_NORMALIZED_LOSS_TYPES and self.model.training
+                and not self.model_accepts_loss_kwargs and self.compute_loss_func is None):
+            gradient_accumulation_steps = \
+                getattr(self, 'current_gradient_accumulation_steps', self.args.gradient_accumulation_steps)
+            loss = loss * gradient_accumulation_steps
+        return loss
 
     def _update_metrics(self, metrics_data):
         """Update metrics from metrics_data."""

--- a/tests/test_align/test_grpo_loss.py
+++ b/tests/test_align/test_grpo_loss.py
@@ -1,0 +1,84 @@
+import pytest
+import torch
+from types import SimpleNamespace
+
+from swift.rlhf_trainers.grpo_trainer import GRPOTrainer
+
+WINDOW_NORMALIZED_LOSS_TYPES = ['dapo', 'cispo', 'fipo']
+MICRO_BATCH_LOSS_TYPES = ['grpo', 'sapo', 'bnpo', 'dr_grpo']
+
+
+def _make_trainer(loss_type,
+                  gradient_accumulation_steps,
+                  training=True,
+                  model_accepts_loss_kwargs=False,
+                  compute_loss_func=None,
+                  has_current_gradient_accumulation_steps=True):
+    trainer = object.__new__(GRPOTrainer)
+    trainer.loss_type = loss_type
+    trainer.model = SimpleNamespace(training=training)
+    trainer.model_accepts_loss_kwargs = model_accepts_loss_kwargs
+    trainer.compute_loss_func = compute_loss_func
+    trainer.args = SimpleNamespace(gradient_accumulation_steps=gradient_accumulation_steps)
+    if has_current_gradient_accumulation_steps:
+        trainer.current_gradient_accumulation_steps = gradient_accumulation_steps
+    return trainer
+
+
+@pytest.mark.parametrize('loss_type', WINDOW_NORMALIZED_LOSS_TYPES)
+@pytest.mark.parametrize('gradient_accumulation_steps', [1, 2, 4, 8])
+def test_window_normalized_loss_keeps_global_token_mean_gradient(loss_type, gradient_accumulation_steps):
+    # The loss is already normalized by the completion tokens of the whole accumulation window, so after the
+    # division performed by `Trainer.training_step` its gradient must stay equal to the gradient of the
+    # uncompensated loss, i.e. to the global token mean.
+    trainer = _make_trainer(loss_type, gradient_accumulation_steps)
+    parameter = torch.tensor(2.0, requires_grad=True)
+    loss = GRPOTrainer._undo_gradient_accumulation_scaling(trainer, parameter.square())
+    (loss / gradient_accumulation_steps).backward()
+
+    torch.testing.assert_close(loss, parameter.square() * gradient_accumulation_steps)
+    torch.testing.assert_close(parameter.grad, torch.tensor(4.0))
+
+
+@pytest.mark.parametrize('has_current_gradient_accumulation_steps', [True, False])
+def test_window_normalized_loss_on_older_transformers(has_current_gradient_accumulation_steps):
+    # `current_gradient_accumulation_steps` only exists in recent transformers versions.
+    trainer = _make_trainer('dapo', 4, has_current_gradient_accumulation_steps=has_current_gradient_accumulation_steps)
+    loss = torch.tensor(3.0)
+
+    actual = GRPOTrainer._undo_gradient_accumulation_scaling(trainer, loss)
+
+    torch.testing.assert_close(actual, loss * 4)
+
+
+@pytest.mark.parametrize('loss_type', MICRO_BATCH_LOSS_TYPES)
+def test_micro_batch_normalized_loss_is_not_scaled(loss_type):
+    # These losses are averaged over the current micro-batch, so scaling them is the correct behaviour.
+    trainer = _make_trainer(loss_type, 4)
+    loss = torch.tensor(3.0)
+
+    actual = GRPOTrainer._undo_gradient_accumulation_scaling(trainer, loss)
+
+    torch.testing.assert_close(actual, loss)
+
+
+@pytest.mark.parametrize(
+    'training, model_accepts_loss_kwargs, compute_loss_func',
+    [
+        (False, False, None),  # evaluation
+        (True, True, None),  # the model handles the gradient-accumulation scaling itself
+        (True, False, object()),  # `compute_loss_func` handles the gradient-accumulation scaling itself
+    ],
+)
+def test_no_scaling_without_trainer_scaling(training, model_accepts_loss_kwargs, compute_loss_func):
+    trainer = _make_trainer(
+        'dapo',
+        4,
+        training=training,
+        model_accepts_loss_kwargs=model_accepts_loss_kwargs,
+        compute_loss_func=compute_loss_func)
+    loss = torch.tensor(3.0)
+
+    actual = GRPOTrainer._undo_gradient_accumulation_scaling(trainer, loss)
+
+    torch.testing.assert_close(actual, loss)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Problem

`dapo`, `cispo` and `fipo` normalize the policy loss with the completion tokens of the **whole
gradient-accumulation window**:

```python
elif self.loss_type in ['cispo', 'dapo', 'fipo']:
    # CISPO, DAPO, and FIPO: Normalize by total completion tokens across all processes
    normalizer = grpo_batch.num_items_in_batch / self.accelerator.num_processes
    loss = (per_token_loss * completion_mask).sum() / normalizer
```

`num_items_in_batch` is built from `ga_batch_encoded_inputs` and `_gather_and_flatten(...)`
(grpo_trainer.py:803-809), so it already covers every micro-batch of the accumulation window on
every process. A single micro-batch therefore contributes only a **slice** of the global token
mean.

`Trainer.training_step` then divides the loss by `current_gradient_accumulation_steps` before
backward (transformers forces `num_steps=1` on the `Accelerator` plugin, so the loss is not
scaled a second time there). For a loss that averages over the current micro-batch that division
is correct, but for these three losses it shrinks the loss and its gradient by the number of
accumulation steps:

| | gradient of one update step |
| --- | --- |
| intended (global token mean) | `g` |
| actual, `gradient_accumulation_steps=4` | `g / 4` |

The logged loss is off in the same way: it is divided by the number of accumulation steps
instead of being the global token mean.

### Minimal reproduction (CPU, no model)

```python
loss = torch.tensor(2.0, requires_grad=True)                    # window-normalized loss of one micro-batch
scaled = loss * trainer.current_gradient_accumulation_steps     # patch
(scaled / trainer.current_gradient_accumulation_steps).backward()
# before the patch the gradient of every micro-batch is 1 / gradient_accumulation_steps smaller
```

## Fix

Compensate the window-normalized policy loss right after the normalizer, inside the
`cispo`/`dapo`/`fipo` branch, so the Trainer division cancels out before the auxiliary losses are
added:

```python
elif self.loss_type in WINDOW_NORMALIZED_LOSS_TYPES:
    normalizer = grpo_batch.num_items_in_batch / self.accelerator.num_processes
    loss = (per_token_loss * completion_mask).sum() / normalizer
    loss = self._undo_gradient_accumulation_scaling(loss)
```

* only `cispo`/`dapo`/`fipo` (`WINDOW_NORMALIZED_LOSS_TYPES`); `grpo`/`sapo`/`bnpo`/`dr_grpo` are
  averaged over the current micro-batch, so the Trainer scaling is already correct for them;
* only where the Trainer itself scales (`training`, `not model_accepts_loss_kwargs`,
  `compute_loss_func is None`), mirroring its condition;
* `getattr(self, 'current_gradient_accumulation_steps', self.args.gradient_accumulation_steps)`
  keeps the fix working on older transformers versions, where the attribute does not exist yet;
* applying it *before* SDAR/CHORD leaves those micro-batch means with the Trainer division they
  need (an earlier revision multiplied the combined loss, which made them
  `gradient_accumulation_steps` times too strong), and the reported policy loss becomes the global
  token mean instead of being divided by the accumulation steps.

The Liger path (`use_liger_loss`) is not touched, it has its own normalization in
`liger_grpo_loss`.

## Experiment results

`tests/test_align/test_grpo_loss.py` runs on CPU only, no model / NPU / GPU required:

```text
$ pytest -q tests/test_align/test_grpo_loss.py
25 passed
```

It checks that

* the gradient after the Trainer division is independent of `gradient_accumulation_steps`
  (1, 2, 4, 8) for `dapo`/`cispo`/`fipo`;
* the accumulated SDAR/CHORD gradient stays the window mean for 1/2/4/8 accumulation steps (this
  fails on the previous placement from 2 steps up);
* the fallback to `args.gradient_accumulation_steps` works on transformers versions without
  `current_gradient_accumulation_steps`;
* `grpo`/`sapo`/`bnpo`/`dr_grpo` are not modified;
* no compensation happens during evaluation, when the model accepts loss kwargs, or when
  `compute_loss_func` is set.
