### PR TITLE
fix(dataset): list hub IDs for named datasets in the Web UI

### DIFF
--- a/swift/dataset/register.py
+++ b/swift/dataset/register.py
@@ -13,13 +13,11 @@ logger = get_logger()
 
 def get_dataset_list():
     datasets = []
-    for key in DATASET_MAPPING:
-        if use_hf_hub():
-            if key[1]:
-                datasets.append(key[1])
-        else:
-            if key[0]:
-                datasets.append(key[0])
+    use_hf = use_hf_hub()
+    for dataset_meta in DATASET_MAPPING.values():
+        dataset_id = dataset_meta.hf_dataset_id if use_hf else dataset_meta.ms_dataset_id
+        if dataset_id:
+            datasets.append(dataset_id)
     return datasets
 
 

--- a/tests/general/test_dataset_list.py
+++ b/tests/general/test_dataset_list.py
@@ -1,0 +1,32 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import os
+import unittest
+from unittest.mock import patch
+
+from swift.dataset import DATASET_MAPPING, DatasetMeta, get_dataset_list, register_dataset
+
+
+class TestDatasetList(unittest.TestCase):
+
+    def test_builtin_named_dataset(self):
+        for use_hf, dataset_id in [('0', 'swift/self-cognition'), ('1', 'modelscope/self-cognition')]:
+            with self.subTest(use_hf=use_hf), patch.dict(os.environ, {'USE_HF': use_hf}):
+                self.assertIn(dataset_id, get_dataset_list())
+
+    def test_named_and_unnamed_datasets_use_selected_hub(self):
+        with patch.dict(DATASET_MAPPING, clear=True):
+            register_dataset(DatasetMeta(dataset_name='named', ms_dataset_id='ms/named', hf_dataset_id='hf/named'))
+            register_dataset(DatasetMeta(dataset_name='x', ms_dataset_id='ms/short', hf_dataset_id='hf/short'))
+            register_dataset(DatasetMeta(ms_dataset_id='ms/unnamed', hf_dataset_id='hf/unnamed'))
+            register_dataset(DatasetMeta(dataset_name='ms-only', ms_dataset_id='ms/only'))
+            register_dataset(DatasetMeta(dataset_name='hf-only', hf_dataset_id='hf/only'))
+            register_dataset(DatasetMeta(dataset_path='/local/data.jsonl'))
+
+            for use_hf, prefix in [('0', 'ms'), ('1', 'hf')]:
+                with self.subTest(use_hf=use_hf), patch.dict(os.environ, {'USE_HF': use_hf}):
+                    self.assertEqual(get_dataset_list(),
+                                     [f'{prefix}/named', f'{prefix}/short', f'{prefix}/unnamed', f'{prefix}/only'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

The dataset dropdowns read registry keys as `(ms_id, hf_id, path)` tuples, but `register_dataset` also stores entries under a string `dataset_name`. The built-in `self-cognition` therefore appears as `s` with ModelScope or `e` with Hugging Face. A one-character custom name also raises `IndexError` in HF mode.

Read the selected hub ID from each `DatasetMeta` instead. This restores the actual dataset IDs while preserving order and filtering out entries without an ID for that hub. The training, sampling and export dropdowns all use this helper.

## Experiment results

Using normal `swift.dataset` imports with Python 3.10 and locally cached dependencies in offline mode:
- `tests/general/test_dataset_list.py`: 2 tests with both hub modes pass. On main, the same tests fail with corrupted IDs and an `IndexError`.
- `tests/general/test_dataset_source.py`: 2 tests pass.
- `pre-commit run --all-files`: passed; the new test file also passes all applicable hooks.

No model downloads or training runs were needed. Developed with Codex assistance.
