### PR TITLE
docs: fix custom reward function examples

### DIFF
--- a/docs/source/Instruction/GRPO/DeveloperGuide/reward_function.md
+++ b/docs/source/Instruction/GRPO/DeveloperGuide/reward_function.md
@@ -9,8 +9,8 @@
 
 ```python
 from swift.rewards import ORM, orms
-class DummyLengthRewardFunction(ORM)
-    def __call__(completions, **kwargs):
+class DummyLengthRewardFunction(ORM):
+    def __call__(self, completions, **kwargs):
         return [1.0 if len(completion) > 1024 else 0.0 for completion in completions]
 
 orms['dummy']= DummyLengthRewardFunction
@@ -22,7 +22,7 @@ orms['dummy']= DummyLengthRewardFunction
 
 第一种：在__call__入参中显式定义列名
 ```python
-    def __call__(completions, solution, trainer_state, **kwargs):
+    def __call__(self, completions, solution, trainer_state, **kwargs):
         print(solution)
         global_step = trainer_state.global_step
         max_steps = trainer_state.max_steps
@@ -31,7 +31,7 @@ orms['dummy']= DummyLengthRewardFunction
 
 第二种：在kwargs中获取
 ```python
-    def __call__(completions, **kwargs):
+    def __call__(self, completions, **kwargs):
         solution = kwargs.get('solution')
         trainer_state = kwargs.get('trainer_state')
         global_step = trainer_state.global_step

--- a/docs/source_en/Instruction/GRPO/DeveloperGuide/reward_function.md
+++ b/docs/source_en/Instruction/GRPO/DeveloperGuide/reward_function.md
@@ -9,8 +9,8 @@ Below is an example illustrating how to implement a simple length-based reward f
 
 ```python
 from swift.rewards import ORM, orms
-class DummyLengthRewardFunction(ORM)
-    def __call__(completions, **kwargs):
+class DummyLengthRewardFunction(ORM):
+    def __call__(self, completions, **kwargs):
         return [1.0 if len(completion) > 1024 else 0.0 for completion in completions]
 
 orms['dummy']= DummyLengthRewardFunction
@@ -22,7 +22,7 @@ For example, if the reward function needs to access the solution column from the
 
 Explicitly define the column name in the __call__ parameters:
 ```python
-    def __call__(completions, solution, trainer_state, **kwargs):
+    def __call__(self, completions, solution, trainer_state, **kwargs):
         print(solution)
         global_step = trainer_state.global_step
         max_steps = trainer_state.max_steps
@@ -31,7 +31,7 @@ Explicitly define the column name in the __call__ parameters:
 
 Retrieve it from kwargs:
 ```python
-    def __call__(completions, **kwargs):
+    def __call__(self, completions, **kwargs):
         solution = kwargs.get('solution')
         trainer_state = kwargs.get('trainer_state')
         global_step = trainer_state.global_step


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [ ] New Feature
- [x] Document Updates
- [ ] More Models or Datasets Support

# PR information

Fix the custom reward function examples in both the Chinese and English GRPO developer guides:
- Add the missing colon to the DummyLengthRewardFunction class declaration.
- Add self to the three synchronous __call__ examples so they work as instance methods.

The length-reward example currently raises SyntaxError. Fixing only the colon still leaves a TypeError when the instance receives completions by keyword.

## Experiment results

- Reproduced both failures from the original snippets.
- Parsed the corrected snippets and tested the length-reward example with the ORM base class extracted from the repository, without importing the training stack. Completion lengths 0, 1024, and 1025 return [0.0, 0.0, 1.0] with both positional and keyword calls.
- Executed both dataset-column method examples with a lightweight trainer-state fixture.
- git diff --check and Markdown parsing passed.

The configured pre-commit hooks passed for both changed files.

No training or model downloads were performed; runtime code is unchanged.
